### PR TITLE
chore: add contracts folder to npm package asset-tokenization-contracts

### DIFF
--- a/changeVersion.sh
+++ b/changeVersion.sh
@@ -33,6 +33,7 @@ update_version() {
 if [[ "$OSTYPE" == "darwin"* || "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "msys" ]]; then
   # Works for macOS, Linux, and Git Bash on Windows
   update_version
+  npm install
 else
   echo "❌ Error: Unsupported OS type: $OSTYPE"
   exit 1

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -33,6 +33,7 @@ gas-report.txt
 cache
 artifacts
 
+.deps/
 ./docs/*
 ./cache/*
 ./typechain-types/*

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@hashgraph/asset-tokenization-contracts",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "main": "./build/typechain-types/index.js",
   "module": "./build/typechain-types/index.js",
   "files": [
-    "build/"
+    "build/",
+    "contracts/"
   ],
   "exports": {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/hedera-asset-tokenization",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/hedera-asset-tokenization",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/hedera-asset-tokenization",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "Apache-2.0",
   "description": "asset tokenization",
   "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/asset-tokenization-sdk",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Testing to MASTER",
   "main": "./build/cjs/src/index.js",
   "module": "./build/esm/src/index.js",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/asset-tokenization-dapp",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "Apache-2.0",
   "scripts": {
     "clean:node": "npx --yes rimraf node_modules",


### PR DESCRIPTION
## Description

Added contracts folder in @hashgraph/asset-tokenization-contracts npm package so other projects could import them adding the dependency

Fixes # (issue) 🛠️

## Type of change

-   [ ] Bug fix 🐞
-   [ ] New feature ✨
-   [ ] Breaking change 💥
-   [ ] Documentation update 📖
-   [X] Refactor 🔧

## Testing

Describe tests and instructions to reproduce. 🧪

-   [ ] Local Tests (npm run test)
-   [X] Manual: Download npm package and check that the folder contracts with the .sol files exists.
-   [ ] Local GitHub Actions (act pull_request)

**Node version**:

-   [ ] 18
-   [ ] 20
-   [x] 22
-   [ ] 23

### Test Results (if any)

## Checklist

-   [X] Style Guidelines followed ✅
-   [X] Self-Reviewed 👀
-   [X] Documentation Updated 📚
-   [X] **Linters** - No New Warnings ⚠️
-   [X] Effective Tests Added ✔️
-   [X] Local Tests Pass ✅
-   [X] No reduction of **Coverage**
