### PR TITLE
chore: add groups to codeowners rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,12 +15,12 @@
 /CODEOWNERS                                     @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/README.md                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/asset-tokenization-studio-committers @hashgraph/developer-advocates @hashgraph/iobuilders-hedera
 **/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/asset-tokenization-studio-committers @hashgraph/developer-advocates @hashgraph/iobuilders-hedera
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+**/.gitignore                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/asset-tokenization-studio-committers @hashgraph/developer-advocates @hashgraph/iobuilders-hedera
+**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/asset-tokenization-studio-committers @hashgraph/developer-advocates @hashgraph/iobuilders-hedera


### PR DESCRIPTION
**Description**:
Add the groups @hashgraph/asset-tokenization-studio-committers @hashgraph/developer-advocates @hashgraph/iobuilders-hedera to the following CODEOWNER rules:

README.md
codecov.yml
both .gitignore entries

**Related issue(s)**:

Fixes #162 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
