### PR TITLE
feat: sdk and mass payout voting

### DIFF
--- a/.changeset/voting-facet-sdk-masspayout.md
+++ b/.changeset/voting-facet-sdk-masspayout.md
@@ -1,0 +1,7 @@
+---
+"@hashgraph/asset-tokenization-sdk": patch
+"@hashgraph/mass-payout-contracts": patch
+"@hashgraph/mass-payout-backend": patch
+---
+
+Migrated all voting operations in the SDK from `Equity__factory` to the new `VotingFacet__factory`, aligning with the contract refactor that split voting logic into a dedicated `VotingFacet`. Updated mass-payout contracts to import `IVoting` for voting structs/methods and `ICoupon` for coupon holders, and updated the backend adapter and tests to use `CouponToken` instead of `BondToken` for `getAllCoupons` and `getTotalCouponHolders`.

--- a/apps/mass-payout/backend/src/infrastructure/adapters/on-chain-distribution.repository.ts
+++ b/apps/mass-payout/backend/src/infrastructure/adapters/on-chain-distribution.repository.ts
@@ -7,6 +7,7 @@ import { Asset } from "@domain/model/asset"
 import { CorporateActionId } from "@domain/model/value-objects/corporate-action-id"
 import {
   Bond,
+  Coupon,
   Equity,
   Security,
   GetAllCouponsRequest,
@@ -50,7 +51,7 @@ export class OnChainDistributionRepository implements OnChainDistributionReposit
           securityId: tokenId,
           couponId: corporateActionId,
         })
-        return await Bond.getTotalCouponHolders(couponRequest)
+        return await Coupon.getTotalCouponHolders(couponRequest)
       }
 
       case AssetType.EQUITY: {
@@ -88,7 +89,7 @@ export class OnChainDistributionRepository implements OnChainDistributionReposit
 
   private async getCouponsForAsset(asset: Asset): Promise<Distribution[]> {
     const request = new GetAllCouponsRequest({ securityId: asset.hederaTokenAddress })
-    const coupons = await Bond.getAllCoupons(request)
+    const coupons = await Coupon.getAllCoupons(request)
     const now = new Date()
 
     const futureCoupons = coupons

--- a/apps/mass-payout/backend/test/unit/infrastructure/adapters/on-chain-distribution.repository.spec.ts
+++ b/apps/mass-payout/backend/test/unit/infrastructure/adapters/on-chain-distribution.repository.spec.ts
@@ -4,7 +4,7 @@ import { OnChainDistributionRepository } from "@infrastructure/adapters/on-chain
 import { AssetType } from "@domain/model/asset-type.enum"
 import { Asset } from "@domain/model/asset"
 import { CorporateActionDetails, DistributionType, PayoutSubtype, AmountType } from "@domain/model/distribution"
-import { Bond, Equity } from "@hashgraph/asset-tokenization-sdk"
+import { Coupon, Equity } from "@hashgraph/asset-tokenization-sdk"
 import { AssetUtils } from "@test/shared/asset.utils"
 import { DistributionUtils } from "@test/shared/distribution.utils"
 import { CorporateActionId } from "@domain/model/value-objects/corporate-action-id"
@@ -12,7 +12,8 @@ import { SnapshotId } from "@domain/model/value-objects/snapshot-id"
 import { faker } from "@faker-js/faker"
 
 jest.mock("@hashgraph/asset-tokenization-sdk", () => ({
-  Bond: {
+  Bond: {},
+  Coupon: {
     getAllCoupons: jest.fn(),
     getTotalCouponHolders: jest.fn(),
   },
@@ -30,7 +31,7 @@ jest.mock("@hashgraph/asset-tokenization-sdk", () => ({
   GetTotalTokenHoldersAtSnapshotRequest: jest.fn(),
 }))
 
-const mockBond = Bond as jest.Mocked<typeof Bond>
+const mockCoupon = Coupon as jest.Mocked<typeof Coupon>
 const mockEquity = Equity as jest.Mocked<typeof Equity>
 import { Security } from "@hashgraph/asset-tokenization-sdk"
 const mockSecurity = Security as jest.Mocked<typeof Security>
@@ -63,11 +64,11 @@ describe(OnChainDistributionRepository.name, () => {
           isDisabled: false,
         },
       ]
-      mockBond.getAllCoupons.mockResolvedValue(mockCoupons)
+      mockCoupon.getAllCoupons.mockResolvedValue(mockCoupons)
 
       await repository.getAllDistributionsByAsset(bondAsset)
 
-      expect(mockBond.getAllCoupons).toHaveBeenCalledWith(expect.any(Object))
+      expect(mockCoupon.getAllCoupons).toHaveBeenCalledWith(expect.any(Object))
     })
 
     it("should call getDividendsForAsset for EQUITY assets", async () => {
@@ -129,7 +130,7 @@ describe(OnChainDistributionRepository.name, () => {
           isDisabled: false,
         },
       ]
-      mockBond.getAllCoupons.mockResolvedValue(mockCoupons)
+      mockCoupon.getAllCoupons.mockResolvedValue(mockCoupons)
 
       const result = await repository.getAllDistributionsByAsset(bondAsset)
 
@@ -158,7 +159,7 @@ describe(OnChainDistributionRepository.name, () => {
           isDisabled: false,
         },
       ]
-      mockBond.getAllCoupons.mockResolvedValue(mockCoupons)
+      mockCoupon.getAllCoupons.mockResolvedValue(mockCoupons)
 
       const result = await repository.getAllDistributionsByAsset(bondAsset)
 
@@ -166,7 +167,7 @@ describe(OnChainDistributionRepository.name, () => {
     })
 
     it("should return empty array when no coupons exist", async () => {
-      mockBond.getAllCoupons.mockResolvedValue([])
+      mockCoupon.getAllCoupons.mockResolvedValue([])
 
       const result = await repository.getAllDistributionsByAsset(bondAsset)
 
@@ -217,7 +218,7 @@ describe(OnChainDistributionRepository.name, () => {
           isDisabled: false,
         },
       ]
-      mockBond.getAllCoupons.mockResolvedValue(mockCoupons)
+      mockCoupon.getAllCoupons.mockResolvedValue(mockCoupons)
 
       const result = await repository.getAllDistributionsByAsset(bondAsset)
 
@@ -349,7 +350,7 @@ describe(OnChainDistributionRepository.name, () => {
         },
       })
       const expectedCount = 250
-      mockBond.getTotalCouponHolders.mockResolvedValue(expectedCount)
+      mockCoupon.getTotalCouponHolders.mockResolvedValue(expectedCount)
 
       const result = await repository.getHoldersCountForCorporateActionId(distribution)
 

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -64,6 +64,7 @@ import {
   KpiLinkedRate__factory,
   ScheduledCouponListingFacet__factory,
   NominalValue__factory,
+  VotingFacet__factory,
 } from "@hashgraph/asset-tokenization-contracts";
 import { ScheduledSnapshot } from "@domain/context/security/ScheduledSnapshot";
 import { VotingRights } from "@domain/context/equity/VotingRights";
@@ -428,7 +429,7 @@ export class RPCQueryAdapter {
   async getVotingFor(address: EvmAddress, target: EvmAddress, voting: number): Promise<VotingFor> {
     LogService.logTrace(`Getting voting for`);
 
-    const votingFor = await this.connect(Equity__factory, address.toString()).getVotingFor(voting, target.toString());
+    const votingFor = await this.connect(VotingFacet__factory, address.toString()).getVotingFor(voting, target.toString());
 
     return new VotingFor(new BigDecimal(votingFor.tokenBalance), Number(votingFor.decimals), votingFor.isDisabled);
   }
@@ -436,7 +437,7 @@ export class RPCQueryAdapter {
   async getVoting(address: EvmAddress, voting: number): Promise<VotingRights> {
     LogService.logTrace(`Getting voting`);
 
-    const { registeredVoting_, isDisabled_ } = await this.connect(Equity__factory, address.toString()).getVoting(
+    const { registeredVoting_, isDisabled_ } = await this.connect(VotingFacet__factory, address.toString()).getVoting(
       voting,
     );
 
@@ -451,7 +452,7 @@ export class RPCQueryAdapter {
   async getVotingsCount(address: EvmAddress): Promise<number> {
     LogService.logTrace(`Getting votings count`);
 
-    const votingsCount = await this.connect(Equity__factory, address.toString()).getVotingCount();
+    const votingsCount = await this.connect(VotingFacet__factory, address.toString()).getVotingCount();
 
     return Number(votingsCount);
   }
@@ -1439,13 +1440,13 @@ export class RPCQueryAdapter {
 
   async getVotingHolders(address: EvmAddress, voteId: number, start: number, end: number): Promise<string[]> {
     LogService.logTrace(`Getting voting holders for vote ${voteId} for security ${address.toString()}`);
-    return await this.connect(Equity__factory, address.toString()).getVotingHolders(voteId, start, end);
+    return await this.connect(VotingFacet__factory, address.toString()).getVotingHolders(voteId, start, end);
   }
 
   async getTotalVotingHolders(address: EvmAddress, voteId: number): Promise<number> {
     LogService.logTrace(`Getting total voting holders for vote ${voteId} for security ${address.toString()}`);
 
-    const total = await this.connect(Equity__factory, address.toString()).getTotalVotingHolders(voteId);
+    const total = await this.connect(VotingFacet__factory, address.toString()).getTotalVotingHolders(voteId);
 
     return Number(total);
   }

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -83,6 +83,8 @@ import {
   HoldTokenHolderFacet__factory,
   ICoupon,
   IEquity,
+  IVoting,
+  VotingFacet__factory,
   KpiLinkedRate__factory,
   Kpis__factory,
   KycFacet__factory,
@@ -611,13 +613,13 @@ export class RPCTransactionAdapter extends TransactionAdapter {
       `equity: ${security} ,
       recordDate :${recordDate} , `,
     );
-    const votingStruct: IEquity.VotingStruct = {
+    const votingStruct: IVoting.VotingStruct = {
       recordDate: recordDate.toBigInt(),
       data: data,
     };
 
     return this.executeTransaction(
-      Equity__factory.connect(security.toString(), this.getSignerOrProvider()),
+      VotingFacet__factory.connect(security.toString(), this.getSignerOrProvider()),
       "setVoting",
       [votingStruct],
       GAS.SET_VOTING_RIGHTS,
@@ -682,7 +684,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     LogService.logTrace(`Cancelling voting: ${votingId} for equity: ${security}`);
 
     return this.executeTransaction(
-      Equity__factory.connect(security.toString(), this.getSignerOrProvider()),
+      VotingFacet__factory.connect(security.toString(), this.getSignerOrProvider()),
       "cancelVoting",
       [votingId],
       GAS.CANCEL_VOTING,

--- a/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
+++ b/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
@@ -15,6 +15,7 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { ISnapshots } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_1/snapshot/ISnapshots.sol";
 import { IBond } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBond.sol";
 import { IBondRead } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondRead.sol";
+import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
 import { IEquity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/equity/IEquity.sol";
 import { ISecurity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/security/ISecurity.sol";
 import { _PERCENTAGE_DECIMALS_SIZE } from "./constants/values.sol";
@@ -727,7 +728,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
         if (_assetType == ILifeCycleCashFlow.AssetType.Equity) {
             return IEquity(_asset).getDividendHolders(_distributionID, _pageIndex, _pageLength);
         } else {
-            return IBondRead(_asset).getCouponHolders(_distributionID, _pageIndex, _pageLength);
+            return ICoupon(_asset).getCouponHolders(_distributionID, _pageIndex, _pageLength);
         }
     }
 
@@ -810,7 +811,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
         address _holder,
         uint8 _paymentTokenDecimals
     ) private view returns (uint256 amount) {
-        IBondRead.CouponAmountFor memory couponAmountFor = IBondRead(_asset).getCouponAmountFor(_couponID, _holder);
+        ICoupon.CouponAmountFor memory couponAmountFor = ICoupon(_asset).getCouponAmountFor(_couponID, _holder);
         return (couponAmountFor.numerator * 10 ** _paymentTokenDecimals) / couponAmountFor.denominator;
     }
 
@@ -864,7 +865,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
             (IEquity.RegisteredDividend memory registeredDividend_, ) = IEquity(_asset).getDividend(_distributionID);
             return registeredDividend_.dividend.executionDate;
         } else {
-            (IBondRead.RegisteredCoupon memory registeredCoupon_, ) = IBondRead(_asset).getCoupon(_distributionID);
+            (ICoupon.RegisteredCoupon memory registeredCoupon_, ) = ICoupon(_asset).getCoupon(_distributionID);
             return registeredCoupon_.coupon.executionDate;
         }
     }

--- a/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
+++ b/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
@@ -125,6 +125,10 @@ contract AssetMock is IAssetMock {
         couponFor_.coupon.rateDecimals = 1;
     }
 
+    function getCouponsFor(uint256, uint256, uint256) external pure returns (CouponFor[] memory, address[] memory) {
+        revert NotImplemented();
+    }
+
     function getCouponCount() external pure returns (uint256) {
         revert NotImplemented();
     }

--- a/packages/mass-payout/contracts/contracts/test/testAsset/interfaces/IAssetMock.sol
+++ b/packages/mass-payout/contracts/contracts/test/testAsset/interfaces/IAssetMock.sol
@@ -5,9 +5,11 @@ pragma solidity 0.8.22;
 
 import { IBond } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBond.sol";
 import { IBondRead } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondRead.sol";
+import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
 import { IERC20 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_1/ERC1400/ERC20/IERC20.sol";
 import { IEquity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/equity/IEquity.sol";
+import { IVoting } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/voting/IVoting.sol";
 
-interface IAssetMock is IBond, IBondRead, IEquity, IERC20 {
+interface IAssetMock is IBond, IBondRead, ICoupon, IEquity, IVoting, IERC20 {
     error NotImplemented();
 }


### PR DESCRIPTION
## Description

<!--
Clearly explain **what** changes you made and **why** they were needed.

Start with a brief summary of the change and its motivation, linking to any relevant issue(s).
Explain the context or problem being solved, the approach taken, and any dependencies introduced.

Focus on *what* and *why* rather than *how*, but you can briefly note implementation details if they help reviewers understand the impact.

Example: Added a reusable Button component to unify UI styling and improve accessibility across forms.

Fixes #(issue)
-->

This pull request refactors the handling of coupon-related functionality in both the backend TypeScript code and Solidity smart contracts. The main change is to move coupon operations from the `Bond`/`BondRead` interfaces to the new `Coupon`/`ICoupon` interfaces, improving code clarity and aligning with updated domain models. Corresponding updates are made to tests and contract mocks.

**Backend Refactoring:**

* Switched from using the `Bond` class to the `Coupon` class for coupon-related operations (`getAllCoupons`, `getTotalCouponHolders`) in `on-chain-distribution.repository.ts` and updated all related imports and method calls. [[1]](diffhunk://#diff-e3e5c52473a8906c83b836aeb73f3491e98a23c2251cd3b7bb7ca0d6e93f2980R10) [[2]](diffhunk://#diff-e3e5c52473a8906c83b836aeb73f3491e98a23c2251cd3b7bb7ca0d6e93f2980L53-R54) [[3]](diffhunk://#diff-e3e5c52473a8906c83b836aeb73f3491e98a23c2251cd3b7bb7ca0d6e93f2980L91-R92)
* Updated unit tests to mock and verify `Coupon` methods instead of `Bond` methods, ensuring tests align with the new implementation. [[1]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL7-R16) [[2]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL33-R34) [[3]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL66-R71) [[4]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL132-R133) [[5]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL161-R170) [[6]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL220-R221) [[7]](diffhunk://#diff-404460d9853ff9ef462bb459cd5d5424feb9b3e6e4085ec0ef32a674806c191eL352-R353)

**Smart Contract Refactoring:**

* Updated the `LifeCycleCashFlowStorageWrapper` contract to use the `ICoupon` interface for coupon-related queries (e.g., `getCouponHolders`, `getCouponAmountFor`, `getCoupon`), replacing previous usage of `IBondRead`. [[1]](diffhunk://#diff-fccded4657cb14a86ac90b4e20b2e01b97d33f604d232773a7a1247c705dd3e2R18) [[2]](diffhunk://#diff-fccded4657cb14a86ac90b4e20b2e01b97d33f604d232773a7a1247c705dd3e2L730-R731) [[3]](diffhunk://#diff-fccded4657cb14a86ac90b4e20b2e01b97d33f604d232773a7a1247c705dd3e2L813-R814) [[4]](diffhunk://#diff-fccded4657cb14a86ac90b4e20b2e01b97d33f604d232773a7a1247c705dd3e2L867-R868)
* Extended the `IAssetMock` interface and the `AssetMock` contract to implement the new `ICoupon` interface, and added a stub for `getCouponsFor`. [[1]](diffhunk://#diff-5d0bb0ff154886b7fc4c24bc1022fb57cb67a0113ce825fe921577f1e9fcd6d0R8-R13) [[2]](diffhunk://#diff-781ae0b04690912a864a46e06fdfe1bb64e0790196e1b1aaa609dea29c25d94cR128-R131)

These changes collectively ensure that coupon logic is clearly separated from bond logic, following the latest domain boundaries and improving maintainability.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
