### PR TITLE
feat: add getDividendAmountFor info in see dividend view

### DIFF
--- a/.changeset/social-cougars-wash.md
+++ b/.changeset/social-cougars-wash.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-dapp": minor
+---
+
+Add getDividendAmountFor info (numerator, denominator, recordDateReached) in see dividend view

--- a/apps/ats/web/src/hooks/queries/useDividends.ts
+++ b/apps/ats/web/src/hooks/queries/useDividends.ts
@@ -1,212 +1,9 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+//SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import { UseQueryOptions, useMutation, useQuery } from '@tanstack/react-query';
-import { SDKService } from '../../services/SDKService';
-import { useToast } from 'io-bricks-ui';
-import { useTranslation } from 'react-i18next';
+import { UseQueryOptions, useMutation, useQuery } from "@tanstack/react-query";
+import { SDKService } from "../../services/SDKService";
+import { useToast } from "io-bricks-ui";
+import { useTranslation } from "react-i18next";
 import {
   DividendsForViewModel,
   DividendsViewModel,
@@ -215,62 +12,53 @@ import {
   GetDividendsRequest,
   GetTotalDividendHoldersRequest,
   SetDividendsRequest,
-} from '@hashgraph/asset-tokenization-sdk';
+  DividendAmountForViewModel,
+} from "@hashgraph/asset-tokenization-sdk";
 
-export const GET_SECURITY_DIVIDENDS_FOR = (
-  securityId: string,
-  dividendId: number,
-  targetId: string,
-) => `GET_SECURITY_DIVIDENDS_${securityId}_${dividendId}_${targetId}`;
+export const GET_SECURITY_DIVIDENDS_FOR = (securityId: string, dividendId: number, targetId: string) =>
+  `GET_SECURITY_DIVIDENDS_${securityId}_${dividendId}_${targetId}`;
 
-export const GET_SECURITY_DIVIDENDS = (
-  securityId: string,
-  dividendId: number,
-) => `GET_SECURITY_DIVIDENDS_${securityId}_${dividendId}`;
+export const GET_SECURITY_DIVIDENDS = (securityId: string, dividendId: number) =>
+  `GET_SECURITY_DIVIDENDS_${securityId}_${dividendId}`;
 
-export const GET_SECURITY_DIVIDENDS_HOLDERS = (
-  securityId: string,
-  dividendId: number,
-) => `GET_SECURITY_DIVIDENDS_HOLDERS_${securityId}_${dividendId}`;
+export const GET_SECURITY_DIVIDENDS_HOLDERS = (securityId: string, dividendId: number) =>
+  `GET_SECURITY_DIVIDENDS_HOLDERS_${securityId}_${dividendId}`;
 
-export const GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS = (
-  securityId: string,
-  dividendId: number,
-) => `GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS_${securityId}_${dividendId}`;
+export const GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS = (securityId: string, dividendId: number) =>
+  `GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS_${securityId}_${dividendId}`;
+
+export const GET_SECURITY_DIVIDENDS_AMOUNT_FOR = (securityId: string, dividendId: number, targetId: string) =>
+  `GET_SECURITY_DIVIDENDS_AMOUNT_FOR_${securityId}_${dividendId}_${targetId}`;
 
 export const useDividends = () => {
   const toast = useToast();
-  const { t } = useTranslation('security', { keyPrefix: 'details.dividends' });
+  const { t } = useTranslation("security", { keyPrefix: "details.dividends" });
 
-  return useMutation(
-    (setDividendsRequest: SetDividendsRequest) =>
-      SDKService.setDividends(setDividendsRequest),
-    {
-      onSuccess: (data) => {
-        console.log('SDK message --> Dividend creation success: ', data);
+  return useMutation((setDividendsRequest: SetDividendsRequest) => SDKService.setDividends(setDividendsRequest), {
+    onSuccess: (data) => {
+      console.log("SDK message --> Dividend creation success: ", data);
 
-        if (!data) return;
+      if (!data) return;
 
-        toast.show({
-          duration: 3000,
-          title: t('messages.succes'),
-          description: t('messages.creationSuccessful'),
-          variant: 'subtle',
-          status: 'success',
-        });
-      },
-      onError: (error) => {
-        console.log('SDK message --> Dividend creation error: ', error);
-        toast.show({
-          duration: 3000,
-          title: t('messages.error'),
-          description: t('messages.creationFailed'),
-          variant: 'subtle',
-          status: 'error',
-        });
-      },
+      toast.show({
+        duration: 3000,
+        title: t("messages.succes"),
+        description: t("messages.creationSuccessful"),
+        variant: "subtle",
+        status: "success",
+      });
     },
-  );
+    onError: (error) => {
+      console.log("SDK message --> Dividend creation error: ", error);
+      toast.show({
+        duration: 3000,
+        title: t("messages.error"),
+        description: t("messages.creationFailed"),
+        variant: "subtle",
+        status: "error",
+      });
+    },
+  });
 };
 
 export const useGetDividendsFor = <TError, TData = DividendsForViewModel>(
@@ -278,13 +66,7 @@ export const useGetDividendsFor = <TError, TData = DividendsForViewModel>(
   options: UseQueryOptions<DividendsForViewModel, TError, TData, [string]>,
 ) => {
   return useQuery(
-    [
-      GET_SECURITY_DIVIDENDS_FOR(
-        params.securityId,
-        params.dividendId,
-        params.targetId,
-      ),
-    ],
+    [GET_SECURITY_DIVIDENDS_FOR(params.securityId, params.dividendId, params.targetId)],
     () => SDKService.getDividendsFor(params),
     options,
   );
@@ -317,13 +99,19 @@ export const useGetDividendHoldersTotal = <TError, TData = number>(
   options: UseQueryOptions<number, TError, TData, [string]>,
 ) => {
   return useQuery(
-    [
-      GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS(
-        params.securityId,
-        params.dividendId,
-      ),
-    ],
+    [GET_SECURITY_DIVIDENDS_TOTAL_HOLDERS(params.securityId, params.dividendId)],
     () => SDKService.getTotalDividendHolders(params),
+    options,
+  );
+};
+
+export const useGetDividendsAmountFor = <TError, TData = DividendAmountForViewModel>(
+  params: GetDividendsForRequest,
+  options: UseQueryOptions<DividendAmountForViewModel, TError, TData, [string]>,
+) => {
+  return useQuery(
+    [GET_SECURITY_DIVIDENDS_AMOUNT_FOR(params.securityId, params.dividendId, params.targetId)],
+    () => SDKService.getDividendAmountFor(params),
     options,
   );
 };

--- a/apps/ats/web/src/i18n/en/security/dividends.ts
+++ b/apps/ats/web/src/i18n/en/security/dividends.ts
@@ -1,286 +1,84 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
+//SPDX-License-Identifier: Apache-2.0
 
 export default {
   tabs: {
-    program: 'Program dividend',
-    see: 'See dividend',
-    holders: 'Holders',
-    list: 'List',
+    program: "Program dividend",
+    see: "See dividend",
+    holders: "Holders",
+    list: "List",
   },
   list: {
     columns: {
-      id: 'ID',
-      recordDate: 'Record Date',
-      executionDate: 'Execution Date',
-      dividendAmount: 'Dividend Amount',
-      snapshotId: 'Snapshot',
+      id: "ID",
+      recordDate: "Record Date",
+      executionDate: "Execution Date",
+      dividendAmount: "Dividend Amount",
+      snapshotId: "Snapshot",
     },
-    emptyTable: 'No dividends found',
+    emptyTable: "No dividends found",
   },
   program: {
     input: {
       recordDate: {
-        label: 'Record date',
-        placeholder: 'Select record date',
-        tooltip:
-          'Dividend’s record date.  A snapshot of Equity holder’s balances will be triggered on this date.',
+        label: "Record date",
+        placeholder: "Select record date",
+        tooltip: "Dividend’s record date.  A snapshot of Equity holder’s balances will be triggered on this date.",
       },
       paymentDate: {
-        label: 'Payment date',
-        placeholder: 'Select payment date',
-        tooltip: 'Dividend’s execution date, must occur after the record date.',
+        label: "Payment date",
+        placeholder: "Select payment date",
+        tooltip: "Dividend’s execution date, must occur after the record date.",
       },
       amount: {
-        label: 'Dividend amount',
-        placeholder: '000 $',
-        tooltip: 'Amount per equity that will be paid to equity holder’s.',
+        label: "Dividend amount",
+        placeholder: "000 $",
+        tooltip: "Amount per equity that will be paid to equity holder’s.",
       },
     },
   },
   see: {
     input: {
       dividend: {
-        label: 'Dividend ID',
-        placeholder: 'Add ID',
-        tooltip: 'ID of the dividend to display.',
+        label: "Dividend ID",
+        placeholder: "Add ID",
+        tooltip: "ID of the dividend to display.",
       },
       account: {
-        label: 'Account ID',
-        placeholder: 'Add ID',
-        tooltip: 'ID of the account to display the dividend for.',
+        label: "Account ID",
+        placeholder: "Add ID",
+        tooltip: "ID of the account to display the dividend for.",
       },
     },
     error: {
-      general:
-        'Sorry, there was an error. Please check data and try again, please',
+      general: "Sorry, there was an error. Please check data and try again, please",
     },
     details: {
-      title: 'Detail',
-      paymentDay: 'Payment day',
-      amount: 'Amount',
+      title: "Detail",
+      paymentDay: "Payment day",
+      amount: "Amount",
+      numerator: "Numerator",
+      denominator: "Denominator",
+      recordDateReached: "Record date reached",
     },
   },
   holders: {
-    title: 'Holders',
+    title: "Holders",
     dividendIdInput: {
-      label: 'Dividend ID',
-      placeholder: '1',
-      tooltip: 'ID of the dividend to display.',
+      label: "Dividend ID",
+      placeholder: "1",
+      tooltip: "ID of the dividend to display.",
     },
-    searchButton: 'Search',
-    emptyTable: 'No data',
+    searchButton: "Search",
+    emptyTable: "No data",
     table: {
-      dividendId: 'Dividend ID',
-      holderAddress: 'Holder address',
+      dividendId: "Dividend ID",
+      holderAddress: "Holder address",
     },
   },
   messages: {
-    succes: 'Success: ',
-    creationSuccessful: 'Dividend creation was successful',
-    error: 'Error: ',
-    creationFailed: 'Dividend creation failed',
+    succes: "Success: ",
+    creationSuccessful: "Dividend creation was successful",
+    error: "Error: ",
+    creationFailed: "Dividend creation failed",
   },
 };

--- a/apps/ats/web/src/views/DigitalSecurityDetails/Components/Dividends/SeeDividend.tsx
+++ b/apps/ats/web/src/views/DigitalSecurityDetails/Components/Dividends/SeeDividend.tsx
@@ -1,209 +1,6 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+//SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import { Button, Center, HStack, Stack, VStack } from '@chakra-ui/react';
+import { Button, Center, HStack, Stack, VStack } from "@chakra-ui/react";
 import {
   InputController,
   InputNumberController,
@@ -212,23 +9,17 @@ import {
   PhosphorIcon,
   Text,
   Tooltip,
-} from 'io-bricks-ui';
-import { Info } from '@phosphor-icons/react';
-import { isValidHederaId, min, required } from '../../../../utils/rules';
-import { useForm } from 'react-hook-form';
-import { useTranslation } from 'react-i18next';
-import {
-  useGetDividends,
-  useGetDividendsFor,
-} from '../../../../hooks/queries/useDividends';
-import {
-  GetDividendsForRequest,
-  GetDividendsRequest,
-} from '@hashgraph/asset-tokenization-sdk';
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { formatDate, formatNumberLocale } from '../../../../utils/format';
-import { DATE_TIME_FORMAT } from '../../../../utils/constants';
+} from "io-bricks-ui";
+import { Info } from "@phosphor-icons/react";
+import { isValidHederaId, min, required } from "../../../../utils/rules";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useGetDividends, useGetDividendsFor, useGetDividendsAmountFor } from "../../../../hooks/queries/useDividends";
+import { GetDividendsForRequest, GetDividendsRequest } from "@hashgraph/asset-tokenization-sdk";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { formatDate, formatNumberLocale } from "../../../../utils/format";
+import { DATE_TIME_FORMAT } from "../../../../utils/constants";
 
 interface SeeDividendFormValues {
   dividendId: number;
@@ -236,14 +27,20 @@ interface SeeDividendFormValues {
 }
 
 const defaultDividendsForRequest = new GetDividendsForRequest({
-  securityId: '',
+  securityId: "",
   dividendId: 0,
-  targetId: '',
+  targetId: "",
 });
 
 const defaultDividendsRequest = new GetDividendsRequest({
-  securityId: '',
+  securityId: "",
   dividendId: 0,
+});
+
+const defaultDividendsAmountForRequest = new GetDividendsForRequest({
+  securityId: "",
+  dividendId: 0,
+  targetId: "",
 });
 
 export const SeeDividend = () => {
@@ -252,57 +49,73 @@ export const SeeDividend = () => {
     handleSubmit,
     formState: { isValid },
   } = useForm<SeeDividendFormValues>({
-    mode: 'all',
+    mode: "all",
   });
-  const { t: tForm } = useTranslation('security', {
-    keyPrefix: 'details.dividends.see.input',
+  const { t: tForm } = useTranslation("security", {
+    keyPrefix: "details.dividends.see.input",
   });
-  const { t: tDetail } = useTranslation('security', {
-    keyPrefix: 'details.dividends.see.details',
+  const { t: tDetail } = useTranslation("security", {
+    keyPrefix: "details.dividends.see.details",
   });
-  const { t: tGlobal } = useTranslation('globals');
-  const { id: securityId = '' } = useParams();
-  const [dividendsRequest, setDividendsRequest] =
-    useState<GetDividendsRequest>();
-  const [dividendsForRequest, setDividendsForRequest] =
-    useState<GetDividendsForRequest>();
-  const [isDividendsForLoading, setIsDivididendForLoading] =
-    useState<boolean>(false);
+  const { t: tGlobal } = useTranslation("globals");
+  const { id: securityId = "" } = useParams();
+  const [dividendsRequest, setDividendsRequest] = useState<GetDividendsRequest>();
+  const [dividendsForRequest, setDividendsForRequest] = useState<GetDividendsForRequest>();
+  const [dividendsAmountForRequest, setDividendsAmountForRequest] = useState<GetDividendsForRequest>();
+  const [isDividendsForLoading, setIsDivididendForLoading] = useState<boolean>(false);
   const [isDividendsLoading, setIsDivididendLoading] = useState<boolean>(false);
+  const [isDividendsAmountForLoading, setIsDivididendAmountForLoading] = useState<boolean>(false);
   const toast = useToast();
-  const { t: tError } = useTranslation('security', {
-    keyPrefix: 'details.dividends.see.error',
+  const { t: tError } = useTranslation("security", {
+    keyPrefix: "details.dividends.see.error",
   });
 
-  const { data: dividendsFor, refetch: refetchDividendsFor } =
-    useGetDividendsFor(dividendsForRequest ?? defaultDividendsForRequest, {
-      enabled: false,
-      onSuccess: () => {
-        setIsDivididendForLoading(false);
-      },
-      onError: () => {
-        setIsDivididendForLoading(false);
-        toast.show({
-          duration: 3000,
-          title: tError('general'),
-          status: 'error',
-        });
-      },
-    });
-
-  const { data: dividends, refetch: refetchDividends } = useGetDividends(
-    dividendsRequest ?? defaultDividendsRequest,
+  const { data: dividendsFor, refetch: refetchDividendsFor } = useGetDividendsFor(
+    dividendsForRequest ?? defaultDividendsForRequest,
     {
       enabled: false,
       onSuccess: () => {
-        setIsDivididendLoading(false);
+        setIsDivididendForLoading(false);
       },
       onError: () => {
-        setIsDivididendLoading(false);
+        setIsDivididendForLoading(false);
         toast.show({
           duration: 3000,
-          title: tError('general'),
-          status: 'error',
+          title: tError("general"),
+          status: "error",
+        });
+      },
+    },
+  );
+
+  const { data: dividends, refetch: refetchDividends } = useGetDividends(dividendsRequest ?? defaultDividendsRequest, {
+    enabled: false,
+    onSuccess: () => {
+      setIsDivididendLoading(false);
+    },
+    onError: () => {
+      setIsDivididendLoading(false);
+      toast.show({
+        duration: 3000,
+        title: tError("general"),
+        status: "error",
+      });
+    },
+  });
+
+  const { data: dividendsAmountFor, refetch: refetchDividendsAmountFor } = useGetDividendsAmountFor(
+    dividendsAmountForRequest ?? defaultDividendsAmountForRequest,
+    {
+      enabled: false,
+      onSuccess: () => {
+        setIsDivididendAmountForLoading(false);
+      },
+      onError: () => {
+        setIsDivididendForLoading(false);
+        toast.show({
+          duration: 3000,
+          title: tError("general"),
+          status: "error",
         });
       },
     },
@@ -323,9 +136,17 @@ export const SeeDividend = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dividendsRequest]);
 
+  useEffect(() => {
+    if (dividendsAmountForRequest) {
+      refetchDividendsAmountFor();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dividendsAmountForRequest]);
+
   const submitForm = ({ dividendId, targetId }: SeeDividendFormValues) => {
     setIsDivididendForLoading(true);
     setIsDivididendLoading(true);
+    setIsDivididendAmountForLoading(true);
 
     const dividendsForReq = new GetDividendsForRequest({
       dividendId,
@@ -339,41 +160,33 @@ export const SeeDividend = () => {
       dividendId,
     });
     setDividendsRequest(dividendsReq);
+
+    const dividendsAmountForReq = new GetDividendsForRequest({
+      dividendId,
+      targetId,
+      securityId,
+    });
+    setDividendsAmountForRequest(dividendsAmountForReq);
   };
 
-  let dividendsPaymentDay = '';
-  let dividendsAmount = '0';
+  let dividendsPaymentDay = "";
+  let dividendsAmount = "0";
 
   if (dividends && dividendsFor) {
     dividendsPaymentDay = dividends.executionDate.toDateString();
-    const amount = (
-      parseFloat(dividends.amountPerUnitOfSecurity) *
-      parseFloat(dividendsFor.tokenBalance)
-    ).toString();
+    const amount = (parseFloat(dividends.amountPerUnitOfSecurity) * parseFloat(dividendsFor.tokenBalance)).toString();
 
-    dividendsAmount = `${formatNumberLocale(
-      amount,
-      parseFloat(dividendsFor.decimals),
-    )} $`;
+    dividendsAmount = `${formatNumberLocale(amount, parseFloat(dividendsFor.decimals))} $`;
   }
 
   return (
     <Center h="full" bg="neutral.dark.600">
       <VStack>
-        <VStack
-          as="form"
-          w="500px"
-          gap={6}
-          py={6}
-          data-testid="dividends-form"
-          onSubmit={handleSubmit(submitForm)}
-        >
+        <VStack as="form" w="500px" gap={6} py={6} data-testid="dividends-form" onSubmit={handleSubmit(submitForm)}>
           <Stack w="full">
             <HStack justifySelf="flex-start">
-              <Text textStyle="BodyTextRegularSM">
-                {tForm('dividend.label')}*
-              </Text>
-              <Tooltip label={tForm('dividend.tooltip')} placement="right">
+              <Text textStyle="BodyTextRegularSM">{tForm("dividend.label")}*</Text>
+              <Tooltip label={tForm("dividend.tooltip")} placement="right">
                 <PhosphorIcon as={Info} />
               </Tooltip>
             </HStack>
@@ -382,15 +195,13 @@ export const SeeDividend = () => {
               control={control}
               id="dividendId"
               rules={{ required, min: min(0) }}
-              placeholder={tForm('dividend.placeholder')}
+              placeholder={tForm("dividend.placeholder")}
             />
           </Stack>
           <Stack w="full">
             <HStack justifySelf="flex-start">
-              <Text textStyle="BodyTextRegularSM">
-                {tForm('account.label')}*
-              </Text>
-              <Tooltip label={tForm('account.tooltip')} placement="right">
+              <Text textStyle="BodyTextRegularSM">{tForm("account.label")}*</Text>
+              <Tooltip label={tForm("account.tooltip")} placement="right">
                 <PhosphorIcon as={Info} />
               </Tooltip>
             </HStack>
@@ -398,36 +209,54 @@ export const SeeDividend = () => {
               control={control}
               id="targetId"
               rules={{ required, isValidHederaId: isValidHederaId }}
-              placeholder={tForm('account.placeholder')}
+              placeholder={tForm("account.placeholder")}
             />
           </Stack>
           <Button
             alignSelf="flex-end"
             data-tesdtid="send-button"
             isDisabled={!isValid}
-            isLoading={isDividendsForLoading || isDividendsLoading}
+            isLoading={isDividendsForLoading || isDividendsLoading || isDividendsAmountForLoading}
             type="submit"
           >
-            {tGlobal('check')}
+            {tGlobal("check")}
           </Button>
         </VStack>
-        {dividends && dividendsFor && (
+        {dividends && dividendsFor && dividendsAmountFor && (
           <DefinitionList
             items={[
               {
-                title: tDetail('paymentDay'),
+                title: tDetail("paymentDay"),
                 description: formatDate(dividendsPaymentDay, DATE_TIME_FORMAT),
                 canCopy: true,
                 valueToCopy: dividendsPaymentDay,
               },
               {
-                title: tDetail('amount'),
+                title: tDetail("amount"),
                 description: dividendsAmount,
                 canCopy: true,
                 valueToCopy: dividendsAmount,
               },
+              {
+                title: tDetail("numerator"),
+                description: dividendsAmountFor?.numerator,
+                canCopy: true,
+                valueToCopy: dividendsAmountFor?.numerator,
+              },
+              {
+                title: tDetail("denominator"),
+                description: dividendsAmountFor?.denominator,
+                canCopy: true,
+                valueToCopy: dividendsAmountFor?.denominator,
+              },
+              {
+                title: tDetail("recordDateReached"),
+                description: dividendsAmountFor?.recordDateReached ? "Yes" : "No",
+                canCopy: true,
+                valueToCopy: dividendsAmountFor?.recordDateReached ? "Yes" : "No",
+              },
             ]}
-            title={tDetail('title')}
+            title={tDetail("title")}
           />
         )}
       </VStack>

--- a/apps/ats/web/src/views/DigitalSecurityDetails/Components/Dividends/__tests__/SeeDividend.test.tsx
+++ b/apps/ats/web/src/views/DigitalSecurityDetails/Components/Dividends/__tests__/SeeDividend.test.tsx
@@ -1,216 +1,344 @@
-/*
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+// SPDX-License-Identifier: Apache-2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+import { SeeDividend } from "../SeeDividend";
+import { render } from "../../../../../test-utils";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  useGetDividends,
+  useGetDividendsFor,
+  useGetDividendsAmountFor,
+} from "../../../../../hooks/queries/useDividends";
 
-   1. Definitions.
+jest.mock("../../../../../hooks/queries/useDividends");
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => ({ id: "0.0.12345" }),
+}));
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+const mockUseGetDividendsFor = useGetDividendsFor as jest.Mock;
+const mockUseGetDividends = useGetDividends as jest.Mock;
+const mockUseGetDividendsAmountFor = useGetDividendsAmountFor as jest.Mock;
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+const mockRefetchDividendsFor = jest.fn();
+const mockRefetchDividends = jest.fn();
+const mockRefetchDividendsAmountFor = jest.fn();
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+const defaultHookResponse = {
+  data: undefined,
+  refetch: jest.fn(),
+  isLoading: false,
+  isError: false,
+};
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+const mockDividendsForData = {
+  tokenBalance: "100",
+  decimals: "2",
+};
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+const mockDividendsData = {
+  executionDate: new Date("2024-06-15T10:00:00Z"),
+  amountPerUnitOfSecurity: "1.5",
+};
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+const mockDividendsAmountForData = {
+  numerator: "150",
+  denominator: "1000",
+  recordDateReached: true,
+};
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+const getFormInputsByName = () => {
+  const dividendInput = document.querySelector('input[name="dividendId"]') as HTMLInputElement;
+  const accountInput = document.querySelector('input[name="targetId"]') as HTMLInputElement;
+  return { dividendInput, accountInput };
+};
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-*/
-
-import { SeeDividend } from '../SeeDividend';
-import { render } from '../../../../../test-utils';
-
-// TODO Improve tests when it is connected to SDK
 describe(`${SeeDividend.name}`, () => {
-  test('should render correctly', () => {
-    const component = render(<SeeDividend />);
+  beforeEach(() => {
+    jest.clearAllMocks();
 
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      refetch: mockRefetchDividends,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      refetch: mockRefetchDividendsAmountFor,
+    });
+  });
+
+  test("should render correctly", () => {
+    const component = render(<SeeDividend />);
     expect(component.asFragment()).toMatchSnapshot();
+  });
+
+  test("should render form inputs", () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+    expect(dividendInput).toBeInTheDocument();
+    expect(accountInput).toBeInTheDocument();
+  });
+
+  test("should disable submit button when form is invalid", () => {
+    render(<SeeDividend />);
+
+    const submitButton = screen.getByRole("button");
+    expect(submitButton).toBeDisabled();
+  });
+
+  test("should enable submit button when form is valid", async () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+
+    fireEvent.change(dividendInput, { target: { value: "1" } });
+    fireEvent.change(accountInput, { target: { value: "0.0.12345" } });
+
+    await waitFor(() => {
+      const submitButton = screen.getByRole("button");
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  test("should call refetch functions on form submit", async () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+
+    fireEvent.change(dividendInput, { target: { value: "1" } });
+    fireEvent.change(accountInput, { target: { value: "0.0.12345" } });
+
+    await waitFor(() => {
+      const submitButton = screen.getByRole("button");
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    const submitButton = screen.getByRole("button");
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockRefetchDividendsFor).toHaveBeenCalled();
+      expect(mockRefetchDividends).toHaveBeenCalled();
+      expect(mockRefetchDividendsAmountFor).toHaveBeenCalled();
+    });
+  });
+
+  test("should display dividend details when all data is loaded", async () => {
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsForData,
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsData,
+      refetch: mockRefetchDividends,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsAmountForData,
+      refetch: mockRefetchDividendsAmountFor,
+    });
+
+    render(<SeeDividend />);
+
+    await waitFor(() => {
+      // Verify numerator from dividendsAmountFor
+      expect(screen.getByText("150")).toBeInTheDocument();
+
+      // Verify denominator from dividendsAmountFor
+      expect(screen.getByText("1000")).toBeInTheDocument();
+
+      // Verify recordDateReached from dividendsAmountFor (displays "Yes")
+      expect(screen.getByText("Yes")).toBeInTheDocument();
+    });
+  });
+
+  test("should display recordDateReached as No when it is false", async () => {
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsForData,
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsData,
+      refetch: mockRefetchDividends,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: {
+        numerator: "50",
+        denominator: "500",
+        recordDateReached: false,
+      },
+      refetch: mockRefetchDividendsAmountFor,
+    });
+
+    render(<SeeDividend />);
+
+    await waitFor(() => {
+      expect(screen.getByText("50")).toBeInTheDocument();
+      expect(screen.getByText("500")).toBeInTheDocument();
+      expect(screen.getByText("No")).toBeInTheDocument();
+    });
+  });
+
+  test("should not display details when data is not loaded", () => {
+    render(<SeeDividend />);
+
+    expect(screen.queryByText(/numerator/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/denominator/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/recordDateReached/i)).not.toBeInTheDocument();
+  });
+
+  test("should not display details when dividendsFor is missing", () => {
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsData,
+      refetch: mockRefetchDividends,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsAmountForData,
+      refetch: mockRefetchDividendsAmountFor,
+    });
+
+    render(<SeeDividend />);
+
+    // Details should not be visible without dividendsFor
+    expect(screen.queryByText("150")).not.toBeInTheDocument();
+  });
+
+  test("should not display details when dividends is missing", () => {
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsForData,
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsAmountForData,
+      refetch: mockRefetchDividendsAmountFor,
+    });
+
+    render(<SeeDividend />);
+
+    // Details should not be visible without dividends
+    expect(screen.queryByText("150")).not.toBeInTheDocument();
+  });
+
+  test("should not display details when dividendsAmountFor is missing", () => {
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsForData,
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsData,
+      refetch: mockRefetchDividends,
+    });
+
+    render(<SeeDividend />);
+
+    // Details should not be visible without dividendsAmountFor
+    expect(screen.queryByText("150")).not.toBeInTheDocument();
+  });
+
+  test("should validate dividendId with min value of 0", async () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+
+    fireEvent.change(dividendInput, { target: { value: "-1" } });
+    fireEvent.change(accountInput, { target: { value: "0.0.12345" } });
+
+    await waitFor(() => {
+      const submitButton = screen.getByRole("button");
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  test("should validate targetId as valid Hedera ID", async () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+
+    fireEvent.change(dividendInput, { target: { value: "1" } });
+    fireEvent.change(accountInput, { target: { value: "invalid-id" } });
+
+    await waitFor(() => {
+      const submitButton = screen.getByRole("button");
+      expect(submitButton).toBeDisabled();
+    });
+  });
+
+  test("should show loading state when fetching data", async () => {
+    render(<SeeDividend />);
+
+    const { dividendInput, accountInput } = getFormInputsByName();
+
+    fireEvent.change(dividendInput, { target: { value: "1" } });
+    fireEvent.change(accountInput, { target: { value: "0.0.12345" } });
+
+    await waitFor(() => {
+      const submitButton = screen.getByRole("button");
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    const submitButton = screen.getByRole("button");
+    fireEvent.click(submitButton);
+
+    // Button should show loading state after click
+    await waitFor(() => {
+      expect(submitButton).toHaveAttribute("data-loading");
+    });
+  });
+
+  test("should calculate and display correct dividend amount", async () => {
+    mockUseGetDividendsFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: {
+        tokenBalance: "100",
+        decimals: "2",
+      },
+      refetch: mockRefetchDividendsFor,
+    });
+
+    mockUseGetDividends.mockReturnValue({
+      ...defaultHookResponse,
+      data: {
+        executionDate: new Date("2024-06-15T10:00:00Z"),
+        amountPerUnitOfSecurity: "1.5",
+      },
+      refetch: mockRefetchDividends,
+    });
+
+    mockUseGetDividendsAmountFor.mockReturnValue({
+      ...defaultHookResponse,
+      data: mockDividendsAmountForData,
+      refetch: mockRefetchDividendsAmountFor,
+    });
+
+    render(<SeeDividend />);
+
+    await waitFor(() => {
+      // Amount = tokenBalance * amountPerUnitOfSecurity = 100 * 1.5 = 150
+      expect(screen.getByText(/150/)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Signed-off-by: Luigi Navarro <luigi@io.builders>

## Description

Add getDividendAmountFor info (numerator, denominator, recordDateReached) in see dividend view

## Type of change

- [ ] Bug fix 🐞
- [X] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Run npm run test → All tests pass.
 Open the web UI → Create a new Equityt -> Mint some tokens to an account -> Create a new Dividend -> See dividend → See the new info in dividend details  (numerator, denominator, recordDateReached) 

**Node version**:

- [ ] 20
- [X] 22
- [ ] 24

## Checklist

- [X] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X] Local Tests Pass ✅
- [X] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
