### PR TITLE
Feat/BBND-1244_Add-decimals-to-nominal-value

### DIFF
--- a/.changeset/mighty-lights-burn.md
+++ b/.changeset/mighty-lights-burn.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-dapp": patch
+---
+
+Add number of decimals to nominal value in bonds and equity in web app

--- a/apps/ats/web/src/views/CreateBond/Components/StepConfiguration.tsx
+++ b/apps/ats/web/src/views/CreateBond/Components/StepConfiguration.tsx
@@ -1,211 +1,8 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import { useEffect } from 'react';
-import { HStack, Stack } from '@chakra-ui/react';
-import { useTranslation } from 'react-i18next';
+import { useEffect } from "react";
+import { HStack, Stack } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
 import {
   PhosphorIcon,
   Text,
@@ -213,30 +10,29 @@ import {
   InputController,
   InputNumberController,
   Tooltip,
-} from 'io-bricks-ui';
-import { CancelButton } from '../../../components/CancelButton';
-import { NextStepButton } from './NextStepButton';
-import { PreviousStepButton } from './PreviousStepButton';
-import { required, isAfterDate, min } from '../../../utils/rules';
-import { ICreateBondFormValues } from '../ICreateBondFormValues';
-import { useFormContext, useFormState } from 'react-hook-form';
-import { FormStepContainer } from '../../../components/FormStepContainer';
-import { formatNumber } from '../../../utils/format';
-import { Info } from '@phosphor-icons/react';
-import { addDays } from 'date-fns';
+} from "io-bricks-ui";
+import { CancelButton } from "../../../components/CancelButton";
+import { NextStepButton } from "./NextStepButton";
+import { PreviousStepButton } from "./PreviousStepButton";
+import { required, isAfterDate, min } from "../../../utils/rules";
+import { ICreateBondFormValues } from "../ICreateBondFormValues";
+import { useFormContext, useFormState } from "react-hook-form";
+import { FormStepContainer } from "../../../components/FormStepContainer";
+import { formatNumber } from "../../../utils/format";
+import { Info } from "@phosphor-icons/react";
+import { addDays } from "date-fns";
 
 export const StepConfiguration = () => {
-  const { t } = useTranslation('security', { keyPrefix: 'createBond' });
-  const { control, watch, setValue, getValues } =
-    useFormContext<ICreateBondFormValues>();
+  const { t } = useTranslation("security", { keyPrefix: "createBond" });
+  const { control, watch, setValue, getValues } = useFormContext<ICreateBondFormValues>();
   const stepFormState = useFormState({ control });
 
   const today = new Date();
-  const startingDate = watch('startingDate');
-  const nominalValue = watch('nominalValue');
-  const numberOfUnits = watch('numberOfUnits');
-  const totalAmount = watch('totalAmount');
-  const decimals = getValues('decimals');
+  const startingDate = watch("startingDate");
+  const nominalValue = watch("nominalValue");
+  const numberOfUnits = watch("numberOfUnits");
+  const totalAmount = watch("totalAmount");
+  const decimals = getValues("decimals");
 
   useEffect(() => {
     let totalAmount = 0;
@@ -244,24 +40,20 @@ export const StepConfiguration = () => {
       totalAmount = Number(nominalValue) * Number(numberOfUnits);
     }
 
-    setValue('totalAmount', formatNumber(totalAmount, {}, 2));
+    setValue("totalAmount", formatNumber(totalAmount, {}, 18));
   }, [nominalValue, numberOfUnits, setValue]);
 
   return (
     <FormStepContainer>
       <Stack gap={2}>
-        <Text textStyle="HeadingMediumLG">{t('stepConfiguration.title')}</Text>
-        <Text textStyle="BodyTextRegularMD">
-          {t('stepConfiguration.subtitle')}
-        </Text>
+        <Text textStyle="HeadingMediumLG">{t("stepConfiguration.title")}</Text>
+        <Text textStyle="BodyTextRegularMD">{t("stepConfiguration.subtitle")}</Text>
         <Text textStyle="ElementsRegularSM" mt={6}>
-          {t('stepConfiguration.mandatoryFields')}
+          {t("stepConfiguration.mandatoryFields")}
         </Text>
       </Stack>
       <Stack w="full">
-        <Text textStyle="BodyTextRegularSM">
-          {t('stepConfiguration.currency')}
-        </Text>
+        <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.currency")}</Text>
         <InputController
           control={control}
           id="currency"
@@ -274,13 +66,8 @@ export const StepConfiguration = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepConfiguration.numberOfUnits')}*
-          </Text>
-          <Tooltip
-            label={t('stepConfiguration.numberOfUnitsTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.numberOfUnits")}*</Text>
+          <Tooltip label={t("stepConfiguration.numberOfUnitsTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -294,7 +81,7 @@ export const StepConfiguration = () => {
           }}
           decimalScale={decimals}
           fixedDecimalScale={true}
-          placeholder={t('stepConfiguration.numberOfUnitsPlaceHolder')}
+          placeholder={t("stepConfiguration.numberOfUnitsPlaceHolder")}
           backgroundColor="neutral.600"
           size="md"
           thousandSeparator=","
@@ -303,13 +90,8 @@ export const StepConfiguration = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepConfiguration.nominalValue')}*
-          </Text>
-          <Tooltip
-            label={t('stepConfiguration.nominalValueTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.nominalValue")}*</Text>
+          <Tooltip label={t("stepConfiguration.nominalValueTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -320,9 +102,8 @@ export const StepConfiguration = () => {
             required,
             min: min(0),
           }}
-          decimalScale={2}
-          fixedDecimalScale={true}
-          placeholder={t('stepConfiguration.nominalValuePlaceHolder')}
+          decimalScale={18}
+          placeholder={t("stepConfiguration.nominalValuePlaceHolder")}
           backgroundColor="neutral.600"
           size="md"
           thousandSeparator=","
@@ -331,13 +112,8 @@ export const StepConfiguration = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepConfiguration.totalAmount')}*
-          </Text>
-          <Tooltip
-            label={t('stepConfiguration.totalAmountTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.totalAmount")}*</Text>
+          <Tooltip label={t("stepConfiguration.totalAmountTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -354,13 +130,8 @@ export const StepConfiguration = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepConfiguration.startingDate')}*
-          </Text>
-          <Tooltip
-            label={t('stepConfiguration.startingDateTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.startingDate")}*</Text>
+          <Tooltip label={t("stepConfiguration.startingDateTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -371,20 +142,15 @@ export const StepConfiguration = () => {
           rules={{
             required,
           }}
-          placeholder={t('stepConfiguration.startingDatePlaceHolder')}
+          placeholder={t("stepConfiguration.startingDatePlaceHolder")}
           backgroundColor="neutral.600"
           size="md"
         />
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepConfiguration.maturityDate')}*
-          </Text>
-          <Tooltip
-            label={t('stepConfiguration.maturityDateTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepConfiguration.maturityDate")}*</Text>
+          <Tooltip label={t("stepConfiguration.maturityDateTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -396,18 +162,12 @@ export const StepConfiguration = () => {
             required,
             validate: isAfterDate(new Date(startingDate)),
           }}
-          placeholder={t('stepConfiguration.maturityDatePlaceHolder')}
+          placeholder={t("stepConfiguration.maturityDatePlaceHolder")}
           backgroundColor="neutral.600"
           size="md"
         />
       </Stack>
-      <HStack
-        gap={4}
-        w="full"
-        h="100px"
-        align="end"
-        justifyContent={'flex-end'}
-      >
+      <HStack gap={4} w="full" h="100px" align="end" justifyContent={"flex-end"}>
         <CancelButton />
         <PreviousStepButton />
         <NextStepButton isDisabled={!stepFormState.isValid} />

--- a/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
+++ b/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
@@ -1,247 +1,23 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import {
-  HStack,
-  SimpleGrid,
-  Stack,
-  VStack,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { useTranslation } from 'react-i18next';
-import { PreviousStepButton } from './PreviousStepButton';
-import { PhosphorIcon, Table, Text } from 'io-bricks-ui';
-import { useFormContext } from 'react-hook-form';
-import {
-  Button,
-  DetailReview,
-  DetailReviewProps,
-  InfoDivider,
-  PopUp,
-} from 'io-bricks-ui';
-import { useCreateBond } from '../../../hooks/queries/useCreateBond';
-import { useWalletStore } from '../../../store/walletStore';
-import { CreateBondRequest } from '@hashgraph/asset-tokenization-sdk';
-import { ICreateBondFormValues } from '../ICreateBondFormValues';
-import { RouterManager } from '../../../router/RouterManager';
-import { RouteName } from '../../../router/RouteName';
-import { WarningCircle, Question } from '@phosphor-icons/react';
-import {
-  dateToUnixTimestamp,
-  formatNumber,
-  numberToExponential,
-  textToHex,
-} from '../../../utils/format';
-import { FormStepContainer } from '../../../components/FormStepContainer';
-import { NOMINAL_VALUE_DECIMALS } from '../../../utils/constants';
-import { CountriesList } from '../../CreateSecurityCommons/CountriesList';
-import {
-  COUNTRY_LIST_ALLOWED,
-  COUNTRY_LIST_BLOCKED,
-} from '../../../utils/countriesConfig';
-import { createColumnHelper } from '@tanstack/table-core';
+import { HStack, SimpleGrid, Stack, VStack, useDisclosure } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { PreviousStepButton } from "./PreviousStepButton";
+import { PhosphorIcon, Table, Text } from "io-bricks-ui";
+import { useFormContext } from "react-hook-form";
+import { Button, DetailReview, DetailReviewProps, InfoDivider, PopUp } from "io-bricks-ui";
+import { useCreateBond } from "../../../hooks/queries/useCreateBond";
+import { useWalletStore } from "../../../store/walletStore";
+import { CreateBondRequest } from "@hashgraph/asset-tokenization-sdk";
+import { ICreateBondFormValues } from "../ICreateBondFormValues";
+import { RouterManager } from "../../../router/RouterManager";
+import { RouteName } from "../../../router/RouteName";
+import { WarningCircle, Question } from "@phosphor-icons/react";
+import { dateToUnixTimestamp, formatNumber, numberToExponential, textToHex } from "../../../utils/format";
+import { FormStepContainer } from "../../../components/FormStepContainer";
+import { CountriesList } from "../../CreateSecurityCommons/CountriesList";
+import { COUNTRY_LIST_ALLOWED, COUNTRY_LIST_BLOCKED } from "../../../utils/countriesConfig";
+import { createColumnHelper } from "@tanstack/table-core";
 
 interface IProceedRecipient {
   address: string;
@@ -249,72 +25,63 @@ interface IProceedRecipient {
 }
 
 export const StepReview = () => {
-  const { t } = useTranslation('security', { keyPrefix: 'createBond' });
-  const { t: tRegulation } = useTranslation('security', {
-    keyPrefix: 'regulation',
+  const { t } = useTranslation("security", { keyPrefix: "createBond" });
+  const { t: tRegulation } = useTranslation("security", {
+    keyPrefix: "regulation",
   });
 
   const { mutate: createBond, isLoading } = useCreateBond();
   const { address } = useWalletStore();
 
-  const {
-    isOpen: isOpenCancel,
-    onClose: onCloseCancel,
-    onOpen: onOpenCancel,
-  } = useDisclosure();
-  const {
-    isOpen: isOpenCreate,
-    onClose: onCloseCreate,
-    onOpen: onOpenCreate,
-  } = useDisclosure();
+  const { isOpen: isOpenCancel, onClose: onCloseCancel, onOpen: onOpenCancel } = useDisclosure();
+  const { isOpen: isOpenCreate, onClose: onCloseCreate, onOpen: onOpenCreate } = useDisclosure();
 
   const { getValues } = useFormContext<ICreateBondFormValues>();
 
-  const name = getValues('name');
-  const symbol = getValues('symbol');
-  const decimals = getValues('decimals');
-  const isin = getValues('isin');
-  const currency = getValues('currency');
-  const numberOfUnits = getValues('numberOfUnits');
-  const nominalValue = getValues('nominalValue');
-  const totalAmount = getValues('totalAmount');
-  const startingDate = getValues('startingDate');
-  const maturityDate = getValues('maturityDate');
-  const isBlocklist = getValues('isBlocklist');
-  const isControllable = getValues('isControllable');
-  const isClearing = getValues('isClearing');
-  const regulationType = getValues('regulationType');
-  const regulationSubType = getValues('regulationSubType');
-  const countriesListType = getValues('countriesListType');
-  let countriesList = getValues('countriesList');
-  const externalPausesList = getValues('externalPausesList');
-  const externalControlList = getValues('externalControlList');
-  const externalKYCList = getValues('externalKYCList');
-  const internalKycActivated = getValues('internalKycActivated');
-  const complianceId = getValues('complianceId');
-  const identityRegistryId = getValues('identityRegistryId');
-  const proceedRecipientsIds = getValues('proceedRecipientsIds');
-  const proceedRecipientsData = getValues('proceedRecipientsData');
+  const name = getValues("name");
+  const symbol = getValues("symbol");
+  const decimals = getValues("decimals");
+  const isin = getValues("isin");
+  const currency = getValues("currency");
+  const numberOfUnits = getValues("numberOfUnits");
+  const nominalValue = getValues("nominalValue");
+  const nominalValueParts = nominalValue.toString().split(".");
+  const nominalValueDynamicDecimals = nominalValueParts.length > 1 ? nominalValueParts[1].length : 0;
+  const nominalValueRawValue = nominalValueParts.join("");
+  const totalAmount = getValues("totalAmount");
+  const startingDate = getValues("startingDate");
+  const maturityDate = getValues("maturityDate");
+  const isBlocklist = getValues("isBlocklist");
+  const isControllable = getValues("isControllable");
+  const isClearing = getValues("isClearing");
+  const regulationType = getValues("regulationType");
+  const regulationSubType = getValues("regulationSubType");
+  const countriesListType = getValues("countriesListType");
+  let countriesList = getValues("countriesList");
+  const externalPausesList = getValues("externalPausesList");
+  const externalControlList = getValues("externalControlList");
+  const externalKYCList = getValues("externalKYCList");
+  const internalKycActivated = getValues("internalKycActivated");
+  const complianceId = getValues("complianceId");
+  const identityRegistryId = getValues("identityRegistryId");
+  const proceedRecipientsIds = getValues("proceedRecipientsIds");
+  const proceedRecipientsData = getValues("proceedRecipientsData");
 
-  countriesList = countriesList.concat(
-    countriesListType === 2 ? COUNTRY_LIST_ALLOWED : COUNTRY_LIST_BLOCKED,
-  );
+  countriesList = countriesList.concat(countriesListType === 2 ? COUNTRY_LIST_ALLOWED : COUNTRY_LIST_BLOCKED);
 
-  const proceedRecipientsTableData: IProceedRecipient[] = (
-    proceedRecipientsIds || []
-  ).map((address, index) => ({
+  const proceedRecipientsTableData: IProceedRecipient[] = (proceedRecipientsIds || []).map((address, index) => ({
     address,
-    data: (proceedRecipientsData || [])[index] || '',
+    data: (proceedRecipientsData || [])[index] || "",
   }));
 
   const columnsHelper = createColumnHelper<IProceedRecipient>();
   const columnsProceedRecipients = [
-    columnsHelper.accessor('address', {
-      header: t('stepProceedRecipients.address'),
+    columnsHelper.accessor("address", {
+      header: t("stepProceedRecipients.address"),
       enableSorting: false,
     }),
-    columnsHelper.accessor('data', {
-      header: t('stepProceedRecipients.data'),
+    columnsHelper.accessor("data", {
+      header: t("stepProceedRecipients.data"),
       enableSorting: false,
     }),
   ];
@@ -333,22 +100,18 @@ export const StepReview = () => {
       isMultiPartition: false,
       diamondOwnerAccount: address,
       numberOfUnits: numberToExponential(numberOfUnits, decimals),
-      nominalValue: (nominalValue * 10 ** NOMINAL_VALUE_DECIMALS).toString(),
-      nominalValueDecimals: NOMINAL_VALUE_DECIMALS,
+      nominalValue: nominalValueRawValue,
+      nominalValueDecimals: nominalValueDynamicDecimals,
       startingDate: dateToUnixTimestamp(startingDate),
       maturityDate: dateToUnixTimestamp(maturityDate),
-      currency:
-        '0x' +
-        currency.charCodeAt(0) +
-        currency.charCodeAt(1) +
-        currency.charCodeAt(2),
+      currency: "0x" + currency.charCodeAt(0) + currency.charCodeAt(1) + currency.charCodeAt(2),
       regulationType: regulationType,
       regulationSubType: regulationSubType,
       isCountryControlListWhiteList: countriesListType === 2,
       countries: countriesList.map((country) => country).toString(),
-      info: '',
-      configId: process.env.REACT_APP_BOND_CONFIG_ID ?? '',
-      configVersion: parseInt(process.env.REACT_APP_BOND_CONFIG_VERSION ?? '0'),
+      info: "",
+      configId: process.env.REACT_APP_BOND_CONFIG_ID ?? "",
+      configVersion: parseInt(process.env.REACT_APP_BOND_CONFIG_VERSION ?? "0"),
       ...(externalPausesList &&
         externalPausesList.length > 0 && {
           externalPausesIds: externalPausesList,
@@ -372,9 +135,7 @@ export const StepReview = () => {
         proceedRecipientsIds: proceedRecipientsIds,
       }),
       ...(proceedRecipientsData && {
-        proceedRecipientsData: proceedRecipientsData.map((data) =>
-          textToHex(data),
-        ),
+        proceedRecipientsData: proceedRecipientsData.map((data) => textToHex(data)),
       }),
     });
 
@@ -383,101 +144,87 @@ export const StepReview = () => {
 
   const tokenDetails: DetailReviewProps[] = [
     {
-      title: t('stepTokenDetails.name'),
+      title: t("stepTokenDetails.name"),
       value: name,
     },
     {
-      title: t('stepTokenDetails.symbol'),
+      title: t("stepTokenDetails.symbol"),
       value: symbol,
     },
     {
-      title: t('stepTokenDetails.decimals'),
+      title: t("stepTokenDetails.decimals"),
       value: decimals,
     },
     {
-      title: t('stepTokenDetails.isin'),
+      title: t("stepTokenDetails.isin"),
       value: isin,
     },
   ];
 
   const configurationDetails: DetailReviewProps[] = [
     {
-      title: t('stepConfiguration.currency'),
+      title: t("stepConfiguration.currency"),
       value: currency,
     },
     {
-      title: t('stepConfiguration.numberOfUnits'),
+      title: t("stepConfiguration.numberOfUnits"),
       value: formatNumber(numberOfUnits, {}, decimals),
     },
     {
-      title: t('stepConfiguration.nominalValue'),
-      value: formatNumber(nominalValue, {}, 2),
+      title: t("stepConfiguration.nominalValue"),
+      value: formatNumber(nominalValue, {}, nominalValueDynamicDecimals),
     },
     {
-      title: t('stepConfiguration.totalAmount'),
+      title: t("stepConfiguration.totalAmount"),
       value: totalAmount,
     },
     {
-      title: t('stepConfiguration.startingDate'),
+      title: t("stepConfiguration.startingDate"),
       value: new Date(startingDate).toLocaleDateString(),
     },
     {
-      title: t('stepConfiguration.maturityDate'),
+      title: t("stepConfiguration.maturityDate"),
       value: new Date(maturityDate).toLocaleDateString(),
     },
   ];
 
   const erc3643Details: DetailReviewProps[] = [
     {
-      title: t('stepERC3643.complianceId'),
-      value: complianceId ?? '-',
+      title: t("stepERC3643.complianceId"),
+      value: complianceId ?? "-",
     },
     {
-      title: t('stepERC3643.identityRegistryId'),
-      value: identityRegistryId ?? '-',
+      title: t("stepERC3643.identityRegistryId"),
+      value: identityRegistryId ?? "-",
     },
   ];
   const externalManagement: DetailReviewProps[] = [
     {
-      title: t('stepExternalManagement.externalPause'),
-      value: externalPausesList
-        ? externalPausesList?.map((pause) => ' ' + pause).toString()
-        : '-',
+      title: t("stepExternalManagement.externalPause"),
+      value: externalPausesList ? externalPausesList?.map((pause) => " " + pause).toString() : "-",
     },
     {
-      title: t('stepExternalManagement.externalControl'),
-      value: externalControlList
-        ? externalControlList?.map((control) => ' ' + control).toString()
-        : '-',
+      title: t("stepExternalManagement.externalControl"),
+      value: externalControlList ? externalControlList?.map((control) => " " + control).toString() : "-",
     },
     {
-      title: t('stepExternalManagement.externalKYC'),
-      value: externalKYCList
-        ? externalKYCList?.map((control) => ' ' + control).toString()
-        : '-',
+      title: t("stepExternalManagement.externalKYC"),
+      value: externalKYCList ? externalKYCList?.map((control) => " " + control).toString() : "-",
     },
   ];
 
   const regulationDetails: DetailReviewProps[] = [
     {
-      title: tRegulation('regulationTypeReview'),
+      title: tRegulation("regulationTypeReview"),
       value: tRegulation(`regulationType_${regulationType}`),
     },
     {
-      title: tRegulation('regulationSubTypeReview'),
+      title: tRegulation("regulationSubTypeReview"),
       value: tRegulation(`regulationSubType_${regulationSubType}`),
     },
     {
-      title:
-        countriesListType === 2
-          ? tRegulation('allowedCountriesReview')
-          : tRegulation('blockedCountriesReview'),
-      value: countriesList
-        .map(
-          (country) =>
-            ' ' + CountriesList[country as keyof typeof CountriesList],
-        )
-        .toString(),
+      title: countriesListType === 2 ? tRegulation("allowedCountriesReview") : tRegulation("blockedCountriesReview"),
+      value: countriesList.map((country) => " " + CountriesList[country as keyof typeof CountriesList]).toString(),
     },
   ];
 
@@ -485,87 +232,56 @@ export const StepReview = () => {
     <FormStepContainer>
       <Stack w="full">
         <VStack gap={5}>
-          <InfoDivider
-            step={1}
-            title={'Token ' + t('header.details')}
-            type="main"
-          />
+          <InfoDivider step={1} title={"Token " + t("header.details")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {tokenDetails.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider
-            step={2}
-            title={t('header.configuration') + ' details'}
-            type="main"
-          />
+          <InfoDivider step={2} title={t("header.configuration") + " details"} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {configurationDetails.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider
-            step={3}
-            title={t('stepProceedRecipients.title')}
-            type="main"
-          />
+          <InfoDivider step={3} title={t("stepProceedRecipients.title")} type="main" />
           <Stack w="full">
             {proceedRecipientsTableData.length > 0 && (
-              <Table
-                name="proceedRecipients"
-                columns={columnsProceedRecipients}
-                data={proceedRecipientsTableData}
-              />
+              <Table name="proceedRecipients" columns={columnsProceedRecipients} data={proceedRecipientsTableData} />
             )}
             {!proceedRecipientsTableData.length && <Text>-</Text>}
           </Stack>
 
-          <InfoDivider step={4} title={t('stepERC3643.title')} type="main" />
+          <InfoDivider step={4} title={t("stepERC3643.title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {erc3643Details.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider
-            step={5}
-            title={t('stepExternalManagement.title')}
-            type="main"
-          />
+          <InfoDivider step={5} title={t("stepExternalManagement.title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {externalManagement.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider step={6} title={t('header.regulation')} type="main" />
+          <InfoDivider step={6} title={t("header.regulation")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {regulationDetails.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <HStack
-            gap={2}
-            w="full"
-            h="100px"
-            align="end"
-            justifyContent={'flex-end'}
-          >
+          <HStack gap={2} w="full" h="100px" align="end" justifyContent={"flex-end"}>
             <Button size="md" variant="secondary" onClick={onOpenCancel}>
-              {t('cancelButton')}
+              {t("cancelButton")}
             </Button>
             <PreviousStepButton />
-            <Button
-              size="md"
-              variant="primary"
-              onClick={onOpenCreate}
-              isLoading={isLoading}
-            >
-              {t('createTokenButton')}
+            <Button size="md" variant="primary" onClick={onOpenCreate} isLoading={isLoading}>
+              {t("createTokenButton")}
             </Button>
           </HStack>
         </VStack>
@@ -576,31 +292,31 @@ export const StepReview = () => {
         isOpen={isOpenCancel}
         onClose={onCloseCancel}
         icon={<PhosphorIcon as={WarningCircle} size="md" />}
-        title={t('cancelSecurityPopUp.title')}
-        description={t('cancelSecurityPopUp.description')}
-        confirmText={t('cancelSecurityPopUp.confirmText')}
+        title={t("cancelSecurityPopUp.title")}
+        description={t("cancelSecurityPopUp.description")}
+        confirmText={t("cancelSecurityPopUp.confirmText")}
         onConfirm={() => {
           RouterManager.to(RouteName.Dashboard);
           onCloseCancel();
         }}
         onCancel={onCloseCancel}
-        cancelText={t('cancelSecurityPopUp.cancelText')}
-        confirmButtonProps={{ status: 'danger' }}
+        cancelText={t("cancelSecurityPopUp.cancelText")}
+        confirmButtonProps={{ status: "danger" }}
       />
       <PopUp
         id="createBond"
         isOpen={isOpenCreate}
         onClose={onCloseCreate}
         icon={<PhosphorIcon as={Question} size="md" />}
-        title={t('createSecurityPopUp.title')}
-        description={t('createSecurityPopUp.description')}
-        confirmText={t('createSecurityPopUp.confirmText')}
+        title={t("createSecurityPopUp.title")}
+        description={t("createSecurityPopUp.description")}
+        confirmText={t("createSecurityPopUp.confirmText")}
         onConfirm={() => {
           submit();
           onCloseCreate();
         }}
         onCancel={onCloseCreate}
-        cancelText={t('createSecurityPopUp.cancelText')}
+        cancelText={t("createSecurityPopUp.cancelText")}
       />
     </FormStepContainer>
   );

--- a/apps/ats/web/src/views/CreateEquity/Components/StepNewSerie.tsx
+++ b/apps/ats/web/src/views/CreateEquity/Components/StepNewSerie.tsx
@@ -1,217 +1,8 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import {
-  FormControl,
-  HStack,
-  SimpleGrid,
-  Stack,
-  VStack,
-} from '@chakra-ui/react';
-import { Trans, useTranslation } from 'react-i18next';
-import { Info } from '@phosphor-icons/react';
+import { FormControl, HStack, SimpleGrid, Stack, VStack } from "@chakra-ui/react";
+import { Trans, useTranslation } from "react-i18next";
+import { Info } from "@phosphor-icons/react";
 import {
   PhosphorIcon,
   Text,
@@ -221,60 +12,54 @@ import {
   SelectController,
   ToggleController,
   Tooltip,
-} from 'io-bricks-ui';
-import { CancelButton } from '../../../components/CancelButton';
-import { NextStepButton } from './NextStepButton';
-import { PreviousStepButton } from './PreviousStepButton';
-import { greaterThan, min, required } from '../../../utils/rules';
-import { ICreateEquityFormValues } from '../ICreateEquityFormValues';
-import { useFormContext, useFormState } from 'react-hook-form';
-import { useEffect } from 'react';
-import { DividendType } from '../DividendType';
-import { FormStepContainer } from '../../../components/FormStepContainer';
-import { formatNumber } from '../../../utils/format';
+} from "io-bricks-ui";
+import { CancelButton } from "../../../components/CancelButton";
+import { NextStepButton } from "./NextStepButton";
+import { PreviousStepButton } from "./PreviousStepButton";
+import { greaterThan, min, required } from "../../../utils/rules";
+import { ICreateEquityFormValues } from "../ICreateEquityFormValues";
+import { useFormContext, useFormState } from "react-hook-form";
+import { useEffect } from "react";
+import { DividendType } from "../DividendType";
+import { FormStepContainer } from "../../../components/FormStepContainer";
+import { formatNumber } from "../../../utils/format";
 
 export const StepNewSerie = () => {
-  const { t } = useTranslation('security', { keyPrefix: 'createEquity' });
+  const { t } = useTranslation("security", { keyPrefix: "createEquity" });
 
-  const { control, watch, setValue, getValues } =
-    useFormContext<ICreateEquityFormValues>();
+  const { control, watch, setValue, getValues } = useFormContext<ICreateEquityFormValues>();
 
   const stepFormState = useFormState({
     control,
   });
 
-  const nominalValue = watch('nominalValue');
-  const numberOfShares = watch('numberOfShares');
-  const totalAmount = watch('totalAmount');
-  const decimals = getValues('decimals');
+  const nominalValue = watch("nominalValue");
+  const numberOfShares = watch("numberOfShares");
+  const totalAmount = watch("totalAmount");
+  const decimals = getValues("decimals");
 
   useEffect(() => {
     let totalAmount = 0;
     if (!isNaN(Number(nominalValue)) && !isNaN(Number(numberOfShares))) {
       totalAmount = Number(nominalValue) * Number(numberOfShares);
     }
-    setValue('totalAmount', formatNumber(totalAmount, {}, 2));
+    setValue("totalAmount", formatNumber(totalAmount, {}, 18));
   }, [nominalValue, numberOfShares, setValue]);
 
   return (
     <FormStepContainer>
       <Stack gap={2}>
-        <Text textStyle="HeadingMediumLG">{t('stepNewSerie.title')}</Text>
-        <Text textStyle="BodyTextRegularMD">{t('stepNewSerie.subtitle')}</Text>
+        <Text textStyle="HeadingMediumLG">{t("stepNewSerie.title")}</Text>
+        <Text textStyle="BodyTextRegularMD">{t("stepNewSerie.subtitle")}</Text>
         <Text textStyle="ElementsRegularSM" mt={6}>
-          {t('stepNewSerie.mandatoryFields')}
+          {t("stepNewSerie.mandatoryFields")}
         </Text>
       </Stack>
-      <InfoDivider title={t('stepNewSerie.economicInformation')} type="main" />
+      <InfoDivider title={t("stepNewSerie.economicInformation")} type="main" />
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepNewSerie.nominalValue')}*
-          </Text>
-          <Tooltip
-            label={t('stepNewSerie.nominalValueTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepNewSerie.nominalValue")}*</Text>
+          <Tooltip label={t("stepNewSerie.nominalValueTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -286,9 +71,8 @@ export const StepNewSerie = () => {
             required,
             min: min(0),
           }}
-          decimalScale={2}
-          fixedDecimalScale={true}
-          placeholder={t('stepNewSerie.nominalValuePlaceHolder')}
+          decimalScale={18}
+          placeholder={t("stepNewSerie.nominalValuePlaceHolder")}
           backgroundColor="neutral.600"
           size="md"
           thousandSeparator=","
@@ -296,7 +80,7 @@ export const StepNewSerie = () => {
         />
       </Stack>
       <Stack w="full">
-        <Text textStyle="BodyTextRegularSM">{t('stepNewSerie.currency')}</Text>
+        <Text textStyle="BodyTextRegularSM">{t("stepNewSerie.currency")}</Text>
         <InputController
           control={control}
           id="currency"
@@ -309,13 +93,8 @@ export const StepNewSerie = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepNewSerie.numberOfShares')}*
-          </Text>
-          <Tooltip
-            label={t('stepNewSerie.numberOfSharesTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepNewSerie.numberOfShares")}*</Text>
+          <Tooltip label={t("stepNewSerie.numberOfSharesTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -338,13 +117,8 @@ export const StepNewSerie = () => {
       </Stack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepNewSerie.totalAmount')}*
-          </Text>
-          <Tooltip
-            label={t('stepNewSerie.totalAmountTooltip')}
-            placement="right"
-          >
+          <Text textStyle="BodyTextRegularSM">{t("stepNewSerie.totalAmount")}*</Text>
+          <Tooltip label={t("stepNewSerie.totalAmountTooltip")} placement="right">
             <PhosphorIcon as={Info} />
           </Tooltip>
         </HStack>
@@ -359,71 +133,37 @@ export const StepNewSerie = () => {
           isDisabled={true}
         />
       </Stack>
-      <InfoDivider title={t('stepNewSerie.rightsAndPrivileges')} type="main" />
+      <InfoDivider title={t("stepNewSerie.rightsAndPrivileges")} type="main" />
       <VStack w="full">
         <FormControl gap={4} as={SimpleGrid} columns={{ base: 7, lg: 1 }}>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isVotingRight"
-              label={t('stepNewSerie.votingRights')}
-            />
+            <ToggleController control={control} id="isVotingRight" label={t("stepNewSerie.votingRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isInformationRight"
-              label={t('stepNewSerie.informationRights')}
-            />
+            <ToggleController control={control} id="isInformationRight" label={t("stepNewSerie.informationRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isLiquidationRight"
-              label={t('stepNewSerie.liquidationRights')}
-            />
+            <ToggleController control={control} id="isLiquidationRight" label={t("stepNewSerie.liquidationRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isConversionRight"
-              label={t('stepNewSerie.conversionRights')}
-            />
+            <ToggleController control={control} id="isConversionRight" label={t("stepNewSerie.conversionRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isSubscriptionRight"
-              label={t('stepNewSerie.subscriptionRights')}
-            />
+            <ToggleController control={control} id="isSubscriptionRight" label={t("stepNewSerie.subscriptionRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isRedemptionRight"
-              label={t('stepNewSerie.redemptionRights')}
-            />
+            <ToggleController control={control} id="isRedemptionRight" label={t("stepNewSerie.redemptionRights")} />
           </HStack>
           <HStack justifySelf="flex-start">
-            <ToggleController
-              control={control}
-              id="isPutRight"
-              label={t('stepNewSerie.putRights')}
-            />
+            <ToggleController control={control} id="isPutRight" label={t("stepNewSerie.putRights")} />
           </HStack>
         </FormControl>
       </VStack>
       <Stack w="full">
         <HStack justifySelf="flex-start">
-          <Text textStyle="BodyTextRegularSM">
-            {t('stepNewSerie.dividendType')}*
-          </Text>
+          <Text textStyle="BodyTextRegularSM">{t("stepNewSerie.dividendType")}*</Text>
           <Tooltip
-            label={
-              <Trans i18nkey="stepNewSerie.dividendTypeTooltip">
-                {t('stepNewSerie.dividendTypeTooltip')}
-              </Trans>
-            }
+            label={<Trans i18nkey="stepNewSerie.dividendTypeTooltip">{t("stepNewSerie.dividendTypeTooltip")}</Trans>}
             placement="right"
           >
             <PhosphorIcon as={Info} />
@@ -437,26 +177,20 @@ export const StepNewSerie = () => {
           options={[
             {
               label: DividendType.NONE,
-              value: '0',
+              value: "0",
             },
             {
               label: DividendType.PREFERRED,
-              value: '1',
+              value: "1",
             },
             {
               label: DividendType.COMMON,
-              value: '2',
+              value: "2",
             },
           ]}
         />
       </Stack>
-      <HStack
-        gap={4}
-        w="full"
-        h="100px"
-        align="end"
-        justifyContent={'flex-end'}
-      >
+      <HStack gap={4} w="full" h="100px" align="end" justifyContent={"flex-end"}>
         <CancelButton />
         <PreviousStepButton />
         <NextStepButton isDisabled={!stepFormState.isValid} />

--- a/apps/ats/web/src/views/CreateEquity/Components/StepReview.tsx
+++ b/apps/ats/web/src/views/CreateEquity/Components/StepReview.tsx
@@ -1,301 +1,73 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import {
-  HStack,
-  SimpleGrid,
-  Stack,
-  VStack,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { useTranslation } from 'react-i18next';
-import { PreviousStepButton } from './PreviousStepButton';
-import {
-  PhosphorIcon,
-  Text,
-  Button,
-  DetailReview,
-  DetailReviewProps,
-  InfoDivider,
-  PopUp,
-} from 'io-bricks-ui';
-import { useFormContext } from 'react-hook-form';
-import { ICreateEquityFormValues } from '../ICreateEquityFormValues';
-import { useCreateEquity } from '../../../hooks/queries/useCreateEquity';
-import { useWalletStore } from '../../../store/walletStore';
-import { CreateEquityRequest } from '@hashgraph/asset-tokenization-sdk';
-import { transformDividendType } from '../DividendType';
-import { WarningCircle, Question } from '@phosphor-icons/react';
-import { RouterManager } from '../../../router/RouterManager';
-import { RouteName } from '../../../router/RouteName';
-import { numberToExponential } from '../../../utils/format';
-import { FormStepContainer } from '../../../components/FormStepContainer';
-import { NOMINAL_VALUE_DECIMALS } from '../../../utils/constants';
-import { formatNumber } from '../../../utils/format';
-import { CountriesList } from '../../CreateSecurityCommons/CountriesList';
-import {
-  COUNTRY_LIST_ALLOWED,
-  COUNTRY_LIST_BLOCKED,
-} from '../../../utils/countriesConfig';
+import { HStack, SimpleGrid, Stack, VStack, useDisclosure } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { PreviousStepButton } from "./PreviousStepButton";
+import { PhosphorIcon, Text, Button, DetailReview, DetailReviewProps, InfoDivider, PopUp } from "io-bricks-ui";
+import { useFormContext } from "react-hook-form";
+import { ICreateEquityFormValues } from "../ICreateEquityFormValues";
+import { useCreateEquity } from "../../../hooks/queries/useCreateEquity";
+import { useWalletStore } from "../../../store/walletStore";
+import { CreateEquityRequest } from "@hashgraph/asset-tokenization-sdk";
+import { transformDividendType } from "../DividendType";
+import { WarningCircle, Question } from "@phosphor-icons/react";
+import { RouterManager } from "../../../router/RouterManager";
+import { RouteName } from "../../../router/RouteName";
+import { numberToExponential } from "../../../utils/format";
+import { FormStepContainer } from "../../../components/FormStepContainer";
+import { formatNumber } from "../../../utils/format";
+import { CountriesList } from "../../CreateSecurityCommons/CountriesList";
+import { COUNTRY_LIST_ALLOWED, COUNTRY_LIST_BLOCKED } from "../../../utils/countriesConfig";
 
 export const StepReview = () => {
-  const { t } = useTranslation('security', { keyPrefix: 'createEquity' });
-  const { t: tRegulation } = useTranslation('security', {
-    keyPrefix: 'regulation',
+  const { t } = useTranslation("security", { keyPrefix: "createEquity" });
+  const { t: tRegulation } = useTranslation("security", {
+    keyPrefix: "regulation",
   });
 
   const { getValues } = useFormContext<ICreateEquityFormValues>();
   const { mutate: createSecurity, isLoading } = useCreateEquity();
   const { address } = useWalletStore();
 
-  const {
-    isOpen: isOpenCancel,
-    onClose: onCloseCancel,
-    onOpen: onOpenCancel,
-  } = useDisclosure();
-  const {
-    isOpen: isOpenCreate,
-    onClose: onCloseCreate,
-    onOpen: onOpenCreate,
-  } = useDisclosure();
+  const { isOpen: isOpenCancel, onClose: onCloseCancel, onOpen: onOpenCancel } = useDisclosure();
+  const { isOpen: isOpenCreate, onClose: onCloseCreate, onOpen: onOpenCreate } = useDisclosure();
 
-  const name = getValues('name');
-  const symbol = getValues('symbol');
-  const isin = getValues('isin');
-  const decimals = getValues('decimals');
-  const isControllable = getValues('isControllable');
-  const isBlocklist = getValues('isBlocklist');
-  const isClearing = getValues('isClearing');
-  const nominalValue = getValues('nominalValue');
-  const currency = getValues('currency');
-  const numberOfShares = getValues('numberOfShares');
-  const totalAmount = getValues('totalAmount');
+  const name = getValues("name");
+  const symbol = getValues("symbol");
+  const isin = getValues("isin");
+  const decimals = getValues("decimals");
+  const isControllable = getValues("isControllable");
+  const isBlocklist = getValues("isBlocklist");
+  const isClearing = getValues("isClearing");
+  const nominalValue = getValues("nominalValue");
+  const nominalValueParts = nominalValue.toString().split(".");
+  const nominalValueDynamicDecimals = nominalValueParts.length > 1 ? nominalValueParts[1].length : 0;
+  const nominalValueRawValue = nominalValueParts.join("");
+  const currency = getValues("currency");
+  const numberOfShares = getValues("numberOfShares");
+  const totalAmount = getValues("totalAmount");
   const rights = {
-    votingRights: getValues('isVotingRight'),
-    informationRights: getValues('isInformationRight'),
-    liquidationRights: getValues('isLiquidationRight'),
-    subscriptionRights: getValues('isSubscriptionRight'),
-    conversionRights: getValues('isConversionRight'),
-    redemptionRights: getValues('isRedemptionRight'),
-    putRights: getValues('isPutRight'),
+    votingRights: getValues("isVotingRight"),
+    informationRights: getValues("isInformationRight"),
+    liquidationRights: getValues("isLiquidationRight"),
+    subscriptionRights: getValues("isSubscriptionRight"),
+    conversionRights: getValues("isConversionRight"),
+    redemptionRights: getValues("isRedemptionRight"),
+    putRights: getValues("isPutRight"),
   };
-  const dividendType = getValues('dividendType');
-  const regulationType = getValues('regulationType');
-  const regulationSubType = getValues('regulationSubType');
-  const countriesListType = getValues('countriesListType');
-  let countriesList: string[] = getValues('countriesList');
-  const externalPausesList = getValues('externalPausesList');
-  const externalControlList = getValues('externalControlList');
-  const externalKYCList = getValues('externalKYCList');
-  const internalKycActivated = getValues('internalKycActivated');
-  const complianceId = getValues('complianceId');
-  const identityRegistryId = getValues('identityRegistryId');
+  const dividendType = getValues("dividendType");
+  const regulationType = getValues("regulationType");
+  const regulationSubType = getValues("regulationSubType");
+  const countriesListType = getValues("countriesListType");
+  let countriesList: string[] = getValues("countriesList");
+  const externalPausesList = getValues("externalPausesList");
+  const externalControlList = getValues("externalControlList");
+  const externalKYCList = getValues("externalKYCList");
+  const internalKycActivated = getValues("internalKycActivated");
+  const complianceId = getValues("complianceId");
+  const identityRegistryId = getValues("identityRegistryId");
 
-  countriesList = countriesList.concat(
-    countriesListType === 2 ? COUNTRY_LIST_ALLOWED : COUNTRY_LIST_BLOCKED,
-  );
+  countriesList = countriesList.concat(countriesListType === 2 ? COUNTRY_LIST_ALLOWED : COUNTRY_LIST_BLOCKED);
 
   const submit = () => {
     const request = new CreateEquityRequest({
@@ -318,23 +90,17 @@ export const StepReview = () => {
       redemptionRight: rights.redemptionRights,
       putRight: rights.putRights,
       dividendRight: dividendType,
-      currency:
-        '0x' +
-        currency.charCodeAt(0) +
-        currency.charCodeAt(1) +
-        currency.charCodeAt(2),
+      currency: "0x" + currency.charCodeAt(0) + currency.charCodeAt(1) + currency.charCodeAt(2),
       numberOfShares: numberToExponential(numberOfShares, decimals),
-      nominalValue: (nominalValue * 10 ** NOMINAL_VALUE_DECIMALS).toString(),
-      nominalValueDecimals: NOMINAL_VALUE_DECIMALS,
+      nominalValue: nominalValueRawValue,
+      nominalValueDecimals: nominalValueDynamicDecimals,
       regulationType: regulationType,
       regulationSubType: regulationSubType,
       isCountryControlListWhiteList: countriesListType === 2,
       countries: countriesList.map((country) => country).toString(),
-      info: '',
-      configId: process.env.REACT_APP_EQUITY_CONFIG_ID ?? '',
-      configVersion: parseInt(
-        process.env.REACT_APP_EQUITY_CONFIG_VERSION ?? '0',
-      ),
+      info: "",
+      configId: process.env.REACT_APP_EQUITY_CONFIG_ID ?? "",
+      configVersion: parseInt(process.env.REACT_APP_EQUITY_CONFIG_VERSION ?? "0"),
       ...(externalPausesList &&
         externalPausesList.length > 0 && {
           externalPausesIds: externalPausesList,
@@ -361,101 +127,87 @@ export const StepReview = () => {
 
   const tokenDetails: DetailReviewProps[] = [
     {
-      title: t('stepTokenDetails.name'),
+      title: t("stepTokenDetails.name"),
       value: name,
     },
     {
-      title: t('stepTokenDetails.symbol'),
+      title: t("stepTokenDetails.symbol"),
       value: symbol,
     },
     {
-      title: t('stepTokenDetails.decimals'),
+      title: t("stepTokenDetails.decimals"),
       value: decimals,
     },
     {
-      title: t('stepTokenDetails.isin'),
+      title: t("stepTokenDetails.isin"),
       value: isin,
     },
   ];
 
   const configurationNewSerieDetails: DetailReviewProps[] = [
     {
-      title: t('stepNewSerie.nominalValue'),
-      value: formatNumber(nominalValue, {}, 2),
+      title: t("stepNewSerie.nominalValue"),
+      value: formatNumber(nominalValue, {}, nominalValueDynamicDecimals),
     },
     {
-      title: t('stepNewSerie.currency'),
+      title: t("stepNewSerie.currency"),
       value: currency,
     },
     {
-      title: t('stepNewSerie.numberOfShares'),
+      title: t("stepNewSerie.numberOfShares"),
       value: formatNumber(numberOfShares, {}, decimals),
     },
     {
-      title: t('stepNewSerie.totalAmount'),
+      title: t("stepNewSerie.totalAmount"),
       value: totalAmount,
     },
   ];
 
   const configurationRightsDetails: DetailReviewProps[] = [
     {
-      title: t('stepNewSerie.dividendType'),
+      title: t("stepNewSerie.dividendType"),
       value: transformDividendType(dividendType.toString()),
     },
   ];
 
   const erc3643Details: DetailReviewProps[] = [
     {
-      title: t('stepERC3643.complianceId'),
-      value: complianceId ?? '-',
+      title: t("stepERC3643.complianceId"),
+      value: complianceId ?? "-",
     },
     {
-      title: t('stepERC3643.identityRegistryId'),
-      value: identityRegistryId ?? '-',
+      title: t("stepERC3643.identityRegistryId"),
+      value: identityRegistryId ?? "-",
     },
   ];
 
   const externalManagement: DetailReviewProps[] = [
     {
-      title: t('stepExternalManagement.externalPause'),
-      value: externalPausesList
-        ? externalPausesList?.map((pause) => ' ' + pause).toString()
-        : '-',
+      title: t("stepExternalManagement.externalPause"),
+      value: externalPausesList ? externalPausesList?.map((pause) => " " + pause).toString() : "-",
     },
     {
-      title: t('stepExternalManagement.externalControl'),
-      value: externalControlList
-        ? externalControlList?.map((control) => ' ' + control).toString()
-        : '-',
+      title: t("stepExternalManagement.externalControl"),
+      value: externalControlList ? externalControlList?.map((control) => " " + control).toString() : "-",
     },
     {
-      title: t('stepExternalManagement.externalKYC'),
-      value: externalKYCList
-        ? externalKYCList?.map((control) => ' ' + control).toString()
-        : '-',
+      title: t("stepExternalManagement.externalKYC"),
+      value: externalKYCList ? externalKYCList?.map((control) => " " + control).toString() : "-",
     },
   ];
 
   const regulationDetails: DetailReviewProps[] = [
     {
-      title: tRegulation('regulationTypeReview'),
+      title: tRegulation("regulationTypeReview"),
       value: tRegulation(`regulationType_${regulationType}`),
     },
     {
-      title: tRegulation('regulationSubTypeReview'),
+      title: tRegulation("regulationSubTypeReview"),
       value: tRegulation(`regulationSubType_${regulationSubType}`),
     },
     {
-      title:
-        countriesListType === 2
-          ? tRegulation('allowedCountriesReview')
-          : tRegulation('blockedCountriesReview'),
-      value: countriesList
-        .map(
-          (country) =>
-            ' ' + CountriesList[country as keyof typeof CountriesList],
-        )
-        .toString(),
+      title: countriesListType === 2 ? tRegulation("allowedCountriesReview") : tRegulation("blockedCountriesReview"),
+      value: countriesList.map((country) => " " + CountriesList[country as keyof typeof CountriesList]).toString(),
     },
   ];
 
@@ -463,22 +215,14 @@ export const StepReview = () => {
     <FormStepContainer>
       <Stack w="full">
         <VStack gap={5}>
-          <InfoDivider
-            step={1}
-            title={t('stepTokenDetails.title')}
-            type="main"
-          />
+          <InfoDivider step={1} title={t("stepTokenDetails.title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {tokenDetails.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider
-            step={2}
-            title={t('stepReview.configurationDetails')}
-            type="main"
-          />
+          <InfoDivider step={2} title={t("stepReview.configurationDetails")} type="main" />
           <InfoDivider title="Economic information" type="secondary" />
           <SimpleGrid columns={1} gap={6} w="full">
             {configurationNewSerieDetails.map((props) => (
@@ -489,17 +233,12 @@ export const StepReview = () => {
           <InfoDivider title="Rights and privileges" type="secondary" />
           <VStack gap={1} w="full">
             <Text textStyle="HeadingMediumMD" w="full" color="neutral.900">
-              {t('stepNewSerie.choosenRights')}
+              {t("stepNewSerie.choosenRights")}
             </Text>
             {Object.entries(rights)
               .filter(([_key, value]) => value)
               .map(([key]) => (
-                <Text
-                  textStyle="BodyTextRegularSM"
-                  w="full"
-                  color="neutral.700"
-                  key={key}
-                >
+                <Text textStyle="BodyTextRegularSM" w="full" color="neutral.700" key={key}>
                   · {t(`stepNewSerie.${key}`)}
                 </Text>
               ))}
@@ -511,49 +250,34 @@ export const StepReview = () => {
             ))}
           </SimpleGrid>
 
-          <InfoDivider step={3} title={t('stepERC3643.title')} type="main" />
+          <InfoDivider step={3} title={t("stepERC3643.title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {erc3643Details.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider
-            step={4}
-            title={t('stepExternalManagement.title')}
-            type="main"
-          />
+          <InfoDivider step={4} title={t("stepExternalManagement.title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {externalManagement.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <InfoDivider step={5} title={tRegulation('title')} type="main" />
+          <InfoDivider step={5} title={tRegulation("title")} type="main" />
           <SimpleGrid columns={1} gap={6} w="full">
             {regulationDetails.map((props) => (
               <DetailReview {...props} />
             ))}
           </SimpleGrid>
 
-          <HStack
-            gap={4}
-            w="full"
-            h="100px"
-            align="end"
-            justifyContent={'flex-end'}
-          >
+          <HStack gap={4} w="full" h="100px" align="end" justifyContent={"flex-end"}>
             <Button size="md" variant="secondary" onClick={onOpenCancel}>
-              {t('cancelButton')}
+              {t("cancelButton")}
             </Button>
             <PreviousStepButton />
-            <Button
-              size="md"
-              variant="primary"
-              onClick={onOpenCreate}
-              isLoading={isLoading}
-            >
-              {t('createTokenButton')}
+            <Button size="md" variant="primary" onClick={onOpenCreate} isLoading={isLoading}>
+              {t("createTokenButton")}
             </Button>
           </HStack>
         </VStack>
@@ -563,31 +287,31 @@ export const StepReview = () => {
         isOpen={isOpenCancel}
         onClose={onCloseCancel}
         icon={<PhosphorIcon as={WarningCircle} size="md" />}
-        title={t('cancelSecurityPopUp.title')}
-        description={t('cancelSecurityPopUp.description')}
-        confirmText={t('cancelSecurityPopUp.confirmText')}
+        title={t("cancelSecurityPopUp.title")}
+        description={t("cancelSecurityPopUp.description")}
+        confirmText={t("cancelSecurityPopUp.confirmText")}
         onConfirm={() => {
           RouterManager.to(RouteName.Dashboard);
           onCloseCancel();
         }}
         onCancel={onCloseCancel}
-        cancelText={t('cancelSecurityPopUp.cancelText')}
-        confirmButtonProps={{ status: 'danger' }}
+        cancelText={t("cancelSecurityPopUp.cancelText")}
+        confirmButtonProps={{ status: "danger" }}
       />
       <PopUp
         id="createEquity"
         isOpen={isOpenCreate}
         onClose={onCloseCreate}
         icon={<PhosphorIcon as={Question} size="md" />}
-        title={t('createSecurityPopUp.title')}
-        description={t('createSecurityPopUp.description')}
-        confirmText={t('createSecurityPopUp.confirmText')}
+        title={t("createSecurityPopUp.title")}
+        description={t("createSecurityPopUp.description")}
+        confirmText={t("createSecurityPopUp.confirmText")}
         onConfirm={() => {
           submit();
           onCloseCreate();
         }}
         onCancel={onCloseCreate}
-        cancelText={t('createSecurityPopUp.cancelText')}
+        cancelText={t("createSecurityPopUp.cancelText")}
       />
     </FormStepContainer>
   );

--- a/apps/ats/web/src/views/DigitalSecurityDetails/Components/Details/components/DetailsCurrentAvailableSupply.tsx
+++ b/apps/ats/web/src/views/DigitalSecurityDetails/Components/Details/components/DetailsCurrentAvailableSupply.tsx
@@ -1,17 +1,16 @@
-import { Center, Box, Text, SkeletonText } from '@chakra-ui/react';
-import { Panel } from '../../../../../components/Panel';
-import { useTranslation } from 'react-i18next';
-import { formatNumberLocale, toNumber } from '../../../../../utils/format';
-import {
-  GetAccountBalanceRequest,
-  SecurityViewModel,
-} from '@hashgraph/asset-tokenization-sdk';
-import { EquityDetailsViewModel } from '@hashgraph/asset-tokenization-sdk';
-import { BondDetailsViewModel } from '@hashgraph/asset-tokenization-sdk';
-import { useUserStore } from '../../../../../store/userStore';
-import { User } from '../../../../../utils/constants';
-import { useWalletStore } from '../../../../../store/walletStore';
-import { useGetBalanceOf } from '../../../../../hooks/queries/useGetSecurityDetails';
+// SPDX-License-Identifier: Apache-2.0
+
+import { Center, Box, Text, SkeletonText } from "@chakra-ui/react";
+import { Panel } from "../../../../../components/Panel";
+import { useTranslation } from "react-i18next";
+import { formatNumberLocale, toNumber } from "../../../../../utils/format";
+import { GetAccountBalanceRequest, SecurityViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { EquityDetailsViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { BondDetailsViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { useUserStore } from "../../../../../store/userStore";
+import { User } from "../../../../../utils/constants";
+import { useWalletStore } from "../../../../../store/walletStore";
+import { useGetBalanceOf } from "../../../../../hooks/queries/useGetSecurityDetails";
 
 interface DetailsCurrentAvailableSupplyProps {
   id: string;
@@ -26,25 +25,21 @@ export const DetailsCurrentAvailableSupply = ({
   equityDetailsResponse,
   bondDetailsResponse,
 }: DetailsCurrentAvailableSupplyProps) => {
-  const { t: tProperties } = useTranslation('properties');
+  const { t: tProperties } = useTranslation("properties");
 
   const { type } = useUserStore();
   const { address: walletAddress } = useWalletStore();
 
-  const { data: availableBalance, isLoading: isAvailableBalanceLoading } =
-    useGetBalanceOf(
-      new GetAccountBalanceRequest({
-        securityId: id,
-        targetId: walletAddress,
-      }),
-    );
+  const { data: availableBalance, isLoading: isAvailableBalanceLoading } = useGetBalanceOf(
+    new GetAccountBalanceRequest({
+      securityId: id,
+      targetId: walletAddress,
+    }),
+  );
 
   const currentAvailableBalance = toNumber(availableBalance?.value);
 
-  const nominalValue = toNumber(
-    equityDetailsResponse?.nominalValue || bondDetailsResponse?.nominalValue,
-    2,
-  );
+  const nominalValue = toNumber(equityDetailsResponse?.nominalValue || bondDetailsResponse?.nominalValue, 2);
 
   const totalAvailableBalanceValue = nominalValue * currentAvailableBalance;
 
@@ -53,21 +48,21 @@ export const DetailsCurrentAvailableSupply = ({
   }
 
   return (
-    <Panel title={tProperties('currentAvailableBalance')}>
+    <Panel title={tProperties("currentAvailableBalance")}>
       <Center w="full">
         {isAvailableBalanceLoading ? (
           <SkeletonText skeletonHeight={2} flex={1} noOfLines={1} />
         ) : (
           <Box>
             <Text textStyle="ElementsSemibold2XL">
-              {detailsResponse?.totalSupply ?? ''}
+              {detailsResponse?.totalSupply ?? ""}
               <Text ml={1} as="span" textStyle="ElementsRegularMD">
-                {detailsResponse?.symbol ?? ''}
+                {detailsResponse?.symbol ?? ""}
               </Text>
             </Text>
             <Text ml={1} as="span" textStyle="ElementsRegularMD">
-              {tProperties('nominalTotalValue')}
-              {formatNumberLocale(totalAvailableBalanceValue, 2)}
+              {tProperties("nominalTotalValue")}
+              {formatNumberLocale(totalAvailableBalanceValue, 18)}
             </Text>
           </Box>
         )}

--- a/apps/ats/web/src/views/DigitalSecurityDetails/Components/Details/components/DetailsTotalSupply.tsx
+++ b/apps/ats/web/src/views/DigitalSecurityDetails/Components/Details/components/DetailsTotalSupply.tsx
@@ -1,11 +1,13 @@
-import { Center, Box, Text, SkeletonText } from '@chakra-ui/react';
-import { Panel } from '../../../../../components/Panel';
-import { useTranslation } from 'react-i18next';
-import { formatNumberLocale, toNumber } from '../../../../../utils/format';
-import { SecurityViewModel } from '@hashgraph/asset-tokenization-sdk';
-import { EquityDetailsViewModel } from '@hashgraph/asset-tokenization-sdk';
-import { BondDetailsViewModel } from '@hashgraph/asset-tokenization-sdk';
-import { useMemo } from 'react';
+// SPDX-License-Identifier: Apache-2.0
+
+import { Center, Box, Text, SkeletonText } from "@chakra-ui/react";
+import { Panel } from "../../../../../components/Panel";
+import { useTranslation } from "react-i18next";
+import { formatNumberLocale, toNumber } from "../../../../../utils/format";
+import { SecurityViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { EquityDetailsViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { BondDetailsViewModel } from "@hashgraph/asset-tokenization-sdk";
+import { useMemo } from "react";
 
 interface DetailsTotalSupplyProps {
   detailsResponse: SecurityViewModel;
@@ -18,37 +20,33 @@ export const DetailsTotalSupply = ({
   equityDetailsResponse,
   bondDetailsResponse,
 }: DetailsTotalSupplyProps) => {
-  const { t: tProperties } = useTranslation('properties');
+  const { t: tProperties } = useTranslation("properties");
 
   const nominalValue = useMemo(() => {
     return toNumber(
       equityDetailsResponse?.nominalValue || bondDetailsResponse?.nominalValue,
-      2,
+      equityDetailsResponse?.nominalValueDecimals || bondDetailsResponse?.nominalValueDecimals || 2,
     );
   }, [equityDetailsResponse, bondDetailsResponse]);
 
   const nominalTotalValue = useMemo(() => {
-    return formatNumberLocale(
-      nominalValue * ((detailsResponse?.totalSupply ?? 0) as number),
-      2,
-    );
+    return formatNumberLocale(nominalValue * ((detailsResponse?.totalSupply ?? 0) as number), 18);
   }, [nominalValue, detailsResponse]);
 
   return (
-    <Panel title={tProperties('totalSupply')}>
+    <Panel title={tProperties("totalSupply")}>
       <Center w="full">
         {detailsResponse &&
-        (equityDetailsResponse?.nominalValue !== undefined ||
-          bondDetailsResponse?.nominalValue !== undefined) ? (
+        (equityDetailsResponse?.nominalValue !== undefined || bondDetailsResponse?.nominalValue !== undefined) ? (
           <Box>
             <Text textStyle="ElementsSemibold2XL">
-              {detailsResponse?.totalSupply ?? ''}
+              {detailsResponse?.totalSupply ?? ""}
               <Text ml={1} as="span" textStyle="ElementsRegularMD">
-                {detailsResponse?.symbol ?? ''}
+                {detailsResponse?.symbol ?? ""}
               </Text>
             </Text>
             <Text ml={1} as="span" textStyle="ElementsRegularMD">
-              {tProperties('nominalTotalValue')}
+              {tProperties("nominalTotalValue")}
               {nominalTotalValue}
             </Text>
           </Box>

--- a/apps/ats/web/src/views/DigitalSecurityDetails/Components/SecurityDetailsExtended.tsx
+++ b/apps/ats/web/src/views/DigitalSecurityDetails/Components/SecurityDetailsExtended.tsx
@@ -1,239 +1,26 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import {
-  DefinitionList,
-  DefinitionListProps,
-  ClipboardButton,
-  Text,
-} from 'io-bricks-ui';
-import { useTranslation } from 'react-i18next';
-import {
-  formatDate,
-  formatNumberLocale,
-  toNumber,
-} from '../../../utils/format';
-import { useSecurityStore } from '../../../store/securityStore';
-import { useParams } from 'react-router-dom';
-import { Flex } from '@chakra-ui/react';
+import { DefinitionList, DefinitionListProps, ClipboardButton, Text } from "io-bricks-ui";
+import { useTranslation } from "react-i18next";
+import { formatDate, formatNumberLocale, toNumber } from "../../../utils/format";
+import { useSecurityStore } from "../../../store/securityStore";
+import { useParams } from "react-router-dom";
+import { Flex } from "@chakra-ui/react";
 import {
   BondDetailsViewModel,
   ComplianceRequest,
   EquityDetailsViewModel,
   IdentityRegistryRequest,
-} from '@hashgraph/asset-tokenization-sdk';
-import { useMemo } from 'react';
-import { MaturityDateItem } from './MadurityDateItem';
-import { DATE_TIME_FORMAT } from '../../../utils/constants';
-import { useGetCompliance } from '../../../hooks/queries/useCompliance';
-import { useGetIdentityRegistry } from '../../../hooks/queries/useIdentityRegistry';
-import { ComplianceItem } from './ComplianceItem';
-import { IdentityRegistryItem } from './IdentityRegistryItem';
+} from "@hashgraph/asset-tokenization-sdk";
+import { useMemo } from "react";
+import { MaturityDateItem } from "./MadurityDateItem";
+import { DATE_TIME_FORMAT } from "../../../utils/constants";
+import { useGetCompliance } from "../../../hooks/queries/useCompliance";
+import { useGetIdentityRegistry } from "../../../hooks/queries/useIdentityRegistry";
+import { ComplianceItem } from "./ComplianceItem";
+import { IdentityRegistryItem } from "./IdentityRegistryItem";
 
-interface SecurityDetailsExtendedProps
-  extends Omit<DefinitionListProps, 'items'> {
+interface SecurityDetailsExtendedProps extends Omit<DefinitionListProps, "items"> {
   bondDetailsResponse?: BondDetailsViewModel;
   equityDetailsResponse?: EquityDetailsViewModel;
   isLoadingSecurityDetails: boolean;
@@ -247,7 +34,7 @@ export const SecurityDetailsExtended = ({
   isFetchingSecurityDetails,
   ...props
 }: SecurityDetailsExtendedProps) => {
-  const { t: tProperties } = useTranslation('properties');
+  const { t: tProperties } = useTranslation("properties");
   const { details } = useSecurityStore();
   const { id } = useParams();
 
@@ -272,112 +59,103 @@ export const SecurityDetailsExtended = ({
   const nominalValue = useMemo(() => {
     return toNumber(
       equityDetailsResponse?.nominalValue || bondDetailsResponse?.nominalValue,
-      2,
+      equityDetailsResponse?.nominalValueDecimals || bondDetailsResponse?.nominalValueDecimals || 2,
     );
+  }, [equityDetailsResponse, bondDetailsResponse]);
+
+  const nominalValueDecimals = useMemo(() => {
+    return equityDetailsResponse?.nominalValueDecimals || bondDetailsResponse?.nominalValueDecimals || 2;
   }, [equityDetailsResponse, bondDetailsResponse]);
 
   const listItems = useMemo(() => {
     const items = [
       {
-        title: tProperties('name'),
-        description: details?.name ?? '',
+        title: tProperties("name"),
+        description: details?.name ?? "",
       },
       {
-        title: tProperties('symbol'),
-        description: details?.symbol ?? '',
+        title: tProperties("symbol"),
+        description: details?.symbol ?? "",
       },
       {
-        title: tProperties('decimal'),
-        description: details?.decimals ?? '',
+        title: tProperties("decimal"),
+        description: details?.decimals ?? "",
       },
       {
-        title: tProperties('isin'),
-        description: details?.isin ?? '',
+        title: tProperties("isin"),
+        description: details?.isin ?? "",
       },
       {
-        title: tProperties('evmAddress'),
-        description: details?.evmDiamondAddress ?? '',
+        title: tProperties("evmAddress"),
+        description: details?.evmDiamondAddress ?? "",
         canCopy: true,
       },
       {
-        title: tProperties('id'),
+        title: tProperties("id"),
         description: (
           <Flex w="full" align="center">
             <Text textStyle="ElementsRegularSM">{id}</Text>
             <ClipboardButton value={id!} />
             <Text textStyle="ElementsSemiboldXS" ml={4}>
-              {tProperties('copyId')}
+              {tProperties("copyId")}
             </Text>
           </Flex>
         ),
       },
       {
-        title: tProperties('currency'),
-        description: 'USD',
+        title: tProperties("currency"),
+        description: "USD",
       }, // TODO: - format from ASCII when more currencies are available
       {
-        title: tProperties('nominalValue'),
-        description: formatNumberLocale(nominalValue, 2),
+        title: tProperties("nominalValue"),
+        description: formatNumberLocale(nominalValue, nominalValueDecimals),
       },
       {
-        title: tProperties('maxSupply'),
+        title: tProperties("maxSupply"),
         description: `${details?.maxSupply} ${details?.symbol}`,
       },
       {
-        title: tProperties('totalSupply'),
+        title: tProperties("totalSupply"),
         description: `${details?.totalSupply} ${details?.symbol}`,
       },
       {
-        title: tProperties('pendingToBeMinted'),
-        description: `${
-          toNumber(details?.maxSupply) - toNumber(details?.totalSupply)
-        } ${details?.symbol}`,
+        title: tProperties("pendingToBeMinted"),
+        description: `${toNumber(details?.maxSupply) - toNumber(details?.totalSupply)} ${details?.symbol}`,
       },
     ];
 
     if (compliance !== undefined && id) {
       items.push({
-        title: tProperties('compliance'),
+        title: tProperties("compliance"),
         description: <ComplianceItem securityId={id} />,
       });
     }
 
     if (identityRegistry !== undefined && id) {
       items.push({
-        title: tProperties('identityRegistry'),
+        title: tProperties("identityRegistry"),
         description: <IdentityRegistryItem securityId={id} />,
       });
     }
 
-    const isBond = details?.type === 'BOND';
+    const isBond = details?.type === "BOND";
 
     if (isBond && bondDetailsResponse?.startingDate) {
       items.push({
-        title: tProperties('startingDate'),
-        description: formatDate(
-          bondDetailsResponse.startingDate,
-          DATE_TIME_FORMAT,
-        ),
+        title: tProperties("startingDate"),
+        description: formatDate(bondDetailsResponse.startingDate, DATE_TIME_FORMAT),
       });
     }
 
     if (isBond && bondDetailsResponse?.maturityDate && id) {
       items.push({
-        title: tProperties('maturityDate'),
+        title: tProperties("maturityDate"),
         description: <MaturityDateItem securityId={id} />,
       });
     }
 
     return items;
-  }, [
-    details,
-    id,
-    nominalValue,
-    tProperties,
-    bondDetailsResponse,
-    compliance,
-    identityRegistry,
-  ]);
+  }, [details, id, nominalValue, tProperties, bondDetailsResponse, compliance, identityRegistry]);
 
   return (
     <DefinitionList


### PR DESCRIPTION
Signed-off-by: Luigi Navarro <luigi@io.builders>

## Description

Decimals for nominal value were fixed to 2, now you can add decimals until 18 decimals for bonds and equities.

## Type of change

- [X] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Run npm run test → All tests pass.
Open the web UI 
  → Create a new bond with different number of decimals for nominal value.
  → Select the created bond to see details and check that the number of decimals are the same used in the creation.
  → Create a new equity with different number of decimals for nominal value.
  → Select the created equity to see details and check that the number of decimals are the same used in the creation.


**Node version**:

- [ ] 20
- [X] 22
- [ ] 24

## Checklist

- [X ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
