### PR TITLE
feat: add MP documentation for testnet walkthrough

### DIFF
--- a/apps/docs/sidebars-mass-payout.ts
+++ b/apps/docs/sidebars-mass-payout.ts
@@ -13,7 +13,12 @@ const sidebars: SidebarsConfig = {
         type: "doc",
         id: "getting-started/index",
       },
-      items: ["getting-started/capabilities-overview", "getting-started/quick-start", "getting-started/full-setup"],
+      items: [
+        "getting-started/capabilities-overview",
+        "getting-started/quick-start",
+        "getting-started/full-setup",
+        "getting-started/testnet-end-to-end",
+      ],
     },
     {
       type: "category",

--- a/docs/ats/developer-guides/contracts/documenting-contracts.md
+++ b/docs/ats/developer-guides/contracts/documenting-contracts.md
@@ -10,7 +10,7 @@ This guide explains how to properly document Solidity smart contracts using NatS
 
 ## Overview
 
-The ATS contracts use **NatSpec** (Ethereum Natural Language Specification Format) for inline documentation. This documentation is automatically extracted and published to the [API Documentation](/docs/references/api) section.
+The ATS contracts use **NatSpec** (Ethereum Natural Language Specification Format) for inline documentation. This documentation is automatically extracted and published to the API Documentation section.
 
 ## NatSpec Basics
 

--- a/docs/mass-payout/getting-started/full-setup.md
+++ b/docs/mass-payout/getting-started/full-setup.md
@@ -71,20 +71,27 @@ GRANT ALL PRIVILEGES ON DATABASE mass_payout TO mass_payout_user;
 \q
 ```
 
-## Step 3: Build All Mass Payout Components
+## Step 3: Build All Components
 
-Build contracts, SDK, backend, and frontend:
+Mass Payout depends on ATS contracts. Build everything in dependency order:
 
 ```bash
-# Build everything with one command
-npm run mass-payout:build
+# 1. ATS contracts first (Mass Payout contracts depend on these ABIs)
+npm run ats:contracts:build
 
-# Or build individually
+# 2. Mass Payout contracts, SDK, backend, and frontend
 npm run mass-payout:contracts:build
 npm run mass-payout:sdk:build
 npm run mass-payout:backend:build
 npm run mass-payout:frontend:build
+
+# 3. ATS SDK last (depends on ATS contracts)
+npm run ats:sdk:build
 ```
+
+:::caution Build order matters
+`npm run mass-payout:build` alone is not sufficient — it skips the required ATS contracts build. Always run `ats:contracts:build` first.
+:::
 
 ## Step 4: Smart Contracts Setup
 

--- a/docs/mass-payout/getting-started/index.md
+++ b/docs/mass-payout/getting-started/index.md
@@ -50,6 +50,22 @@ Welcome to Mass Payout! Choose your path based on what you want to accomplish.
 
 ---
 
+## Run Your First End-to-End Test
+
+<div className="card-box card-success">
+  <h3>Testnet Walkthrough</h3>
+  <p>Build everything, run the full local stack, and execute a real distribution on Hedera Testnet using a test asset and USDC test funds.</p>
+  <ul>
+    <li>Correct build order for all components</li>
+    <li>Create a test asset via ATS staging</li>
+    <li>Fund the Distributions contract via Circle faucet</li>
+    <li>Verify on Hashscan and execute payout</li>
+  </ul>
+  <a href="./testnet-end-to-end" className="card-link">Testnet Walkthrough →</a>
+</div>
+
+---
+
 ## What's Next?
 
 After getting started, explore:

--- a/docs/mass-payout/getting-started/testnet-end-to-end.md
+++ b/docs/mass-payout/getting-started/testnet-end-to-end.md
@@ -1,0 +1,164 @@
+---
+id: testnet-end-to-end
+title: End-to-End Testnet Walkthrough
+sidebar_label: Testnet Walkthrough
+sidebar_position: 3
+---
+
+# End-to-End Testnet Walkthrough
+
+This guide walks you through a complete end-to-end flow: building all components from scratch, running the full stack locally, and executing a real distribution on Hedera Testnet using a test asset and USDC test funds.
+
+## Prerequisites
+
+- All [Full Development Setup](./full-setup.md) steps completed
+- Docker running (for PostgreSQL)
+- A Hedera Testnet account with HBAR
+- Access to the ATS staging environment (see [Step 3](#step-3-create-a-test-asset-in-ats-staging))
+
+---
+
+## Step 1: Build All Components in Order
+
+Mass Payout depends on the ATS contracts and SDK. Build everything in the correct dependency order:
+
+```bash
+# 1. ATS contracts first (MP contracts depend on these ABIs)
+npm run ats:contracts:build
+
+# 2. Mass Payout contracts
+npm run mass-payout:contracts:build
+
+# 3. Mass Payout SDK (depends on MP contracts)
+npm run mass-payout:sdk:build
+
+# 4. Mass Payout backend (depends on MP SDK)
+npm run mass-payout:backend:build
+
+# 5. ATS SDK last (depends on ATS contracts)
+npm run ats:sdk:build
+```
+
+:::caution Build order matters
+Building `mass-payout:contracts` before `ats:contracts` will fail. Always start with ATS contracts.
+:::
+
+---
+
+## Step 2: Start the Local Stack
+
+### 2.1 Start the Database
+
+```bash
+cd apps/mass-payout/backend
+docker compose up -d
+```
+
+### 2.2 Start the Backend
+
+From the backend directory (required to load `.env` correctly):
+
+```bash
+cd apps/mass-payout/backend
+npm run start:debug
+```
+
+The backend API will be available at **http://localhost:3000**.
+
+> **Tip**: Use `start:debug` instead of `start:dev` to have the Node.js debugger available on port 9229, useful for stepping through distribution execution.
+
+### 2.3 Start the Frontend
+
+In a new terminal, from the monorepo root:
+
+```bash
+npm run mass-payout:frontend:dev
+```
+
+The frontend will be available at **http://localhost:5173**.
+
+---
+
+## Step 3: Create a Test Asset in ATS Staging
+
+You need a token deployed on Hedera Testnet to import into Mass Payout. Use the ATS staging environment:
+
+1. Go to the ATS staging app: **https://asset-tokenization-studio-iobuilders.netlify.app/**
+   - Password: Ask for it
+2. Connect your Hedera Testnet wallet
+3. Create a new security token (bond or equity)
+4. **Mint tokens** to at least one holder address
+
+:::info Why mint tokens?
+An address only becomes a token holder after tokens are minted to it. If you skip minting, Mass Payout will import the asset but show zero holders — no distribution can be executed. See [Asset Imported But Shows Zero Holders](../user-guides/importing-assets.md#asset-imported-but-shows-zero-holders) for details.
+:::
+
+---
+
+## Step 4: Import the Asset into Mass Payout
+
+1. Open the local frontend at **http://localhost:5173**
+2. Click **Import Asset**
+3. On the asset row, click the import button on the right side
+4. Follow the next steps to confirm the import
+
+After import, the asset will appear in the dashboard with holder count and balances synced from the blockchain.
+
+---
+
+## Step 5: Fund the Distributions Contract with Test USDC
+
+Each imported asset has a **Distributions SC** address — the smart contract that will hold the funds to be distributed.
+
+### 5.1 Find the Distributions SC Address
+
+In the Mass Payout frontend:
+
+1. Navigate to the asset row
+2. Copy the **Distributions SC** address (format: `0.0.XXXXXXXX`)
+
+### 5.2 Get Test USDC from Circle Faucet
+
+1. Go to **https://faucet.circle.com/**
+2. Select **Hedera Testnet** as the network
+3. Paste the **Distributions SC** address as the recipient
+4. Request test USDC
+
+### 5.3 Verify the Balance on Hashscan
+
+1. Go to **https://hashscan.io/testnet/**
+2. Search for the **Distributions SC** address
+3. Navigate to **Associated Contract → Assets**
+4. Confirm the USDC balance appears
+
+Once the contract has funds, Mass Payout can execute a distribution to all token holders.
+
+---
+
+## Step 6: Create and Execute a Distribution
+
+1. In the frontend, select the imported asset
+2. Click **New Distribution**
+3. Set the distribution amount and payment token (USDC)
+4. Review the list of holders and their proportional amounts
+5. Click **Execute Payout**
+
+The backend will batch the payments via the Distributions contract and submit transactions to Hedera Testnet. You can monitor progress in the backend logs and verify transactions on Hashscan.
+
+---
+
+## Troubleshooting
+
+### Backend fails to start after rebuilding contracts
+
+The backend depends on generated ABIs from the contracts build. If you change contracts, rebuild in the correct order (Step 1) before restarting the backend.
+
+### Distribution SC shows no balance after faucet
+
+- Confirm the faucet transaction was on **Hedera Testnet** (not another network)
+- Wait ~10 seconds for Mirror Node indexing, then refresh Hashscan
+- Ensure you used the **Distributions SC** address, not the token contract address
+
+### Holders not appearing after import
+
+Tokens must be minted to holder addresses in ATS before importing. Re-mint in ATS, then click **Sync Holders** in the Mass Payout asset details page.

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -10,6 +10,6 @@ Technical references and guides for the Asset Tokenization Studio project.
 
 ## Contents
 
-### [Guides](./guides/)
+### [Guides](./guides/ci-cd-workflows)
 
 Additional technical guides and references.


### PR DESCRIPTION
## Description

Fixes broken links in the docs build and adds missing Mass Payout documentation.

### Broken links fixed (`apps/docs` build was failing with `onBrokenLinks: "throw"`)

- **`docs/ats/developer-guides/contracts/documenting-contracts.md`**: Removed a hyperlink pointing to `/docs/references/api` — the path was wrong (base is `/references/`, not `/docs/references/`) and the `api/` folder does not exist yet (it is generated by a Hardhat script).
- **`docs/references/index.md`**: Changed `./guides/` to `./guides/ci-cd-workflows` — Docusaurus cannot resolve a link to a directory without an `index.md` inside it.

### New documentation: Mass Payout testnet end-to-end walkthrough

Added `docs/mass-payout/getting-started/testnet-end-to-end.md` — a step-by-step guide covering the full local development flow that was previously undocumented:

1. Correct build order including ATS dependencies (`ats:contracts:build` must run before `mass-payout:contracts:build`)
2. Starting the local stack (Docker + backend in debug mode + frontend)
3. Creating a test asset via the ATS staging environment
4. Importing the asset into the local Mass Payout frontend
5. Funding the Distributions SC with test USDC via the Circle faucet
6. Verifying the balance on Hashscan and executing the distribution

Also fixed the build order in `full-setup.md`, which previously omitted the required `ats:contracts:build` step, and registered the new doc in the sidebar and Getting Started index page.


## Testing

Verified the Docusaurus build passes with no broken links:

```bash
npm run build --workspace=apps/docs
```


## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
