### PR TITLE
fix: [cap] add setMaxSupplyByPartition test

### DIFF
--- a/contracts/test/unitTests/layer_2/cap/cap.test.ts
+++ b/contracts/test/unitTests/layer_2/cap/cap.test.ts
@@ -441,9 +441,6 @@ describe('CAP Layer 2 Tests', () => {
         // wait for first balance adjustment
         await new Promise((f) => setTimeout(f, TIME + 1))
         await snapshotFacet.takeSnapshot() // execute first adjustment balance only
-        // wait for second balance adjustment
-        await new Promise((f) => setTimeout(f, TIME + 1))
-        await accessControlFacet.revokeRole(_SNAPSHOT_ROLE, account_A) // dumb operation
 
         // Attempt to change the max supply by partition with the same value as before
         await expect(


### PR DESCRIPTION
Jira link:  https://iobuilders.atlassian.net/browse/BBND-474

Solve this issue:

![image](https://github.com/user-attachments/assets/79f806c6-ad84-498f-a231-519bce45a296)

The test will fail if a user attempts to set the same maximum supply because in the modifier the total supply would be greater than the maximum supply set.