### PR TITLE
test: erc20 decreaseAllowance

### DIFF
--- a/contracts/test/unitTests/layer_2/ERC1400/erc1400.test.ts
+++ b/contracts/test/unitTests/layer_2/ERC1400/erc1400.test.ts
@@ -3303,7 +3303,7 @@ describe('ERC1400 Tests', () => {
                 )
 
                 // APPROVE 2
-                await erc20Facet.decreaseAllowance(account_B, amount)
+                await erc20Facet.decreaseAllowance(account_B, allowance_Before.add(amount))
 
                 const allowance_After = await erc20Facet.allowance(
                     account_A,
@@ -3315,7 +3315,7 @@ describe('ERC1400 Tests', () => {
                 )
 
                 expect(allowance_After).to.be.equal(
-                    allowance_Before.mul(adjustFactor).sub(amount)
+                    allowance_Before.mul(adjustFactor).sub(allowance_Before.add(amount))
                 )
                 expect(LABAF_Before).to.be.equal(0)
                 expect(LABAF_After).to.be.equal(adjustFactor)


### PR DESCRIPTION
Jira link: https://iobuilders.atlassian.net/browse/BBND-476

Will check this issue:
![image](https://github.com/user-attachments/assets/afff3e4f-3c2c-42f9-aa71-89166933cc8a)

Fixed the current test, changing to decrease to an amount larger than the original one, cause moving _beforeAllowanceUpdate to the beginning should update the balance by the factor.
