### PR TITLE
Added eslint and prettier configuration

### DIFF
--- a/contracts/.eslintrc.json
+++ b/contracts/.eslintrc.json
@@ -21,6 +21,14 @@
     "rules": {
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-non-null-assertion":"off",
-        "@typescript-eslint/no-var-requires":"off"
+        "@typescript-eslint/no-var-requires":"off",
+        "max-len": [
+            "error",
+            {
+              "code": 120,
+              "ignoreStrings": true,  // Ignore string literals (like test descriptions)
+              "ignoreTemplateLiterals": true // Ignore template literals (if used in test descriptions)
+            }
+          ]
     }
 }

--- a/contracts/prettier.config.js
+++ b/contracts/prettier.config.js
@@ -4,6 +4,7 @@ module.exports = {
     tabWidth: 4,
     semi: false,
     singleQuote: true,
+    printWidth: 80,
     overrides: [
         {
             files: 'contracts/**/*.sol',

--- a/contracts/test/demo/Demo.test.Hedera.ts
+++ b/contracts/test/demo/Demo.test.Hedera.ts
@@ -1190,7 +1190,8 @@ describe('Demo RedSwam', () => {
         ).to.eventually.be.rejectedWith(Error)
 
         console.log(
-            'Grant issuer, control list, corporate action and controller roles to account "I" using account "Z" => succeeds'
+            'Grant issuer, control list, corporate action 
+            and controller roles to account "I" using account "Z" => succeeds'
         )
         accessControlFacet = accessControlFacet.connect(signer_Z)
         await accessControlFacet.grantRole(_ISSUER_ROLE, account_I)


### PR DESCRIPTION
For this task, I aligned the .eslintrc.json with the .solhint.json in terms of a maximum length of 120.

I added exclusions in the lint for test descriptions (because most of them are over 120 characters).

And, I kept the prettier at 80 characters because a change to 120 will require a reformatting of
all files.