### PR TITLE
test: operatorRedeemByPartition

### DIFF
--- a/contracts/test/unitTests/layer_2/ERC1400/erc1400.test.ts
+++ b/contracts/test/unitTests/layer_2/ERC1400/erc1400.test.ts
@@ -3117,6 +3117,39 @@ describe('ERC1400 Tests', () => {
                 await checkAdjustmentsAfterRedeem(after, before)
             })
 
+            it('GIVEN an account with adjustBalances role WHEN adjustBalances THEN ERC1410 operatorRedeemByPartition with the expected adjusted amount succeeds', async () => {
+                await setPreBalanceAdjustment()
+
+                // adjustBalances
+                await adjustBalancesFacet.adjustBalances(
+                    adjustFactor,
+                    adjustDecimals
+                )
+
+                const adjustAmount = amount * adjustFactor
+
+                // Transaction Partition 1
+                await erc1410Facet.authorizeOperator(account_A)
+                await expect(
+                    erc1410Facet.operatorRedeemByPartition(
+                        _PARTITION_ID_1,
+                        account_A,
+                        adjustAmount,
+                        data,
+                        '0x'
+                    )
+                )
+                    .to.emit(erc1410Facet, 'RedeemedByPartition')
+                    .withArgs(
+                        _PARTITION_ID_1,
+                        account_A,
+                        account_A,
+                        adjustAmount,
+                        data,
+                        '0x'
+                    )
+            })
+
             it('GIVEN an account with adjustBalances role WHEN adjustBalances THEN ERC1410 controllerRedeemByPartition succeeds', async () => {
                 await setPreBalanceAdjustment()
 


### PR DESCRIPTION
Jira link: https://iobuilders.atlassian.net/browse/BBND-480

Will fix this issue:
![image](https://github.com/user-attachments/assets/ccfc83bb-545b-4084-9b2a-53635a4a33c6)

Description:
Currently, the _redeemByPartition method is not checking the value with the adjusted balance, so the test will try to operatorRedeemByPartition with the expected adjusted balance