### PR TITLE
Fix: no autoexecute extractMethods script

### DIFF
--- a/packages/ats/contracts/scripts/extractMethods.ts
+++ b/packages/ats/contracts/scripts/extractMethods.ts
@@ -344,4 +344,4 @@ export function main() {
     console.log(`✅ Methods extracted to ${OUTPUT_FILE}`)
 }
 
-main()
+// main()


### PR DESCRIPTION
## Description
Remove autoexecute extractMethods when execute any hardhat script

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
