### PR TITLE
fix(test): resolve flaky timestamp comparison in holder repository test

### DIFF
--- a/apps/mass-payout/backend/test/integration/adapters/repositories/typeorm-holder.repository.spec.ts
+++ b/apps/mass-payout/backend/test/integration/adapters/repositories/typeorm-holder.repository.spec.ts
@@ -298,8 +298,22 @@ describe(HolderTypeOrmRepository.name, () => {
       const savedHolders = await holderRepository.saveHolders(holders)
 
       expect(savedHolders).toHaveLength(2)
-      expect(savedHolders).toContainEqual(holder1)
-      expect(savedHolders).toContainEqual(holder2)
+
+      const savedHolder1 = savedHolders.find((h) => h.id === holder1.id)
+      const savedHolder2 = savedHolders.find((h) => h.id === holder2.id)
+
+      expect(savedHolder1).toMatchObject({
+        id: holder1.id,
+        holderEvmAddress: holder1.holderEvmAddress,
+        holderHederaAddress: holder1.holderHederaAddress,
+        status: holder1.status,
+      })
+      expect(savedHolder2).toMatchObject({
+        id: holder2.id,
+        holderEvmAddress: holder2.holderEvmAddress,
+        holderHederaAddress: holder2.holderHederaAddress,
+        status: holder2.status,
+      })
     })
 
     it("should throw HolderRepositoryError when saving multiple holders fails", async () => {


### PR DESCRIPTION
## Description

Fixed flaky test in typeorm-holder.repository.spec.ts that was failing due to millisecond timestamp differences
Changed from exact object equality to partial field matching using toMatchObject
Finds holders by ID rather than assuming array order
Compares only essential fields, excluding auto-generated timestamps

## Type of change

- [X] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [X] 22
- [ ] 24

## Checklist

- [X] Style Guidelines followed ✅
- [X] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X] Local Tests Pass ✅
- [X] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
