### PR TITLE
feat: new feature in the ATS SDK: cancel scheduled balance adjustment

### DIFF
--- a/packages/ats/sdk/__tests__/fixtures/equity/EquityFixture.ts
+++ b/packages/ats/sdk/__tests__/fixtures/equity/EquityFixture.ts
@@ -44,6 +44,8 @@ import { VotingRights } from "@domain/context/equity/VotingRights";
 import { GetRegulationDetailsQuery } from "@query/factory/get/GetRegulationDetailsQuery";
 import { GetConfigInfoQuery } from "@query/management/GetConfigInfoQuery";
 import { SetScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/setScheduledBalanceAdjustment/SetScheduledBalanceAdjustmentCommand";
+import CancelScheduledBalanceAdjustmentRequest from "@port/in/request/equity/CancelScheduledBalanceAdjustmentRequest";
+import { CancelScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommand";
 import { CreateEquityCommand } from "@command/equity/create/CreateEquityCommand";
 import { SetDividendsCommand } from "@command/equity/dividends/set/SetDividendsCommand";
 import { CancelDividendCommand } from "@command/equity/dividends/cancel/CancelDividendCommand";
@@ -385,6 +387,20 @@ export const CancelDividendRequestFixture = createFixture<CancelDividendRequest>
   request.securityId.as(() => HederaIdPropsFixture.create().value);
   request.dividendId.faker((faker) => faker.number.int({ min: 1, max: 10 }));
 });
+
+export const CancelScheduledBalanceAdjustmentCommandFixture = createFixture<CancelScheduledBalanceAdjustmentCommand>(
+  (command) => {
+    command.securityId.as(() => HederaIdPropsFixture.create().value);
+    command.balanceAdjustmentId.faker((faker) => faker.number.int({ min: 1, max: 10 }));
+  },
+);
+
+export const CancelScheduledBalanceAdjustmentRequestFixture = createFixture<CancelScheduledBalanceAdjustmentRequest>(
+  (request) => {
+    request.securityId.as(() => HederaIdPropsFixture.create().value);
+    request.balanceAdjustmentId.faker((faker) => faker.number.int({ min: 1, max: 10 }));
+  },
+);
 
 export const SetDividendsCommandFixture = createFixture<SetDividendsCommand>((command) => {
   command.address.as(() => HederaIdPropsFixture.create().value);

--- a/packages/ats/sdk/__tests__/fixtures/equity/EquityFixture.ts
+++ b/packages/ats/sdk/__tests__/fixtures/equity/EquityFixture.ts
@@ -431,6 +431,7 @@ export const ScheduledBalanceAdjustmentFixture = createFixture<ScheduledBalanceA
   props.executionTimeStamp.faker((faker) => faker.date.future());
   props.factor.faker((faker) => faker.number.int({ min: 1, max: 999 }));
   props.decimals.faker((faker) => faker.number.int({ min: 1, max: 999 }));
+  props.isDisabled.faker((faker) => faker.datatype.boolean());
 });
 
 export const DividendFixture = createFixture<Dividend>((props) => {

--- a/packages/ats/sdk/__tests__/port/environmentMock.ts
+++ b/packages/ats/sdk/__tests__/port/environmentMock.ts
@@ -1686,6 +1686,19 @@ jest.mock("@port/out/rpc/RPCTransactionAdapter", () => {
     } as TransactionResponse;
   });
 
+  singletonInstance.cancelScheduledBalanceAdjustment = jest.fn(async function (
+    _security: EvmAddress,
+    balanceAdjustmentId: number,
+  ) {
+    if (balanceAdjustmentId > 0 && balanceAdjustmentId <= scheduledBalanceAdjustments.length) {
+      scheduledBalanceAdjustments.splice(balanceAdjustmentId - 1, 1);
+    }
+    return {
+      status: "success",
+      id: transactionId,
+    } as TransactionResponse;
+  });
+
   singletonInstance.protectPartitions = jest.fn(async () => {
     securityInfo.arePartitionsProtected = true;
     return {

--- a/packages/ats/sdk/__tests__/port/environmentMock.ts
+++ b/packages/ats/sdk/__tests__/port/environmentMock.ts
@@ -1407,6 +1407,16 @@ jest.mock("@port/out/rpc/RPCTransactionAdapter", () => {
     } as TransactionResponse;
   });
 
+  singletonInstance.cancelVoting = jest.fn(async function (_security: EvmAddress, votingId: number) {
+    if (votingId > 0 && votingId <= votingRights.length) {
+      votingRights.splice(votingId - 1, 1);
+    }
+    return {
+      status: "success",
+      id: transactionId,
+    } as TransactionResponse;
+  });
+
   singletonInstance.setCoupon = jest.fn(
     async (
       address: EvmAddress,

--- a/packages/ats/sdk/__tests__/port/in/Equity.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Equity.test.ts
@@ -314,6 +314,7 @@ describe("🧪 Equity test", () => {
     expect(scheduledBalanceAdjustment.executionDate.getTime() / 1000).toEqual(recordTimestamp);
     expect(scheduledBalanceAdjustment.factor).toEqual(factor);
     expect(scheduledBalanceAdjustment.decimals).toEqual(decimals.toString());
+    expect(scheduledBalanceAdjustment.isDisabled).toEqual(false);
 
     await Role.revokeRole(
       new RoleRequest({
@@ -565,6 +566,7 @@ describe("🧪 Equity test", () => {
     expect(allScheduledAdjustments[0].factor).toEqual(factor);
     expect(allScheduledAdjustments[0].decimals).toEqual(decimals);
     expect(allScheduledAdjustments[0].executionDate.getTime() / 1000).toEqual(executionTimestamp);
+    expect(allScheduledAdjustments[0].isDisabled).toEqual(false);
 
     await Role.revokeRole(
       new RoleRequest({

--- a/packages/ats/sdk/__tests__/port/in/Equity.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Equity.test.ts
@@ -378,6 +378,134 @@ describe("🧪 Equity test", () => {
     );
   }, 600_000);
 
+  it("Should cancel a scheduled balance adjustment correctly", async () => {
+    await Role.grantRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+
+    await Equity.setScheduledBalanceAdjustment(
+      new SetScheduledBalanceAdjustmentRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        executionDate: recordTimestamp.toString(),
+        factor,
+        decimals: decimals.toString(),
+      }),
+    );
+
+    const result = await Equity.cancelScheduledBalanceAdjustment(
+      new GetScheduledBalanceAdjustmentRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        balanceAdjustmentId: 1,
+      }),
+    );
+
+    expect(result.payload).toEqual(true);
+
+    await Role.revokeRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+  }, 60_000);
+
+  it("Should return error if try to cancel a scheduled balance adjust and do not have the role", async () => {
+    await Role.grantRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+
+    await Equity.setScheduledBalanceAdjustment(
+      new SetScheduledBalanceAdjustmentRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        executionDate: recordTimestamp.toString(),
+        factor,
+        decimals: decimals.toString(),
+      }),
+    );
+
+    await Role.revokeRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+
+    let thrownError;
+    try {
+      await Equity.cancelScheduledBalanceAdjustment(
+        new GetScheduledBalanceAdjustmentRequest({
+          securityId: equity.evmDiamondAddress!.toString(),
+          balanceAdjustmentId: 1,
+        }),
+      );
+    } catch (error) {
+      thrownError = error;
+    }
+    expect(thrownError).toBeInstanceOf(Error);
+  }, 600_000);
+
+  it("Should return error if try to cancel a scheduled balance adjust and the token is paused", async () => {
+    await Role.grantRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+
+    await Role.grantRole(
+      new RoleRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._PAUSER_ROLE,
+      }),
+    );
+
+    await Equity.setScheduledBalanceAdjustment(
+      new SetScheduledBalanceAdjustmentRequest({
+        securityId: equity.evmDiamondAddress!.toString(),
+        executionDate: recordTimestamp.toString(),
+        factor,
+        decimals: decimals.toString(),
+      }),
+    );
+
+    await Security.pause(
+      new PauseRequest({
+        securityId: equity.evmDiamondAddress!,
+      }),
+    );
+
+    let thrownError;
+    try {
+      const result = await Equity.cancelScheduledBalanceAdjustment(
+        new GetScheduledBalanceAdjustmentRequest({
+          securityId: equity.evmDiamondAddress!.toString(),
+          balanceAdjustmentId: 1,
+        }),
+      );
+    } catch (error) {
+      thrownError = error;
+    }
+    expect(thrownError).toBeInstanceOf(Error);
+
+    await Security.unpause(
+      new PauseRequest({
+        securityId: equity.evmDiamondAddress!,
+      }),
+    );
+  }, 600_000);
+
   it("Should return scheduled balance adjustments count correctly", async () => {
     await Role.grantRole(
       new RoleRequest({

--- a/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommand.ts
+++ b/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommand.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "@core/command/Command";
+import { CommandResponse } from "@core/command/CommandResponse";
+
+export class CancelScheduledBalanceAdjustmentCommandResponse implements CommandResponse {
+  constructor(
+    public readonly payload: boolean,
+    public readonly transactionId: string,
+  ) {}
+}
+
+export class CancelScheduledBalanceAdjustmentCommand extends Command<CancelScheduledBalanceAdjustmentCommandResponse> {
+  constructor(
+    public readonly securityId: string,
+    public readonly balanceAdjustmentId: number,
+  ) {
+    super();
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommandHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommandHandler.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ICommandHandler } from "@core/command/CommandHandler";
+import { CommandHandler } from "@core/decorator/CommandHandlerDecorator";
+import {
+  CancelScheduledBalanceAdjustmentCommand,
+  CancelScheduledBalanceAdjustmentCommandResponse,
+} from "./CancelScheduledBalanceAdjustmentCommand";
+import TransactionService from "@service/transaction/TransactionService";
+import { lazyInject } from "@core/decorator/LazyInjectDecorator";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import BigDecimal from "@domain/context/shared/BigDecimal";
+import AccountService from "@service/account/AccountService";
+import { SecurityRole } from "@domain/context/security/SecurityRole";
+import ValidationService from "@service/validation/ValidationService";
+import ContractService from "@service/contract/ContractService";
+import { CancelScheduledBalanceAdjustmentCommandError } from "./error/CancelScheduledBalanceAdjustmentCommandError";
+
+@CommandHandler(CancelScheduledBalanceAdjustmentCommand)
+export class CancelScheduledBalanceAdjustmentCommandHandler
+  implements ICommandHandler<CancelScheduledBalanceAdjustmentCommand>
+{
+  constructor(
+    @lazyInject(TransactionService)
+    private readonly transactionService: TransactionService,
+    @lazyInject(AccountService)
+    private readonly accountService: AccountService,
+    @lazyInject(ValidationService)
+    private readonly validationService: ValidationService,
+    @lazyInject(ContractService)
+    private readonly contractService: ContractService,
+  ) {}
+
+  async execute(
+    command: CancelScheduledBalanceAdjustmentCommand,
+  ): Promise<CancelScheduledBalanceAdjustmentCommandResponse> {
+    try {
+      const { securityId, balanceAdjustmentId } = command;
+      const handler = this.transactionService.getHandler();
+      const account = this.accountService.getCurrentAccount();
+
+      const securityEvmAddress: EvmAddress = await this.contractService.getContractEvmAddress(securityId);
+
+      await this.validationService.checkPause(securityId);
+      await this.validationService.checkRole(SecurityRole._CORPORATEACTIONS_ROLE, account.evmAddress!, securityId);
+
+      const res = await handler.cancelScheduledBalanceAdjustment(securityEvmAddress, balanceAdjustmentId, securityId);
+
+      return Promise.resolve(new CancelScheduledBalanceAdjustmentCommandResponse(res.error === undefined, res.id!));
+    } catch (error) {
+      throw new CancelScheduledBalanceAdjustmentCommandError(error as Error);
+    }
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommandHandler.unit.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMock } from "@golevelup/ts-jest";
+import { CancelScheduledBalanceAdjustmentCommandHandler } from "./CancelScheduledBalanceAdjustmentCommandHandler";
+import {
+  CancelScheduledBalanceAdjustmentCommand,
+  CancelScheduledBalanceAdjustmentCommandResponse,
+} from "./CancelScheduledBalanceAdjustmentCommand";
+import TransactionService from "@service/transaction/TransactionService";
+import ContractService from "@service/contract/ContractService";
+import ValidationService from "@service/validation/ValidationService";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import { AccountPropsFixture, ErrorMsgFixture, TransactionIdFixture } from "@test/fixtures/shared/DataFixture";
+import AccountService from "@service/account/AccountService";
+import { CancelScheduledBalanceAdjustmentCommandFixture } from "@test/fixtures/equity/EquityFixture";
+import { SecurityRole } from "@domain/context/security/SecurityRole";
+import Account from "@domain/context/account/Account";
+import { CancelScheduledBalanceAdjustmentCommandError } from "./error/CancelScheduledBalanceAdjustmentCommandError";
+
+import { ErrorCode } from "@core/error/BaseError";
+
+describe("CancelScheduledBalanceAdjustmentCommandHandler", () => {
+  let handler: CancelScheduledBalanceAdjustmentCommandHandler;
+  let command: CancelScheduledBalanceAdjustmentCommand;
+  const transactionServiceMock = createMock<TransactionService>();
+  const accountServiceMock = createMock<AccountService>();
+  const contractServiceMock = createMock<ContractService>();
+  const validationServiceMock = createMock<ValidationService>();
+
+  const transactionId = TransactionIdFixture.create().id;
+  const account = new Account(AccountPropsFixture.create());
+  const evmAddress = new EvmAddress(account.evmAddress!);
+  const errorMsg = ErrorMsgFixture.create().msg;
+
+  beforeEach(() => {
+    handler = new CancelScheduledBalanceAdjustmentCommandHandler(
+      transactionServiceMock,
+      accountServiceMock,
+      validationServiceMock,
+      contractServiceMock,
+    );
+    command = CancelScheduledBalanceAdjustmentCommandFixture.create();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("execute", () => {
+    describe("error cases", () => {
+      it("throws CancelScheduledBalanceAdjustmentCommandError when command fails with uncaught error", async () => {
+        const fakeError = new Error(errorMsg);
+
+        contractServiceMock.getContractEvmAddress.mockRejectedValue(fakeError);
+
+        const resultPromise = handler.execute(command);
+
+        await expect(resultPromise).rejects.toBeInstanceOf(CancelScheduledBalanceAdjustmentCommandError);
+
+        await expect(resultPromise).rejects.toMatchObject({
+          message: expect.stringContaining(
+            `An error occurred while cancelling the scheduled balance adjustment: ${errorMsg}`,
+          ),
+          errorCode: ErrorCode.UncaughtCommandError,
+        });
+      });
+    });
+    describe("success cases", () => {
+      it("should successfully cancel a scheduled balance adjustment", async () => {
+        contractServiceMock.getContractEvmAddress.mockResolvedValue(evmAddress);
+        accountServiceMock.getCurrentAccount.mockReturnValue(account);
+
+        transactionServiceMock.getHandler().cancelScheduledBalanceAdjustment.mockResolvedValue({
+          id: transactionId,
+        });
+
+        const result = await handler.execute(command);
+
+        expect(result).toBeInstanceOf(CancelScheduledBalanceAdjustmentCommandResponse);
+        expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledTimes(1);
+        expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(command.securityId);
+        expect(validationServiceMock.checkPause).toHaveBeenCalledTimes(1);
+        expect(validationServiceMock.checkRole).toHaveBeenCalledTimes(1);
+        expect(validationServiceMock.checkRole).toHaveBeenCalledWith(
+          SecurityRole._CORPORATEACTIONS_ROLE,
+          account.evmAddress!,
+          command.securityId,
+        );
+        expect(transactionServiceMock.getHandler().cancelScheduledBalanceAdjustment).toHaveBeenCalledTimes(1);
+        expect(transactionServiceMock.getHandler().cancelScheduledBalanceAdjustment).toHaveBeenCalledWith(
+          evmAddress,
+          command.balanceAdjustmentId,
+          command.securityId,
+        );
+        expect(result.payload).toBe(true);
+        expect(result.transactionId).toBe(transactionId);
+      });
+    });
+  });
+});

--- a/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/error/CancelScheduledBalanceAdjustmentCommandError.ts
+++ b/packages/ats/sdk/src/app/usecase/command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/error/CancelScheduledBalanceAdjustmentCommandError.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { CommandError } from "@command/error/CommandError";
+import BaseError from "@core/error/BaseError";
+
+export class CancelScheduledBalanceAdjustmentCommandError extends CommandError {
+  constructor(error: Error) {
+    const msg = `An error occurred while cancelling the scheduled balance adjustment: ${error.message}`;
+    super(msg, error instanceof BaseError ? error.errorCode : undefined);
+  }
+}

--- a/packages/ats/sdk/src/core/Constants.ts
+++ b/packages/ats/sdk/src/core/Constants.ts
@@ -155,6 +155,7 @@ export const GAS = {
   SET_INTEREST_RATE: 7000000,
   ADD_KPI_DATA: 7000000,
   SET_IMPACT_DATA: 7000000,
+  CANCEL_SCHEDULED_BALANCE_ADJUSTMENT: 7000000,
 } as const;
 
 export const _PARTITION_ID_1 = "0x0000000000000000000000000000000000000000000000000000000000000001";
@@ -166,6 +167,7 @@ export const SET_VOTING_RIGHTS_EVENT = "VotingSet";
 export const SET_COUPON_EVENT = "CouponSet";
 export const CANCEL_COUPON_EVENT = "CouponCancelled";
 export const SET_SCHEDULED_BALANCE_ADJUSTMENT_EVENT = "ScheduledBalanceAdjustmentSet";
+export const CANCEL_SCHEDULED_BALANCE_ADJUSTMENT_EVENT = "ScheduledBalanceAdjustmentCancelled";
 
 // * Generic
 export const BYTES_32_LENGTH = 32 * 2;

--- a/packages/ats/sdk/src/core/injectable/equity/InjectableEquity.ts
+++ b/packages/ats/sdk/src/core/injectable/equity/InjectableEquity.ts
@@ -17,6 +17,7 @@ import { GetDividendHoldersQueryHandler } from "@query/equity/dividends/getDivid
 import { GetTotalDividendHoldersQueryHandler } from "@query/equity/dividends/getTotalDividendHolders/GetTotalDividendHoldersQueryHandler";
 import { GetVotingHoldersQueryHandler } from "@query/equity/votingRights/getVotingHolders/GetVotingHoldersQueryHandler";
 import { GetTotalVotingHoldersQueryHandler } from "@query/equity/votingRights/getTotalVotingHolders/GetTotalVotingHoldersQueryHandler";
+import { CancelScheduledBalanceAdjustmentCommandHandler } from "@command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommandHandler";
 
 export const COMMAND_HANDLERS_EQUITY = [
   {
@@ -34,6 +35,10 @@ export const COMMAND_HANDLERS_EQUITY = [
   {
     token: TOKENS.COMMAND_HANDLER,
     useClass: SetVotingRightsCommandHandler,
+  },
+  {
+    token: TOKENS.COMMAND_HANDLER,
+    useClass: CancelScheduledBalanceAdjustmentCommandHandler,
   },
 ];
 

--- a/packages/ats/sdk/src/domain/context/equity/ScheduledBalanceAdjustment.ts
+++ b/packages/ats/sdk/src/domain/context/equity/ScheduledBalanceAdjustment.ts
@@ -4,9 +4,11 @@ export class ScheduledBalanceAdjustment {
   executionTimeStamp: number;
   factor: number;
   decimals: number;
-  constructor(executionTimeStamp: number, factor: number, decimals: number) {
+  isDisabled: boolean;
+  constructor(executionTimeStamp: number, factor: number, decimals: number, isDisabled: boolean = false) {
     this.executionTimeStamp = executionTimeStamp;
     this.factor = factor;
     this.decimals = decimals;
+    this.isDisabled = isDisabled;
   }
 }

--- a/packages/ats/sdk/src/port/in/equity/Equity.ts
+++ b/packages/ats/sdk/src/port/in/equity/Equity.ts
@@ -10,6 +10,7 @@ import { SetVotingRightsCommand } from "@command/equity/votingRights/set/SetVoti
 import { GetVotingQuery } from "@query/equity/votingRights/getVoting/GetVotingQuery";
 import { GetVotingCountQuery } from "@query/equity/votingRights/getVotingCount/GetVotingCountQuery";
 import { GetVotingForQuery } from "@query/equity/votingRights/getVotingFor/GetVotingForQuery";
+import { CancelScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommand";
 import { SetScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/setScheduledBalanceAdjustment/SetScheduledBalanceAdjustmentCommand";
 import Injectable from "@core/injectable/Injectable";
 import { CommandBus } from "@core/command/CommandBus";
@@ -43,6 +44,7 @@ import GetEquityDetailsRequest from "../request/equity/GetEquityDetailsRequest";
 import EquityDetailsViewModel from "../response/EquityDetailsViewModel";
 import { GetEquityDetailsQuery } from "@query/equity/get/getEquityDetails/GetEquityDetailsQuery";
 import { CastRegulationSubType, CastRegulationType } from "@domain/context/factory/RegulationType";
+import CancelScheduledBalanceAdjustmentRequest from "../request/equity/CancelScheduledBalanceAdjustmentRequest";
 import SetScheduledBalanceAdjustmentRequest from "../request/equity/SetScheduledBalanceAdjustmentRequest";
 import GetScheduledBalanceAdjustmentRequest from "../request/equity/GetScheduledBalanceAdjustmentRequest";
 import ScheduledBalanceAdjustmentViewModel from "../response/ScheduledBalanceAdjustmentViewModel";
@@ -96,6 +98,10 @@ interface IEquityInPort {
 
   createTrexSuite(request: CreateTrexSuiteEquityRequest): Promise<{
     security: SecurityViewModel;
+    transactionId: string;
+  }>;
+  cancelScheduledBalanceAdjustment(request: CancelScheduledBalanceAdjustmentRequest): Promise<{
+    payload: boolean;
     transactionId: string;
   }>;
 }
@@ -549,6 +555,17 @@ class EquityInPort implements IEquityInPort {
     ValidatedRequest.handleValidation(GetTotalVotingHoldersRequest.name, request);
 
     return (await this.queryBus.execute(new GetTotalVotingHoldersQuery(securityId, voteId))).payload;
+  }
+
+  @LogError
+  async cancelScheduledBalanceAdjustment(request: CancelScheduledBalanceAdjustmentRequest): Promise<{
+    payload: boolean;
+    transactionId: string;
+  }> {
+    const { securityId, balanceAdjustmentId } = request;
+    ValidatedRequest.handleValidation("CancelScheduledBalanceAdjustmentRequest", request);
+
+    return await this.commandBus.execute(new CancelScheduledBalanceAdjustmentCommand(securityId, balanceAdjustmentId));
   }
 }
 

--- a/packages/ats/sdk/src/port/in/equity/Equity.ts
+++ b/packages/ats/sdk/src/port/in/equity/Equity.ts
@@ -480,6 +480,7 @@ class EquityInPort implements IEquityInPort {
       executionDate: new Date(res.scheduleBalanceAdjustment.executionTimeStamp * ONE_THOUSAND),
       factor: res.scheduleBalanceAdjustment.factor.toString(),
       decimals: res.scheduleBalanceAdjustment.decimals.toString(),
+      isDisabled: res.scheduleBalanceAdjustment.isDisabled,
     };
 
     return scheduledBalanceAdjustment;
@@ -517,6 +518,7 @@ class EquityInPort implements IEquityInPort {
         executionDate: new Date(res.scheduleBalanceAdjustment.executionTimeStamp * ONE_THOUSAND),
         factor: res.scheduleBalanceAdjustment.factor.toString(),
         decimals: res.scheduleBalanceAdjustment.decimals.toString(),
+        isDisabled: res.scheduleBalanceAdjustment.isDisabled,
       };
 
       scheduledBalanceAdjustments.push(scheduledBalanceAdjustment);

--- a/packages/ats/sdk/src/port/in/equity/Equity.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/equity/Equity.unit.test.ts
@@ -23,6 +23,7 @@ import {
   GetTotalVotingHoldersRequest,
   CreateTrexSuiteEquityRequest,
   CancelDividendRequest,
+  CancelScheduledBalanceAdjustmentRequest,
 } from "../request";
 import { HederaIdPropsFixture, TransactionIdFixture } from "@test/fixtures/shared/DataFixture";
 import LogService from "@service/log/LogService";
@@ -61,6 +62,7 @@ import {
   SetDividendsRequestFixture,
   CancelDividendRequestFixture,
   SetScheduledBalanceAdjustmentRequestFixture,
+  CancelScheduledBalanceAdjustmentRequestFixture,
   SetVotingRightsRequestFixture,
   VotingRightsFixture,
 } from "@test/fixtures/equity/EquityFixture";
@@ -79,6 +81,7 @@ import { GetDividendsCountQuery } from "@query/equity/dividends/getDividendsCoun
 import { SetScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/setScheduledBalanceAdjustment/SetScheduledBalanceAdjustmentCommand";
 import { GetScheduledBalanceAdjustmentQuery } from "@query/equity/balanceAdjustments/getScheduledBalanceAdjustment/GetScheduledBalanceAdjustmentQuery";
 import { GetScheduledBalanceAdjustmentCountQuery } from "@query/equity/balanceAdjustments/getScheduledBalanceAdjustmentCount/GetScheduledBalanceAdjustmentsCountQuery";
+import { CancelScheduledBalanceAdjustmentCommand } from "@command/equity/balanceAdjustments/cancelScheduledBalanceAdjustment/CancelScheduledBalanceAdjustmentCommand";
 import { GetDividendHoldersQuery } from "@query/equity/dividends/getDividendHolders/GetDividendHoldersQuery";
 import { GetTotalDividendHoldersQuery } from "@query/equity/dividends/getTotalDividendHolders/GetTotalDividendHoldersQuery";
 import { GetVotingHoldersQuery } from "@query/equity/votingRights/getVotingHolders/GetVotingHoldersQuery";
@@ -103,6 +106,7 @@ describe("Equity", () => {
   let setScheduledBalanceAdjustmentRequest: SetScheduledBalanceAdjustmentRequest;
   let getScheduledBalanceAdjustmentCountRequest: GetScheduledBalanceAdjustmentCountRequest;
   let getScheduledBalanceAdjustmentRequest: GetScheduledBalanceAdjustmentRequest;
+  let cancelScheduledBalanceAdjustmentRequest: CancelScheduledBalanceAdjustmentRequest;
   let getAllScheduledBalanceAdjustmentsRequest: GetAllScheduledBalanceAdjustmentsRequest;
   let getDividendHoldersRequest: GetDividendHoldersRequest;
   let getTotalDividendHoldersRequest: GetTotalDividendHoldersRequest;
@@ -1183,6 +1187,70 @@ describe("Equity", () => {
       await expect(EquityToken.setScheduledBalanceAdjustment(setScheduledBalanceAdjustmentRequest)).rejects.toThrow(
         ValidationError,
       );
+    });
+  });
+
+  describe("cancelScheduledBalanceAdjustment", () => {
+    cancelScheduledBalanceAdjustmentRequest = new CancelScheduledBalanceAdjustmentRequest(
+      CancelScheduledBalanceAdjustmentRequestFixture.create(),
+    );
+    it("should set scheduled balance adjustment successfully", async () => {
+      const expectedResponse = {
+        payload: 1,
+        transactionId: transactionId,
+      };
+
+      commandBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await EquityToken.cancelScheduledBalanceAdjustment(cancelScheduledBalanceAdjustmentRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(
+        "CancelScheduledBalanceAdjustmentRequest",
+        cancelScheduledBalanceAdjustmentRequest,
+      );
+
+      expect(commandBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new CancelScheduledBalanceAdjustmentCommand(
+          cancelScheduledBalanceAdjustmentRequest.securityId,
+          cancelScheduledBalanceAdjustmentRequest.balanceAdjustmentId,
+        ),
+      );
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it("should throw an error if command execution fails", async () => {
+      const error = new Error("Command execution failed");
+      commandBusMock.execute.mockRejectedValue(error);
+
+      await expect(
+        EquityToken.cancelScheduledBalanceAdjustment(cancelScheduledBalanceAdjustmentRequest),
+      ).rejects.toThrow("Command execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(
+        "CancelScheduledBalanceAdjustmentRequest",
+        cancelScheduledBalanceAdjustmentRequest,
+      );
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new CancelScheduledBalanceAdjustmentCommand(
+          cancelScheduledBalanceAdjustmentRequest.securityId,
+          cancelScheduledBalanceAdjustmentRequest.balanceAdjustmentId,
+        ),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      cancelScheduledBalanceAdjustmentRequest = new CancelScheduledBalanceAdjustmentRequest({
+        ...CancelScheduledBalanceAdjustmentRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(
+        EquityToken.cancelScheduledBalanceAdjustment(cancelScheduledBalanceAdjustmentRequest),
+      ).rejects.toThrow(ValidationError);
     });
   });
 

--- a/packages/ats/sdk/src/port/in/equity/Equity.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/equity/Equity.unit.test.ts
@@ -1287,6 +1287,7 @@ describe("Equity", () => {
           executionDate: new Date(expectedResponse.scheduleBalanceAdjustment.executionTimeStamp * ONE_THOUSAND),
           factor: expectedResponse.scheduleBalanceAdjustment.factor.toString(),
           decimals: expectedResponse.scheduleBalanceAdjustment.decimals.toString(),
+          isDisabled: expectedResponse.scheduleBalanceAdjustment.isDisabled,
         }),
       );
     });
@@ -1433,6 +1434,7 @@ describe("Equity", () => {
             id: 1,
             executionDate: new Date(expectedResponse2.scheduleBalanceAdjustment.executionTimeStamp * ONE_THOUSAND),
             factor: expectedResponse2.scheduleBalanceAdjustment.factor.toString(),
+            isDisabled: expectedResponse2.scheduleBalanceAdjustment.isDisabled,
           },
         ]),
       );

--- a/packages/ats/sdk/src/port/in/request/equity/CancelScheduledBalanceAdjustmentRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/equity/CancelScheduledBalanceAdjustmentRequest.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import FormatValidation from "../FormatValidation";
+
+export default class CancelScheduledBalanceAdjustmentRequest extends ValidatedRequest<CancelScheduledBalanceAdjustmentRequest> {
+  securityId: string;
+  balanceAdjustmentId: number;
+
+  constructor({ securityId, balanceAdjustmentId }: { securityId: string; balanceAdjustmentId: number }) {
+    super({
+      securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
+    });
+
+    this.securityId = securityId;
+    this.balanceAdjustmentId = balanceAdjustmentId;
+  }
+}

--- a/packages/ats/sdk/src/port/in/request/index.ts
+++ b/packages/ats/sdk/src/port/in/request/index.ts
@@ -217,6 +217,7 @@ import GetImpactDataRequest from "./kpiLinkedRate/GetImpactDataRequest";
 import SetImpactDataRequest from "./interestRates/SetImpactDataRequest";
 import GetScheduledCouponListingRequest from "./scheduledTasks/GetScheduledCouponListingRequest";
 import CancelCouponRequest from "./bond/CancelCouponRequest";
+import CancelScheduledBalanceAdjustmentRequest from "./equity/CancelScheduledBalanceAdjustmentRequest";
 
 export {
   CreateEquityRequest,
@@ -435,4 +436,5 @@ export {
   GetImpactDataRequest,
   GetScheduledCouponListingRequest,
   CancelCouponRequest,
+  CancelScheduledBalanceAdjustmentRequest,
 };

--- a/packages/ats/sdk/src/port/in/response/ScheduledBalanceAdjustmentViewModel.ts
+++ b/packages/ats/sdk/src/port/in/response/ScheduledBalanceAdjustmentViewModel.ts
@@ -7,4 +7,5 @@ export default interface ScheduledBalanceAdjustmentViewModel extends QueryRespon
   executionDate: Date;
   factor: string;
   decimals: string;
+  isDisabled: boolean;
 }

--- a/packages/ats/sdk/src/port/out/TransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/TransactionAdapter.ts
@@ -347,6 +347,11 @@ interface ITransactionAdapter {
     sourceId: EvmAddress,
     securityId?: ContractId | string,
   ): Promise<TransactionResponse>;
+  cancelScheduledBalanceAdjustment(
+    security: EvmAddress,
+    balanceAdjustmentId: number,
+    securityId?: ContractId | string,
+  ): Promise<TransactionResponse<any, Error>>;
 }
 
 interface RoleTransactionAdapter {
@@ -1783,4 +1788,10 @@ export default abstract class TransactionAdapter
     rateDecimals: number,
     securityId?: ContractId | string,
   ): Promise<TransactionResponse>;
+
+  abstract cancelScheduledBalanceAdjustment(
+    security: EvmAddress,
+    balanceAdjustmentId: number,
+    securityId?: ContractId | string,
+  ): Promise<TransactionResponse<any, Error>>;
 }

--- a/packages/ats/sdk/src/port/out/hs/HederaTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/hs/HederaTransactionAdapter.ts
@@ -3289,6 +3289,20 @@ export abstract class HederaTransactionAdapter extends TransactionAdapter {
     );
   }
 
+  async cancelScheduledBalanceAdjustment(
+    security: EvmAddress,
+    balanceAdjustmentId: number,
+    securityId: ContractId | string,
+  ): Promise<TransactionResponse<any, Error>> {
+    return this.executeWithArgs(
+      new EquityUSAFacet__factory().attach(security.toString()),
+      "cancelScheduledBalanceAdjustment",
+      securityId,
+      GAS.CANCEL_SCHEDULED_BALANCE_ADJUSTMENT,
+      [balanceAdjustmentId],
+    );
+  }
+
   // * Definition of the abstract methods
   abstract signAndSendTransaction(
     transaction: Transaction,

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -759,6 +759,7 @@ export class RPCQueryAdapter {
       Number(scheduledBalanceAdjustmentInfo.balanceAdjustment_.executionDate),
       Number(scheduledBalanceAdjustmentInfo.balanceAdjustment_.factor),
       Number(scheduledBalanceAdjustmentInfo.balanceAdjustment_.decimals),
+      scheduledBalanceAdjustmentInfo.isDisabled_,
     );
   }
 

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -9,6 +9,7 @@ import {
   _PARTITION_ID_1,
   CANCEL_COUPON_EVENT,
   CANCEL_DIVIDEND_EVENT,
+  CANCEL_SCHEDULED_BALANCE_ADJUSTMENT_EVENT,
   EVM_ZERO_ADDRESS,
   GAS,
   SET_COUPON_EVENT,
@@ -2702,6 +2703,16 @@ export class RPCTransactionAdapter extends TransactionAdapter {
       "addKpiData",
       [date, value, project.toString()],
       GAS.ADD_KPI_DATA,
+    );
+  }
+
+  async cancelScheduledBalanceAdjustment(security: EvmAddress, balanceAdjustmentId: number): Promise<TransactionResponse> {
+    return this.executeTransaction(
+      Equity__factory.connect(security.toString(), this.getSignerOrProvider()),
+      "cancelScheduledBalanceAdjustment",
+      [balanceAdjustmentId],
+      GAS.CANCEL_SCHEDULED_BALANCE_ADJUSTMENT,
+      CANCEL_SCHEDULED_BALANCE_ADJUSTMENT_EVENT,
     );
   }
 }


### PR DESCRIPTION
## Description
A new operation was added regarding equity: cancelScheduledBalanceAdjustment and also the property isDisabled was added to ScheduledBalanceAdjustment, so when calling to getScheduledBalanceAdjustment, this new property will be fetched along with the others were already fetched.

## Type of change

- [ ] Bug fix 🐞
- [X] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X] Local Tests Pass ✅
- [X] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
