### PR TITLE
feat: security creation mock and loader

### DIFF
--- a/.changeset/green-walls-doubt.md
+++ b/.changeset/green-walls-doubt.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-dapp": patch
+---
+
+Add loading overlay in security's details page and a fill form button in create security page

--- a/apps/ats/web/src/components/ProgressOverlay.tsx
+++ b/apps/ats/web/src/components/ProgressOverlay.tsx
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import { Modal, ModalOverlay, ModalContent, ModalBody, VStack, HStack, Progress, Box } from "@chakra-ui/react";
+import { Text, PhosphorIcon, Weight } from "io-bricks-ui";
+import { CheckCircle, Circle, Spinner as SpinnerIcon, XCircle } from "@phosphor-icons/react";
+
+export type ProgressStepStatus = "pending" | "in-progress" | "completed" | "error";
+
+export interface ProgressStep {
+  id: string;
+  label: string;
+  status: ProgressStepStatus;
+  description?: string;
+}
+
+export interface ProgressOverlayProps {
+  isOpen: boolean;
+  title: string;
+  steps: ProgressStep[];
+  progress: number;
+  description?: string;
+}
+
+const STEP_ICONS: Record<ProgressStepStatus, React.ReactNode> = {
+  completed: <PhosphorIcon as={CheckCircle} weight={Weight.Fill} color="success.600" />,
+  "in-progress": <PhosphorIcon as={SpinnerIcon} weight={Weight.Bold} color="primary.600" />,
+  error: <PhosphorIcon as={XCircle} weight={Weight.Fill} color="danger.600" />,
+  pending: <PhosphorIcon as={Circle} weight={Weight.Regular} color="neutral.500" />,
+};
+
+const STEP_COLORS: Record<ProgressStepStatus, string> = {
+  completed: "neutral.900",
+  "in-progress": "primary.600",
+  error: "danger.600",
+  pending: "neutral.500",
+};
+
+const getStepIcon = (status: ProgressStepStatus) => STEP_ICONS[status];
+const getStepColor = (status: ProgressStepStatus) => STEP_COLORS[status];
+
+export const ProgressOverlay: React.FC<ProgressOverlayProps> = ({ isOpen, title, steps, progress, description }) => {
+  return (
+    <Modal isOpen={isOpen} onClose={() => {}} closeOnOverlayClick={false} closeOnEsc={false} isCentered size="lg">
+      <ModalOverlay bg="blackAlpha.700" backdropFilter="blur(8px)" />
+      <ModalContent bg="neutral.50" borderRadius="8px" boxShadow="xl">
+        <ModalBody p={8}>
+          <VStack spacing={6} align="stretch">
+            <VStack spacing={2} align="stretch">
+              <Text textStyle="HeadingBoldXL" color="neutral.900">
+                {title}
+              </Text>
+              {description && (
+                <Text textStyle="BodyTextRegularMD" color="neutral.700">
+                  {description}
+                </Text>
+              )}
+            </VStack>
+
+            <VStack spacing={2} align="stretch">
+              <Progress
+                value={progress}
+                size="md"
+                colorScheme="purple"
+                borderRadius="full"
+                bg="neutral.200"
+                hasStripe
+                isAnimated
+              />
+              <Text textStyle="ElementsRegularSM" color="neutral.600" textAlign="right">
+                {Math.round(progress)}%
+              </Text>
+            </VStack>
+
+            <VStack spacing={3} align="stretch">
+              {steps.map((step) => (
+                <HStack key={step.id} spacing={3} align="flex-start">
+                  <Box mt={0.5}>{getStepIcon(step.status)}</Box>
+                  <VStack spacing={0} align="flex-start" flex={1}>
+                    <Text textStyle="BodyTextMediumMD" color={getStepColor(step.status)}>
+                      {step.label}
+                    </Text>
+                    {step.description && step.status === "in-progress" && (
+                      <Text textStyle="ElementsRegularSM" color="neutral.600">
+                        {step.description}
+                      </Text>
+                    )}
+                  </VStack>
+                </HStack>
+              ))}
+            </VStack>
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/apps/ats/web/src/components/__tests__/ProgressOverlay.test.tsx
+++ b/apps/ats/web/src/components/__tests__/ProgressOverlay.test.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from "../../test-utils";
+import { ProgressOverlay, ProgressOverlayProps } from "../ProgressOverlay";
+
+const defaultProps: ProgressOverlayProps = {
+  isOpen: true,
+  title: "Loading Security Details",
+  description: "Please wait while we fetch all the information...",
+  progress: 42,
+  steps: [
+    { id: "details", label: "Loading Details", status: "completed" },
+    { id: "balance", label: "Loading Balance", status: "in-progress" },
+    { id: "operations", label: "Loading Operations", status: "pending" },
+    { id: "management", label: "Loading Management", status: "pending" },
+    { id: "control", label: "Loading Control", status: "pending" },
+  ],
+};
+
+describe(`${ProgressOverlay.name}`, () => {
+  const factoryComponent = () => render(<ProgressOverlay {...defaultProps} />);
+
+  test("should render correctly", () => {
+    const component = factoryComponent();
+
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+  test("should render title, description, progress and steps", () => {
+    const component = factoryComponent();
+    expect(component.getByText(defaultProps.title)).toBeInTheDocument();
+    expect(component.getByText(defaultProps.description!)).toBeInTheDocument();
+    expect(component.getByText("42%")).toBeInTheDocument();
+    expect(component.getByText("Loading Details")).toBeInTheDocument();
+    expect(component.getByText("Loading Balance")).toBeInTheDocument();
+    expect(component.getByText("Loading Operations")).toBeInTheDocument();
+    expect(component.getByText("Loading Management")).toBeInTheDocument();
+    expect(component.getByText("Loading Control")).toBeInTheDocument();
+  });
+});

--- a/apps/ats/web/src/components/__tests__/__snapshots__/ProgressOverlay.test.tsx.snap
+++ b/apps/ats/web/src/components/__tests__/__snapshots__/ProgressOverlay.test.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProgressOverlay should render correctly 1`] = `
+<DocumentFragment>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;

--- a/apps/ats/web/src/i18n/en/security/createBond.ts
+++ b/apps/ats/web/src/i18n/en/security/createBond.ts
@@ -156,4 +156,5 @@ export default {
   cancelButton: "Cancel",
   nextStepButton: "Next step",
   previousStepButton: "Previous step",
+  fillWithExample: "Fill with example data",
 };

--- a/apps/ats/web/src/i18n/en/security/details.ts
+++ b/apps/ats/web/src/i18n/en/security/details.ts
@@ -22,6 +22,15 @@ export default {
   header: {
     title: "Digital security details",
   },
+  progress: {
+    title: "Loading Security Details",
+    description: "Please wait while we fetch all the information...",
+    details: "Loading Details",
+    balance: "Loading Balance",
+    operations: "Loading Operations",
+    control: "Loading Control",
+    management: "Loading Management",
+  },
   tabs: {
     balance: "Balance",
     allowedList: "Allowed list",

--- a/apps/ats/web/src/i18n/en/security/equity/create.ts
+++ b/apps/ats/web/src/i18n/en/security/equity/create.ts
@@ -125,4 +125,5 @@ export default {
   cancelButton: "Cancel",
   nextStepButton: "Next step",
   previousStepButton: "Previous step",
+  fillWithExample: "Fill with example data",
 };

--- a/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
+++ b/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
@@ -131,12 +131,14 @@ export const StepReview = () => {
       ...(identityRegistryId && {
         identityRegistryId: identityRegistryId,
       }),
-      ...(proceedRecipientsIds && {
-        proceedRecipientsIds: proceedRecipientsIds,
-      }),
-      ...(proceedRecipientsData && {
-        proceedRecipientsData: proceedRecipientsData.map((data) => textToHex(data)),
-      }),
+      ...(proceedRecipientsIds &&
+        proceedRecipientsIds.length > 0 && {
+          proceedRecipientsIds: proceedRecipientsIds,
+        }),
+      ...(proceedRecipientsData &&
+        proceedRecipientsData.length > 0 && {
+          proceedRecipientsData: proceedRecipientsData.map((data) => textToHex(data)),
+        }),
     });
 
     createBond(request);
@@ -286,7 +288,6 @@ export const StepReview = () => {
           </HStack>
         </VStack>
       </Stack>
-
       <PopUp
         id="cancelBondCreation"
         isOpen={isOpenCancel}

--- a/apps/ats/web/src/views/CreateBond/Components/StepTokenDetails.tsx
+++ b/apps/ats/web/src/views/CreateBond/Components/StepTokenDetails.tsx
@@ -18,6 +18,8 @@ import { ICreateBondFormValues } from "../ICreateBondFormValues";
 import { CancelButton } from "../../../components/CancelButton";
 import { NextStepButton } from "./NextStepButton";
 import { FormStepContainer } from "../../../components/FormStepContainer";
+import { FillWithExampleButton } from "../../CreateSecurityCommons/FillWithExampleButton";
+import { getMockBondFormData } from "../utils/mockBondData";
 
 export const StepTokenDetails = () => {
   const { t } = useTranslation("security", { keyPrefix: "createBond" });
@@ -33,9 +35,10 @@ export const StepTokenDetails = () => {
       <Stack gap={2}>
         <Text textStyle="HeadingMediumLG">{t("stepTokenDetails.title")}</Text>
         <Text textStyle="BodyTextRegularMD">{t("stepTokenDetails.subtitle")}</Text>
-        <Text textStyle="ElementsRegularSM" mt={6}>
-          {t("stepTokenDetails.mandatoryFields")}
-        </Text>
+        <HStack w="full" justify="space-between" align="center" mb={4}>
+          <Text textStyle="ElementsRegularSM">{t("stepTokenDetails.mandatoryFields")}</Text>
+          <FillWithExampleButton getMockData={getMockBondFormData} translationKey="createBond.fillWithExample" />
+        </HStack>
       </Stack>
       <InfoDivider title={t("stepTokenDetails.generalInformation")} type="main" />
       <Stack w="full">

--- a/apps/ats/web/src/views/CreateBond/__tests__/__snapshots__/CreateBond.test.tsx.snap
+++ b/apps/ats/web/src/views/CreateBond/__tests__/__snapshots__/CreateBond.test.tsx.snap
@@ -330,11 +330,39 @@ exports[`CreateBond render correctly 1`] = `
               >
                 Enter the basics details of the digital security to start creating it.
               </p>
-              <p
-                class="css-ykptgm"
+              <div
+                class="chakra-stack css-2p6avo"
               >
-                *Mandatory fields
-              </p>
+                <p
+                  class="css-w4vgn5"
+                >
+                  *Mandatory fields
+                </p>
+                <button
+                  class="chakra-button css-1yo43a"
+                  type="button"
+                >
+                  <span
+                    class="chakra-button__icon css-1wh2kri"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="chakra-icon css-kpbtv0"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 256 256"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M248,152a8,8,0,0,1-8,8H224v16a8,8,0,0,1-16,0V160H192a8,8,0,0,1,0-16h16V128a8,8,0,0,1,16,0v16h16A8,8,0,0,1,248,152ZM56,72H72V88a8,8,0,0,0,16,0V72h16a8,8,0,0,0,0-16H88V40a8,8,0,0,0-16,0V56H56a8,8,0,0,0,0,16ZM184,192h-8v-8a8,8,0,0,0-16,0v8h-8a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM219.31,80,80,219.31a16,16,0,0,1-22.62,0L36.68,198.63a16,16,0,0,1,0-22.63L176,36.69a16,16,0,0,1,22.63,0l20.68,20.68A16,16,0,0,1,219.31,80ZM208,68.69,187.31,48l-32,32L176,100.69Z"
+                      />
+                    </svg>
+                  </span>
+                  Fill with example data
+                </button>
+              </div>
             </div>
             <div
               class="css-7xu97p"

--- a/apps/ats/web/src/views/CreateBond/utils/mockBondData.ts
+++ b/apps/ats/web/src/views/CreateBond/utils/mockBondData.ts
@@ -9,7 +9,7 @@ export const getMockBondFormData = (): Partial<ICreateBondFormValues> => {
   // Starting date: tomorrow (at least 1 day from today as required by CalendarInputController)
   const startingDate = addDays(today, 1);
   // Maturity date: 7 days after starting date
-  const maturityDate = addDays(startingDate, 7);
+  const maturityDate = addDays(startingDate, 61);
 
   const nominalValue = 1000;
   const numberOfUnits = 10000;
@@ -25,7 +25,7 @@ export const getMockBondFormData = (): Partial<ICreateBondFormValues> => {
     isBlocklist: true,
     isApproval: false,
     isClearing: false,
-    internalKycActivated: true,
+    internalKycActivated: false,
 
     // Step 2: Configuration
     currency: "USD",

--- a/apps/ats/web/src/views/CreateBond/utils/mockBondData.ts
+++ b/apps/ats/web/src/views/CreateBond/utils/mockBondData.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ICreateBondFormValues } from "../ICreateBondFormValues";
+import { addDays } from "date-fns";
+import { formatNumber } from "../../../utils/format";
+
+export const getMockBondFormData = (): Partial<ICreateBondFormValues> => {
+  const today = new Date();
+  // Starting date: tomorrow (at least 1 day from today as required by CalendarInputController)
+  const startingDate = addDays(today, 1);
+  // Maturity date: 7 days after starting date
+  const maturityDate = addDays(startingDate, 7);
+
+  const nominalValue = 1000;
+  const numberOfUnits = 10000;
+  const totalAmount = nominalValue * numberOfUnits;
+
+  return {
+    // Step 1: Details
+    name: "Demo Bond 2026",
+    symbol: "DCB2026",
+    decimals: 6,
+    isin: "US0378331005",
+    isControllable: true,
+    isBlocklist: true,
+    isApproval: false,
+    isClearing: false,
+    internalKycActivated: true,
+
+    // Step 2: Configuration
+    currency: "USD",
+    numberOfUnits: numberOfUnits.toString(),
+    nominalValue: nominalValue,
+    nominalValueDecimals: 2,
+    totalAmount: formatNumber(totalAmount, {}, 18),
+    startingDate: startingDate as any,
+    maturityDate: maturityDate as any,
+
+    // Step 3: Proceed Recipients
+    proceedRecipientsIds: [],
+    proceedRecipientsData: [],
+
+    // Step 4: ERC3643
+    complianceId: undefined,
+    identityRegistryId: undefined,
+
+    // Step 5: External Lists
+    externalPausesList: [],
+    externalControlList: [],
+    externalKYCList: [],
+
+    // Step 6: Regulation
+    regulationType: 1,
+    regulationSubType: 0,
+    countriesListType: 1,
+    countriesList: [],
+  };
+};

--- a/apps/ats/web/src/views/CreateEquity/Components/StepTokenDetails.tsx
+++ b/apps/ats/web/src/views/CreateEquity/Components/StepTokenDetails.tsx
@@ -18,6 +18,8 @@ import { ICreateEquityFormValues } from "../ICreateEquityFormValues";
 import { CancelButton } from "../../../components/CancelButton";
 import { NextStepButton } from "./NextStepButton";
 import { FormStepContainer } from "../../../components/FormStepContainer";
+import { FillWithExampleButton } from "../../CreateSecurityCommons/FillWithExampleButton";
+import { getMockEquityFormData } from "../utils/mockEquityData";
 
 export const StepTokenDetails = () => {
   const { t } = useTranslation("security", { keyPrefix: "createEquity" });
@@ -33,9 +35,10 @@ export const StepTokenDetails = () => {
       <Stack gap={2}>
         <Text textStyle="HeadingMediumLG">{t("stepTokenDetails.title")}</Text>
         <Text textStyle="BodyTextRegularMD">{t("stepTokenDetails.subtitle")}</Text>
-        <Text textStyle="ElementsRegularSM" mt={6}>
-          {t("stepTokenDetails.mandatoryFields")}
-        </Text>
+        <HStack w="full" justify="space-between" align="center" mb={4}>
+          <Text textStyle="ElementsRegularSM">{t("stepTokenDetails.mandatoryFields")}</Text>
+          <FillWithExampleButton getMockData={getMockEquityFormData} translationKey="createEquity.fillWithExample" />
+        </HStack>
       </Stack>
       <InfoDivider title={t("stepTokenDetails.generalInformation")} type="main" />
       <Stack w="full">

--- a/apps/ats/web/src/views/CreateEquity/__tests__/__snapshots__/CreateEquity.test.tsx.snap
+++ b/apps/ats/web/src/views/CreateEquity/__tests__/__snapshots__/CreateEquity.test.tsx.snap
@@ -296,11 +296,39 @@ exports[`CreateEquity render correctly 1`] = `
               >
                 Enter the basics details of the digital security to start creating it.
               </p>
-              <p
-                class="css-ykptgm"
+              <div
+                class="chakra-stack css-2p6avo"
               >
-                *Mandatory fields
-              </p>
+                <p
+                  class="css-w4vgn5"
+                >
+                  *Mandatory fields
+                </p>
+                <button
+                  class="chakra-button css-1yo43a"
+                  type="button"
+                >
+                  <span
+                    class="chakra-button__icon css-1wh2kri"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="chakra-icon css-kpbtv0"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="0 0 256 256"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M248,152a8,8,0,0,1-8,8H224v16a8,8,0,0,1-16,0V160H192a8,8,0,0,1,0-16h16V128a8,8,0,0,1,16,0v16h16A8,8,0,0,1,248,152ZM56,72H72V88a8,8,0,0,0,16,0V72h16a8,8,0,0,0,0-16H88V40a8,8,0,0,0-16,0V56H56a8,8,0,0,0,0,16ZM184,192h-8v-8a8,8,0,0,0-16,0v8h-8a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM219.31,80,80,219.31a16,16,0,0,1-22.62,0L36.68,198.63a16,16,0,0,1,0-22.63L176,36.69a16,16,0,0,1,22.63,0l20.68,20.68A16,16,0,0,1,219.31,80ZM208,68.69,187.31,48l-32,32L176,100.69Z"
+                      />
+                    </svg>
+                  </span>
+                  Fill with example data
+                </button>
+              </div>
             </div>
             <div
               class="css-7xu97p"

--- a/apps/ats/web/src/views/CreateEquity/utils/mockEquityData.ts
+++ b/apps/ats/web/src/views/CreateEquity/utils/mockEquityData.ts
@@ -18,7 +18,7 @@ export const getMockEquityFormData = (): Partial<ICreateEquityFormValues> => {
     isBlocklist: true,
     isApproval: false,
     isClearing: false,
-    internalKycActivated: true,
+    internalKycActivated: false,
 
     // Step 2: Specific details
     currency: "USD",

--- a/apps/ats/web/src/views/CreateEquity/utils/mockEquityData.ts
+++ b/apps/ats/web/src/views/CreateEquity/utils/mockEquityData.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ICreateEquityFormValues } from "../ICreateEquityFormValues";
+import { formatNumber } from "../../../utils/format";
+
+export const getMockEquityFormData = (): Partial<ICreateEquityFormValues> => {
+  const nominalValue = 10;
+  const numberOfShares = 1000000;
+  const totalAmount = nominalValue * numberOfShares;
+
+  return {
+    // Step 1: Create Equity
+    name: "Demo Equity 2026",
+    symbol: "DES2026",
+    decimals: 6,
+    isin: "US0378331005",
+    isControllable: true,
+    isBlocklist: true,
+    isApproval: false,
+    isClearing: false,
+    internalKycActivated: true,
+
+    // Step 2: Specific details
+    currency: "USD",
+    numberOfShares: numberOfShares.toString(),
+    nominalValue: nominalValue,
+    nominalValueDecimals: 2,
+    totalAmount: formatNumber(totalAmount, {}, 18),
+    isVotingRight: true,
+    isInformationRight: true,
+    isLiquidationRight: false,
+    isSubscriptionRight: false,
+    isConversionRight: false,
+    isRedemptionRight: false,
+    isPutRight: false,
+    dividendType: 2,
+
+    // Step 3: External Lists
+    externalPausesList: [],
+    externalControlList: [],
+    externalKYCList: [],
+
+    // Step 4: ERC3643
+    complianceId: undefined,
+    identityRegistryId: undefined,
+
+    // Step 5: Regulation
+    regulationType: 1,
+    regulationSubType: 0,
+    countriesListType: 1,
+    countriesList: [],
+  };
+};

--- a/apps/ats/web/src/views/CreateSecurityCommons/FillWithExampleButton.tsx
+++ b/apps/ats/web/src/views/CreateSecurityCommons/FillWithExampleButton.tsx
@@ -18,19 +18,13 @@ export const FillWithExampleButton = ({
   translationKey = "fillWithExample",
 }: FillWithExampleButtonProps) => {
   const { t } = useTranslation("security");
-  const { setValue, trigger } = useFormContext();
+  const { trigger, reset } = useFormContext();
 
   const handleFillWithExample = () => {
     const mockData = getMockData();
 
-    Object.entries(mockData).forEach(([key, value]) => {
-      setValue(key, value, {
-        shouldValidate: true,
-        shouldDirty: true,
-      });
-    });
-
-    trigger();
+    reset(mockData);
+    void trigger();
   };
 
   return (

--- a/apps/ats/web/src/views/CreateSecurityCommons/FillWithExampleButton.tsx
+++ b/apps/ats/web/src/views/CreateSecurityCommons/FillWithExampleButton.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { useFormContext } from "react-hook-form";
+import { MagicWand } from "@phosphor-icons/react";
+import { PhosphorIcon, Weight } from "io-bricks-ui";
+import { ICreateEquityFormValues } from "../CreateEquity/ICreateEquityFormValues";
+import { ICreateBondFormValues } from "../CreateBond/ICreateBondFormValues";
+
+interface FillWithExampleButtonProps {
+  getMockData: () => Partial<ICreateBondFormValues> | Partial<ICreateEquityFormValues>;
+  translationKey?: string;
+}
+
+export const FillWithExampleButton = ({
+  getMockData,
+  translationKey = "fillWithExample",
+}: FillWithExampleButtonProps) => {
+  const { t } = useTranslation("security");
+  const { setValue, trigger } = useFormContext();
+
+  const handleFillWithExample = () => {
+    const mockData = getMockData();
+
+    Object.entries(mockData).forEach(([key, value]) => {
+      setValue(key, value, {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+    });
+
+    trigger();
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="secondary"
+      leftIcon={<PhosphorIcon as={MagicWand} weight={Weight.Fill} />}
+      onClick={handleFillWithExample}
+    >
+      {t(translationKey)}
+    </Button>
+  );
+};

--- a/apps/ats/web/src/views/CreateSecurityCommons/__tests__/FillWithExampleButton.test.tsx
+++ b/apps/ats/web/src/views/CreateSecurityCommons/__tests__/FillWithExampleButton.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { render } from "../../../test-utils";
+import { useForm, FormProvider } from "react-hook-form";
+import { FillWithExampleButton } from "../FillWithExampleButton";
+import userEvent from "@testing-library/user-event";
+
+const TestForm = () => {
+  const methods = useForm<{ name: string }>({
+    defaultValues: { name: "" },
+    mode: "onChange",
+  });
+
+  const getMockData = () => ({
+    name: "Demo Name",
+  });
+
+  return (
+    <FormProvider {...methods}>
+      <form>
+        <input aria-label="Name" {...methods.register("name", { required: true })} />
+        <FillWithExampleButton getMockData={getMockData} translationKey="createBond.fillWithExample" />
+      </form>
+    </FormProvider>
+  );
+};
+
+describe(`${FillWithExampleButton.name}`, () => {
+  const factoryComponent = () => render(<TestForm />);
+
+  test("should render correctly", () => {
+    const component = factoryComponent();
+
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+
+  test("should fill form with example data and trigger validation", async () => {
+    const component = factoryComponent();
+
+    expect(component.getByLabelText("Name")).toHaveValue("");
+
+    await userEvent.click(component.getByText("Fill with example data"));
+
+    expect(component.getByLabelText("Name")).toHaveValue("Demo Name");
+  });
+});

--- a/apps/ats/web/src/views/CreateSecurityCommons/__tests__/__snapshots__/FillWithExampleButton.test.tsx.snap
+++ b/apps/ats/web/src/views/CreateSecurityCommons/__tests__/__snapshots__/FillWithExampleButton.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FillWithExampleButton should render correctly 1`] = `
+<DocumentFragment>
+  <form>
+    <input
+      aria-label="Name"
+      name="name"
+    />
+    <button
+      class="chakra-button css-1yo43a"
+      type="button"
+    >
+      <span
+        class="chakra-button__icon css-1wh2kri"
+      >
+        <svg
+          aria-hidden="true"
+          class="chakra-icon css-kpbtv0"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M248,152a8,8,0,0,1-8,8H224v16a8,8,0,0,1-16,0V160H192a8,8,0,0,1,0-16h16V128a8,8,0,0,1,16,0v16h16A8,8,0,0,1,248,152ZM56,72H72V88a8,8,0,0,0,16,0V72h16a8,8,0,0,0,0-16H88V40a8,8,0,0,0-16,0V56H56a8,8,0,0,0,0,16ZM184,192h-8v-8a8,8,0,0,0-16,0v8h-8a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0v-8h8a8,8,0,0,0,0-16ZM219.31,80,80,219.31a16,16,0,0,1-22.62,0L36.68,198.63a16,16,0,0,1,0-22.63L176,36.69a16,16,0,0,1,22.63,0l20.68,20.68A16,16,0,0,1,219.31,80ZM208,68.69,187.31,48l-32,32L176,100.69Z"
+          />
+        </svg>
+      </span>
+      Fill with example data
+    </button>
+  </form>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Description

Add “Fill with example data” button: Introduces a button to quickly populate bond/equity creation forms with realistic mock data, improving testing and demo workflows.

Improve security details loading UI: Adds a loading overlay for the Digital Security Details view so users get clear feedback while security data is being fetched and processed.

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [X] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
