### PR TITLE
feat: port coupon facet split (add93355) onto lib-diamond migration

### DIFF
--- a/apps/ats/web/src/services/SDKService.ts
+++ b/apps/ats/web/src/services/SDKService.ts
@@ -4,6 +4,7 @@ import {
   ApplyRolesRequest,
   BalanceViewModel,
   Bond,
+  Coupon,
   BondDetailsViewModel,
   ConnectRequest,
   ControlListRequest,
@@ -181,6 +182,11 @@ import {
   GetProceedRecipientDataRequest,
   DividendAmountForViewModel,
   FullRedeemAtMaturityRequest,
+  CancelCouponRequest,
+  GetCouponsForRequest,
+  GetCouponFromOrderedListAtRequest,
+  GetCouponsOrderedListRequest,
+  GetCouponsOrderedListTotalRequest,
 } from "@hashgraph/asset-tokenization-sdk";
 
 export class SDKService {
@@ -396,16 +402,16 @@ export class SDKService {
 
   // COUPONS ////////////////////////////////////////////
   public static async setCoupon(req: SetCouponRequest): Promise<number> {
-    const response = await Bond.setCoupon(req);
+    const response = await Coupon.setCoupon(req);
     return response.payload;
   }
 
   public static async getCouponFor(req: GetCouponForRequest): Promise<CouponForViewModel> {
-    return await Bond.getCouponFor(req);
+    return await Coupon.getCouponFor(req);
   }
 
   public static async getCouponAmountFor(req: GetCouponForRequest): Promise<CouponAmountForViewModel> {
-    return await Bond.getCouponAmountFor(req);
+    return await Coupon.getCouponAmountFor(req);
   }
 
   public static async getPrincipalFor(req: GetPrincipalForRequest): Promise<PrincipalForViewModel> {
@@ -413,19 +419,42 @@ export class SDKService {
   }
 
   public static async getCoupon(req: GetCouponRequest): Promise<CouponViewModel> {
-    return await Bond.getCoupon(req);
+    return await Coupon.getCoupon(req);
   }
 
   public static async getAllCoupons(req: GetAllCouponsRequest): Promise<CouponViewModel[]> {
-    return await Bond.getAllCoupons(req);
+    return await Coupon.getAllCoupons(req);
   }
 
   public static async getCouponHolders(req: GetCouponHoldersRequest): Promise<string[]> {
-    return await Bond.getCouponHolders(req);
+    return await Coupon.getCouponHolders(req);
   }
 
   public static async getTotalCouponHolders(req: GetTotalCouponHoldersRequest): Promise<number> {
-    return await Bond.getTotalCouponHolders(req);
+    return await Coupon.getTotalCouponHolders(req);
+  }
+
+  public static async cancelCoupon(req: CancelCouponRequest): Promise<boolean> {
+    const response = await Coupon.cancelCoupon(req);
+    return response.payload;
+  }
+
+  public static async getCouponsFor(
+    req: GetCouponsForRequest,
+  ): Promise<{ coupons: CouponForViewModel[]; accounts: string[] }> {
+    return await Coupon.getCouponsFor(req);
+  }
+
+  public static async getCouponsOrderedList(req: GetCouponsOrderedListRequest): Promise<number[]> {
+    return await Coupon.getCouponsOrderedList(req);
+  }
+
+  public static async getCouponsOrderedListTotal(req: GetCouponsOrderedListTotalRequest): Promise<number> {
+    return await Coupon.getCouponsOrderedListTotal(req);
+  }
+
+  public static async getCouponFromOrderedListAt(req: GetCouponFromOrderedListAtRequest): Promise<number> {
+    return await Coupon.getCouponFromOrderedListAt(req);
   }
 
   // ROLES ////////////////////////////////////////////

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -560,6 +560,18 @@ bytes32 constant _SCHEDULED_COUPON_LISTING_KPI_LINKED_RATE_RESOLVER_KEY = 0x9f42
 // keccak256("security.token.standard.scheduled.couponListing.SustainabilityPerformanceTarget.rate.resolverKey")
 bytes32 constant _SCHEDULED_COUPON_LISTING_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY = 0x85c0dee450a5a4657a9de39ca4ba19881b079d55d5bb64641d52f59bea709ba8;
 
+// keccak256('security.token.standard.coupon.variable.rate.resolverKey');
+bytes32 constant _COUPON_RESOLVER_KEY = 0xa404f705370f56f56364ac9aa1092c1002b2bfcd7020c1bb5ca7489f8061efa7;
+
+// keccak256('security.token.standard.coupon.fixed.rate.resolverKey');
+bytes32 constant _COUPON_FIXED_RATE_RESOLVER_KEY = 0x2e0b1146e97bc72f92441d75c9cfa74185548319741c7f292fe0014252933ae9;
+
+// keccak256('security.token.standard.coupon.kpilinked.rate.resolverKey');
+bytes32 constant _COUPON_KPI_LINKED_RATE_RESOLVER_KEY = 0x45f4a1774eac5a47f3cbc755bf5332ca30d8a6bb0330d479c77590dd0d5aab18;
+
+// keccak256('security.token.standard.coupon.SustainabilityPerformanceTarget.rate.resolverKey');
+bytes32 constant _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY = 0x435034f1d262736f434867e5f70c71157492ebd5a90e9e4455b2868f5bda6b6e;
+
 // keccak256('security.token.standard.scheduled.tasks.resolverKey');
 bytes32 constant _SCHEDULED_TASKS_RESOLVER_KEY = 0xa4934195ab83f1497ce5fc99b68d0f41694716bcfba5f232aa6c8e0d4d504f08;
 

--- a/packages/ats/contracts/contracts/constants/storagePositions.sol
+++ b/packages/ats/contracts/contracts/constants/storagePositions.sol
@@ -40,6 +40,9 @@ bytes32 constant _SCHEDULED_BALANCE_ADJUSTMENTS_STORAGE_POSITION = 0xaf4aaa3de47
 // keccak256('security.token.standard.scheduledCouponListing.storage');
 bytes32 constant _SCHEDULED_COUPON_LISTING_STORAGE_POSITION = 0x020cecc946ba57a1f8569220f46e5763939a3e864a1a4064efc2be63a845635a;
 
+// keccak256('security.token.standard.coupon.storage');
+bytes32 constant _COUPON_STORAGE_POSITION = 0x79c5b8f4968a14226894648408bdac3dd5ca35b5a2c206fad6dbd1aa25b6a774;
+
 // keccak256('security.token.standard.scheduledCrossOrderedTasks.storage');
 bytes32 constant _SCHEDULED_CROSS_ORDERED_TASKS_STORAGE_POSITION = 0x07c301a048b8fa80688acfab6d93f7e94a43ce454031a02cdd132b92ca943a70;
 

--- a/packages/ats/contracts/contracts/domain/asset/BondStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/BondStorageWrapper.sol
@@ -1,26 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {
-    COUPON_CORPORATE_ACTION_TYPE,
-    COUPON_LISTING_TASK_TYPE,
-    SNAPSHOT_RESULT_ID,
-    SNAPSHOT_TASK_TYPE
-} from "../../constants/values.sol";
-import { CorporateActionsStorageWrapper } from "../core/CorporateActionsStorageWrapper.sol";
-import { ERC1410StorageWrapper } from "./ERC1410StorageWrapper.sol";
 import { ERC20StorageWrapper } from "./ERC20StorageWrapper.sol";
 import { ERC3643StorageWrapper } from "../core/ERC3643StorageWrapper.sol";
-import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
-import { IBond } from "../../facets/layer_2/bond/IBond.sol";
 import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
-import { InterestRateStorageWrapper } from "./InterestRateStorageWrapper.sol";
-import { KpiLinkedRateLib } from "./KpiLinkedRateLib.sol";
 import { NominalValueStorageWrapper } from "./nominalValue/NominalValueStorageWrapper.sol";
-import { Pagination } from "../../infrastructure/utils/Pagination.sol";
-import { ScheduledTasksStorageWrapper } from "./ScheduledTasksStorageWrapper.sol";
-import { SnapshotsStorageWrapper } from "./SnapshotsStorageWrapper.sol";
-import { SustainabilityPerformanceTargetRateLib } from "./SustainabilityPerformanceTargetRateLib.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { _BOND_STORAGE_POSITION } from "../../constants/storagePositions.sol";
 
@@ -39,7 +23,14 @@ library BondStorageWrapper {
         /// @deprecated Kept for storage layout compatibility. Use NominalValueStorageWrapper instead.
         // solhint-disable-next-line var-name-mixedcase
         uint8 DEPRECATED_nominalValueDecimals;
-        uint256[] couponsOrderedListByIds;
+        /// @deprecated Kept for storage layout compatibility. Use CouponStorageWrapper instead.
+        // solhint-disable-next-line var-name-mixedcase
+        uint256[] DEPRECATED_couponsOrderedListByIds;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function DEPRECATED_pushCouponOrderedListId(uint256 couponID) internal {
+        _bondStorage().DEPRECATED_couponsOrderedListByIds.push(couponID);
     }
 
     // solhint-disable-next-line func-name-mixedcase
@@ -51,66 +42,8 @@ library BondStorageWrapper {
         bs.maturityDate = bondDetailsData.maturityDate;
     }
 
-    function setCoupon(
-        IBondTypes.Coupon memory newCoupon
-    ) internal returns (bytes32 corporateActionId_, uint256 couponID_) {
-        (corporateActionId_, couponID_) = CorporateActionsStorageWrapper.addCorporateAction(
-            COUPON_CORPORATE_ACTION_TYPE,
-            abi.encode(newCoupon)
-        );
-
-        initCoupon(corporateActionId_, newCoupon);
-
-        emit IBondTypes.CouponSet(corporateActionId_, couponID_, EvmAccessors.getMsgSender(), newCoupon);
-    }
-
-    function cancelCoupon(uint256 couponId) internal returns (bool success_) {
-        IBondTypes.RegisteredCoupon memory registeredCoupon;
-        bytes32 corporateActionId;
-        (registeredCoupon, corporateActionId, ) = getCoupon(couponId);
-        if (registeredCoupon.coupon.executionDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
-            revert IBond.CouponAlreadyExecuted(corporateActionId, couponId);
-        }
-        CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
-        success_ = true;
-    }
-
-    function initCoupon(bytes32 actionId, IBondTypes.Coupon memory newCoupon) internal {
-        if (actionId == bytes32(0)) {
-            revert IBondTypes.CouponCreationFailed();
-        }
-
-        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newCoupon.recordDate, SNAPSHOT_TASK_TYPE);
-        ScheduledTasksStorageWrapper.addScheduledSnapshot(newCoupon.recordDate, actionId);
-
-        // For fixing date rate bonds, add coupon listing task
-        if (newCoupon.fixingDate == 0) return;
-        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newCoupon.fixingDate, COUPON_LISTING_TASK_TYPE);
-        ScheduledTasksStorageWrapper.addScheduledCouponListing(newCoupon.fixingDate, actionId);
-    }
-
     function setMaturityDate(uint256 maturityDate) internal {
         _bondStorage().maturityDate = maturityDate;
-    }
-
-    function addToCouponsOrderedList(uint256 couponID) internal {
-        _bondStorage().couponsOrderedListByIds.push(couponID);
-    }
-
-    function updateCouponRate(
-        uint256 couponID,
-        IBondTypes.Coupon memory coupon,
-        uint256 rate,
-        uint8 rateDecimals
-    ) internal {
-        coupon.rate = rate;
-        coupon.rateDecimals = rateDecimals;
-        coupon.rateStatus = IBondTypes.RateCalculationStatus.SET;
-
-        CorporateActionsStorageWrapper.updateCorporateActionData(
-            CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(COUPON_CORPORATE_ACTION_TYPE, couponID - 1),
-            abi.encode(coupon)
-        );
     }
 
     /// @dev DEPRECATED – MIGRATION: Remove this function and the DEPRECATED_ fields from
@@ -132,6 +65,16 @@ library BondStorageWrapper {
         nominalValue_ = _bondStorage().DEPRECATED_nominalValue;
     }
 
+    // solhint-disable-next-line func-name-mixedcase
+    function DEPRECATED_getCouponsOrderedListTotal() internal view returns (uint256) {
+        return _bondStorage().DEPRECATED_couponsOrderedListByIds.length;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function DEPRECATED_getCouponsOrderedListByPosition(uint256 position) internal view returns (uint256) {
+        return _bondStorage().DEPRECATED_couponsOrderedListByIds[position];
+    }
+
     function getDeprecatedNominalValueDecimals() internal view returns (uint8 nominalValueDecimals_) {
         nominalValueDecimals_ = _bondStorage().DEPRECATED_nominalValueDecimals;
     }
@@ -151,98 +94,6 @@ library BondStorageWrapper {
         return _bondStorage().maturityDate;
     }
 
-    function getCoupon(
-        uint256 couponID
-    )
-        internal
-        view
-        returns (IBondTypes.RegisteredCoupon memory registeredCoupon_, bytes32 corporateActionId_, bool isDisabled_)
-    {
-        corporateActionId_ = CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(
-            COUPON_CORPORATE_ACTION_TYPE,
-            couponID - 1
-        );
-
-        bytes memory data;
-        (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
-
-        if (data.length > 0) {
-            registeredCoupon_.coupon = abi.decode(data, (IBondTypes.Coupon));
-        }
-
-        registeredCoupon_.snapshotId = CorporateActionsStorageWrapper.getUintResultAt(
-            corporateActionId_,
-            SNAPSHOT_RESULT_ID
-        );
-
-        if (
-            InterestRateStorageWrapper.isFixedRateInitialized() ||
-            registeredCoupon_.coupon.fixingDate == 0 ||
-            registeredCoupon_.coupon.rateStatus == IBondTypes.RateCalculationStatus.SET ||
-            registeredCoupon_.coupon.fixingDate > TimeTravelStorageWrapper.getBlockTimestamp()
-        ) return (registeredCoupon_, corporateActionId_, isDisabled_);
-
-        // Calculate SPT rate on-the-fly if needed (similar to _getCouponAdjustedAt pattern in inheritance-based impl)
-        // This ensures the rate is available when getCoupon is called, not just during scheduled task triggers
-        if (InterestRateStorageWrapper.isSustainabilityPerformanceTargetRateInitialized()) {
-            (
-                registeredCoupon_.coupon.rate,
-                registeredCoupon_.coupon.rateDecimals
-            ) = SustainabilityPerformanceTargetRateLib.calculateSustainabilityPerformanceTargetInterestRate(
-                couponID,
-                registeredCoupon_.coupon
-            );
-            registeredCoupon_.coupon.rateStatus = IBondTypes.RateCalculationStatus.SET;
-            return (registeredCoupon_, corporateActionId_, isDisabled_);
-        }
-        // Calculate KPI Linked rate on-the-fly if needed
-        (registeredCoupon_.coupon.rate, registeredCoupon_.coupon.rateDecimals) = KpiLinkedRateLib
-            .calculateKpiLinkedInterestRate(couponID, registeredCoupon_.coupon);
-        registeredCoupon_.coupon.rateStatus = IBondTypes.RateCalculationStatus.SET;
-    }
-
-    function getCouponFor(
-        uint256 couponID,
-        address account
-    ) internal view returns (IBondTypes.CouponFor memory couponFor_) {
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , bool isDisabled) = getCoupon(couponID);
-
-        couponFor_.coupon = registeredCoupon.coupon;
-        couponFor_.isDisabled = isDisabled;
-
-        if (registeredCoupon.coupon.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return couponFor_;
-
-        couponFor_.recordDateReached = true;
-
-        couponFor_.tokenBalance = (registeredCoupon.snapshotId != 0)
-            ? SnapshotsStorageWrapper.getTotalBalanceOfAtSnapshot(registeredCoupon.snapshotId, account)
-            : ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(account, TimeTravelStorageWrapper.getBlockTimestamp());
-
-        couponFor_.decimals = ERC20StorageWrapper.decimalsAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp());
-    }
-
-    function getCouponAmountFor(
-        uint256 couponID,
-        address account
-    ) internal view returns (IBondTypes.CouponAmountFor memory couponAmountFor_) {
-        IBondTypes.CouponFor memory couponFor = getCouponFor(couponID, account);
-
-        if (!couponFor.recordDateReached) return couponAmountFor_;
-
-        IBondTypes.BondDetailsData memory bondDetails = getBondDetails();
-
-        couponAmountFor_.recordDateReached = true;
-
-        couponAmountFor_.numerator =
-            couponFor.tokenBalance *
-            bondDetails.nominalValue *
-            couponFor.coupon.rate *
-            (couponFor.coupon.endDate - couponFor.coupon.startDate);
-        couponAmountFor_.denominator =
-            10 ** (couponFor.decimals + bondDetails.nominalValueDecimals + couponFor.coupon.rateDecimals) *
-            365 days;
-    }
-
     function getPrincipalFor(address account) internal view returns (IBondTypes.PrincipalFor memory principalFor_) {
         IBondTypes.BondDetailsData memory bondDetails = getBondDetails();
 
@@ -255,98 +106,8 @@ library BondStorageWrapper {
                     bondDetails.nominalValueDecimals);
     }
 
-    function getCouponCount() internal view returns (uint256 couponCount_) {
-        return CorporateActionsStorageWrapper.getCorporateActionCountByType(COUPON_CORPORATE_ACTION_TYPE);
-    }
-
-    function getCouponHolders(
-        uint256 couponID,
-        uint256 pageIndex,
-        uint256 pageLength
-    ) internal view returns (address[] memory holders_) {
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = getCoupon(couponID);
-
-        if (registeredCoupon.coupon.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return holders_;
-
-        if (registeredCoupon.snapshotId != 0)
-            return SnapshotsStorageWrapper.tokenHoldersAt(registeredCoupon.snapshotId, pageIndex, pageLength);
-
-        return ERC1410StorageWrapper.getTokenHolders(pageIndex, pageLength);
-    }
-
-    function getTotalCouponHolders(uint256 couponID) internal view returns (uint256) {
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = getCoupon(couponID);
-
-        if (registeredCoupon.coupon.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return 0;
-
-        if (registeredCoupon.snapshotId != 0)
-            return SnapshotsStorageWrapper.totalTokenHoldersAt(registeredCoupon.snapshotId);
-
-        return ERC1410StorageWrapper.getTotalTokenHolders();
-    }
-
     function isBondInitialized() internal view returns (bool) {
         return _bondStorage().initialized;
-    }
-
-    function getCouponFromOrderedListAt(uint256 pos) internal view returns (uint256 couponID_) {
-        if (pos >= getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp())) return 0;
-
-        uint256 actualOrderedListLengthTotal = getCouponsOrderedListTotal();
-
-        if (pos < actualOrderedListLengthTotal) return _bondStorage().couponsOrderedListByIds[pos];
-
-        return
-            ScheduledTasksStorageWrapper.getScheduledCouponListingIdAtIndex(
-                ScheduledTasksStorageWrapper.getScheduledCouponListingCount() + actualOrderedListLengthTotal - 1 - pos
-            );
-    }
-
-    function getCouponsOrderedList(
-        uint256 pageIndex,
-        uint256 pageLength
-    ) internal view returns (uint256[] memory couponIDs_) {
-        (uint256 start, uint256 end) = Pagination.getStartAndEnd(pageIndex, pageLength);
-
-        couponIDs_ = new uint256[](
-            Pagination.getSize(
-                start,
-                end,
-                getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp())
-            )
-        );
-
-        uint256 length = couponIDs_.length;
-        for (uint256 i; i < length; ) {
-            unchecked {
-                couponIDs_[i] = getCouponFromOrderedListAt(start + i);
-                ++i;
-            }
-        }
-    }
-
-    function getCouponsOrderedListTotalAdjustedAt(uint256 timestamp) internal view returns (uint256 total_) {
-        return
-            getCouponsOrderedListTotal() +
-            ScheduledTasksStorageWrapper.getPendingScheduledCouponListingTotalAt(timestamp);
-    }
-
-    function getCouponsOrderedListTotal() internal view returns (uint256 total_) {
-        return _bondStorage().couponsOrderedListByIds.length;
-    }
-
-    function getPreviousCouponInOrderedList(uint256 couponID) internal view returns (uint256 previousCouponID_) {
-        uint256 orderedListLength = getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp());
-
-        if (orderedListLength < 2 || getCouponFromOrderedListAt(0) == couponID) return 0;
-
-        unchecked {
-            --orderedListLength;
-            for (uint256 index; index < orderedListLength; ) {
-                previousCouponID_ = getCouponFromOrderedListAt(index);
-                if (getCouponFromOrderedListAt(++index) == couponID) return previousCouponID_;
-            }
-        }
     }
 
     function requireValidMaturityDate(uint256 maturityDate) internal view {

--- a/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
@@ -21,7 +21,6 @@ import { SnapshotsStorageWrapper } from "./SnapshotsStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "./ERC1410StorageWrapper.sol";
 import { ERC20StorageWrapper } from "./ERC20StorageWrapper.sol";
 import { ERC3643StorageWrapper } from "../core/ERC3643StorageWrapper.sol";
-import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 

--- a/packages/ats/contracts/contracts/domain/asset/KpiLinkedRateLib.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpiLinkedRateLib.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
+import { ICouponTypes } from "../../facets/layer_2/coupon/ICouponTypes.sol";
 import { InterestRateStorageWrapper, KpiLinkedRateDataStorage } from "./InterestRateStorageWrapper.sol";
 import { KpisStorageWrapper } from "./KpisStorageWrapper.sol";
 import { ProceedRecipientsStorageWrapper } from "./ProceedRecipientsStorageWrapper.sol";
-import { BondStorageWrapper } from "./BondStorageWrapper.sol";
+import { CouponStorageWrapper } from "./coupon/CouponStorageWrapper.sol";
 import { DecimalsLib } from "../../infrastructure/utils/DecimalsLib.sol";
 import { KPI_LINKED_RATE_COUPON } from "../../constants/values.sol";
 import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
@@ -37,7 +37,7 @@ library KpiLinkedRateLib {
      */
     function calculateKpiLinkedInterestRate(
         uint256 couponID,
-        IBondTypes.Coupon memory coupon
+        ICouponTypes.Coupon memory coupon
     ) internal view returns (uint256 rate_, uint8 rateDecimals_) {
         KpiLinkedRateDataStorage memory kpiData = InterestRateStorageWrapper.kpiLinkedRateStorage();
 
@@ -107,17 +107,17 @@ library KpiLinkedRateLib {
      * @return rateDecimals_ The decimals of the previous coupon rate.
      */
     function _previousRate(uint256 couponID) private view returns (uint256 rate_, uint8 rateDecimals_) {
-        uint256 previousCouponId = BondStorageWrapper.getPreviousCouponInOrderedList(couponID);
+        uint256 previousCouponId = CouponStorageWrapper.getPreviousCouponInOrderedList(couponID);
 
         if (previousCouponId == 0) {
             return (0, 0);
         }
 
-        (IBondTypes.RegisteredCoupon memory previousCoupon, , ) = BondStorageWrapper.getCoupon(previousCouponId);
+        (ICouponTypes.RegisteredCoupon memory previousCoupon, , ) = CouponStorageWrapper.getCoupon(previousCouponId);
 
         // Previous coupon rate must be set
         _checkUnexpectedError(
-            previousCoupon.coupon.rateStatus != IBondTypes.RateCalculationStatus.SET,
+            previousCoupon.coupon.rateStatus != ICouponTypes.RateCalculationStatus.SET,
             KPI_LINKED_RATE_COUPON
         );
 

--- a/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
@@ -5,8 +5,8 @@ import { _KPIS_STORAGE_POSITION } from "../../constants/storagePositions.sol";
 import { KPI_KPIS_ADD_COUPON_DATE, KPI_KPIS_SET_MINDATE } from "../../constants/values.sol";
 import { IKpis } from "../../facets/layer_2/kpi/kpiLatest/IKpis.sol";
 import { Checkpoints } from "../../infrastructure/utils/Checkpoints.sol";
-import { BondStorageWrapper } from "./BondStorageWrapper.sol";
-import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
+import { CouponStorageWrapper } from "./coupon/CouponStorageWrapper.sol";
+import { ICouponTypes } from "../../facets/layer_2/coupon/ICouponTypes.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 
@@ -54,9 +54,9 @@ library KpisStorageWrapper {
     }
 
     function addToCouponsOrderedList(uint256 couponID) internal {
-        BondStorageWrapper.addToCouponsOrderedList(couponID);
+        CouponStorageWrapper.addToCouponsOrderedList(couponID);
 
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = BondStorageWrapper.getCoupon(couponID);
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = CouponStorageWrapper.getCoupon(couponID);
         uint256 lastFixingDate = registeredCoupon.coupon.fixingDate;
 
         _checkUnexpectedError(lastFixingDate < kpisDataStorage().minDate, KPI_KPIS_ADD_COUPON_DATE);
@@ -107,14 +107,14 @@ library KpisStorageWrapper {
     function getMinDateAdjusted() internal view returns (uint256 minDate_) {
         minDate_ = kpisDataStorage().minDate;
 
-        uint256 total = BondStorageWrapper.getCouponsOrderedListTotalAdjustedAt(
+        uint256 total = CouponStorageWrapper.getCouponsOrderedListTotalAdjustedAt(
             TimeTravelStorageWrapper.getBlockTimestamp()
         );
 
         if (total == 0) return minDate_;
 
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = BondStorageWrapper.getCoupon(
-            BondStorageWrapper.getCouponFromOrderedListAt(total - 1)
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = CouponStorageWrapper.getCoupon(
+            CouponStorageWrapper.getCouponFromOrderedListAt(total - 1)
         );
         uint256 lastFixingDate = registeredCoupon.coupon.fixingDate;
 

--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -10,7 +10,6 @@ import {
     IScheduledCrossOrderedTasks
 } from "../../facets/layer_2/scheduledTask/scheduledCrossOrderedTask/IScheduledCrossOrderedTasks.sol";
 import { IEquity } from "../../facets/layer_2/equity/IEquity.sol";
-import { IBondRead } from "../../facets/layer_2/bond/IBondRead.sol";
 import { ISnapshots } from "../../facets/layer_1/snapshot/ISnapshots.sol";
 import {
     _SCHEDULED_SNAPSHOTS_STORAGE_POSITION,
@@ -27,12 +26,12 @@ import {
 } from "../../constants/values.sol";
 import { SnapshotsStorageWrapper } from "./SnapshotsStorageWrapper.sol";
 import { AdjustBalancesStorageWrapper } from "./AdjustBalancesStorageWrapper.sol";
-import { BondStorageWrapper } from "./BondStorageWrapper.sol";
+import { CouponStorageWrapper } from "./coupon/CouponStorageWrapper.sol";
 import { CorporateActionsStorageWrapper } from "../core/CorporateActionsStorageWrapper.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { InterestRateStorageWrapper } from "./InterestRateStorageWrapper.sol";
 import { SustainabilityPerformanceTargetRateLib } from "./SustainabilityPerformanceTargetRateLib.sol";
-import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
+import { ICouponTypes } from "../../facets/layer_2/coupon/ICouponTypes.sol";
 import { KpiLinkedRateLib } from "./KpiLinkedRateLib.sol";
 
 library ScheduledTasksStorageWrapper {
@@ -352,8 +351,8 @@ library ScheduledTasksStorageWrapper {
 
         uint256 couponID = _getCouponIdFromAction(actionId);
 
-        BondStorageWrapper.addToCouponsOrderedList(couponID);
-        uint256 orderedListPos = BondStorageWrapper.getCouponsOrderedListTotal();
+        CouponStorageWrapper.addToCouponsOrderedList(couponID);
+        uint256 orderedListPos = CouponStorageWrapper.getCouponsOrderedListTotal();
 
         _updateCouponRatesIfNeeded(couponID);
 
@@ -406,13 +405,13 @@ library ScheduledTasksStorageWrapper {
     }
 
     function _updateCouponRatesIfNeeded(uint256 couponID) private {
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = BondStorageWrapper.getCoupon(couponID);
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = CouponStorageWrapper.getCoupon(couponID);
 
         if (InterestRateStorageWrapper.isSustainabilityPerformanceTargetRateInitialized()) {
             (uint256 rate, uint8 rateDecimals) = SustainabilityPerformanceTargetRateLib
                 .calculateSustainabilityPerformanceTargetInterestRate(couponID, registeredCoupon.coupon);
 
-            BondStorageWrapper.updateCouponRate(couponID, registeredCoupon.coupon, rate, rateDecimals);
+            CouponStorageWrapper.updateCouponRate(couponID, registeredCoupon.coupon, rate, rateDecimals);
         }
 
         if (InterestRateStorageWrapper.isKpiLinkedRateInitialized()) {
@@ -421,7 +420,7 @@ library ScheduledTasksStorageWrapper {
                 registeredCoupon.coupon
             );
 
-            BondStorageWrapper.updateCouponRate(couponID, registeredCoupon.coupon, rate, rateDecimals);
+            CouponStorageWrapper.updateCouponRate(couponID, registeredCoupon.coupon, rate, rateDecimals);
         }
     }
 

--- a/packages/ats/contracts/contracts/domain/asset/SustainabilityPerformanceTargetRateLib.sol
+++ b/packages/ats/contracts/contracts/domain/asset/SustainabilityPerformanceTargetRateLib.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { IBondRead } from "../../facets/layer_2/bond/IBondRead.sol";
 import {
     ISustainabilityPerformanceTargetRate
 } from "../../facets/layer_2/interestRate/sustainabilityPerformanceTargetRate/ISustainabilityPerformanceTargetRate.sol";
 import { InterestRateStorageWrapper } from "./InterestRateStorageWrapper.sol";
 import { KpisStorageWrapper } from "./KpisStorageWrapper.sol";
 import { ProceedRecipientsStorageWrapper } from "./ProceedRecipientsStorageWrapper.sol";
-import { BondStorageWrapper } from "./BondStorageWrapper.sol";
-import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
+import { CouponStorageWrapper } from "./coupon/CouponStorageWrapper.sol";
+import { ICouponTypes } from "../../facets/layer_2/coupon/ICouponTypes.sol";
 
 /**
  * @title SustainabilityPerformanceTargetRateLib
@@ -28,7 +27,7 @@ import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
 library SustainabilityPerformanceTargetRateLib {
     function calculateSustainabilityPerformanceTargetInterestRate(
         uint256 couponID,
-        IBondRead.Coupon memory coupon
+        ICouponTypes.Coupon memory coupon
     ) internal view returns (uint256, uint8) {
         ISustainabilityPerformanceTargetRate.InterestRate memory interestRate = InterestRateStorageWrapper
             .getSPTInterestRate();
@@ -131,9 +130,9 @@ library SustainabilityPerformanceTargetRateLib {
      * @return fixingDate_ The fixing date of the previous coupon in the ordered list, or 0 if this is the first coupon.
      */
     function _getPreviousFixingDate(uint256 couponID) private view returns (uint256 fixingDate_) {
-        uint256 previousCouponId = BondStorageWrapper.getPreviousCouponInOrderedList(couponID);
+        uint256 previousCouponId = CouponStorageWrapper.getPreviousCouponInOrderedList(couponID);
         if (previousCouponId == 0) return 0;
-        (IBondTypes.RegisteredCoupon memory registeredCoupon, , ) = BondStorageWrapper.getCoupon(previousCouponId);
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = CouponStorageWrapper.getCoupon(previousCouponId);
         return registeredCoupon.coupon.fixingDate;
     }
 }

--- a/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
@@ -16,8 +16,11 @@ import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 import { IBondTypes } from "../../../facets/layer_2/bond/IBondTypes.sol";
 import { ICoupon } from "../../../facets/layer_2/coupon/ICoupon.sol";
 import { ICouponTypes } from "../../../facets/layer_2/coupon/ICouponTypes.sol";
+import { InterestRateStorageWrapper } from "../InterestRateStorageWrapper.sol";
+import { KpiLinkedRateLib } from "../KpiLinkedRateLib.sol";
 import { NominalValueStorageWrapper } from "../nominalValue/NominalValueStorageWrapper.sol";
 import { Pagination } from "../../../infrastructure/utils/Pagination.sol";
+import { SustainabilityPerformanceTargetRateLib } from "../SustainabilityPerformanceTargetRateLib.sol";
 import { ScheduledTasksStorageWrapper } from "../ScheduledTasksStorageWrapper.sol";
 import { SnapshotsStorageWrapper } from "../SnapshotsStorageWrapper.sol";
 import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
@@ -48,7 +51,10 @@ library CouponStorageWrapper {
         ICouponTypes.RegisteredCoupon memory registeredCoupon;
         bytes32 corporateActionId;
         (registeredCoupon, corporateActionId, ) = getCoupon(couponId);
-        if (registeredCoupon.coupon.executionDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
+        if (
+            registeredCoupon.coupon.executionDate != 0 &&
+            registeredCoupon.coupon.executionDate <= TimeTravelStorageWrapper.getBlockTimestamp()
+        ) {
             revert ICoupon.CouponAlreadyExecuted(corporateActionId, couponId);
         }
         CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
@@ -101,13 +107,37 @@ library CouponStorageWrapper {
         bytes memory data;
         (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
 
-        require(data.length > 0, "ICouponTypes: Coupon not found");
+        if (data.length == 0) revert ICoupon.CouponNotFound(couponID);
         (registeredCoupon_.coupon) = abi.decode(data, (ICouponTypes.Coupon));
 
         registeredCoupon_.snapshotId = CorporateActionsStorageWrapper.getUintResultAt(
             corporateActionId_,
             SNAPSHOT_RESULT_ID
         );
+
+        if (
+            registeredCoupon_.coupon.fixingDate == 0 ||
+            registeredCoupon_.coupon.rateStatus == ICouponTypes.RateCalculationStatus.SET ||
+            registeredCoupon_.coupon.fixingDate > TimeTravelStorageWrapper.getBlockTimestamp()
+        ) return (registeredCoupon_, corporateActionId_, isDisabled_);
+
+        if (InterestRateStorageWrapper.isSustainabilityPerformanceTargetRateInitialized()) {
+            (
+                registeredCoupon_.coupon.rate,
+                registeredCoupon_.coupon.rateDecimals
+            ) = SustainabilityPerformanceTargetRateLib.calculateSustainabilityPerformanceTargetInterestRate(
+                couponID,
+                registeredCoupon_.coupon
+            );
+            registeredCoupon_.coupon.rateStatus = ICouponTypes.RateCalculationStatus.SET;
+            return (registeredCoupon_, corporateActionId_, isDisabled_);
+        }
+
+        if (InterestRateStorageWrapper.isKpiLinkedRateInitialized()) {
+            (registeredCoupon_.coupon.rate, registeredCoupon_.coupon.rateDecimals) = KpiLinkedRateLib
+                .calculateKpiLinkedInterestRate(couponID, registeredCoupon_.coupon);
+            registeredCoupon_.coupon.rateStatus = ICouponTypes.RateCalculationStatus.SET;
+        }
     }
 
     function getCouponFor(
@@ -229,20 +259,19 @@ library CouponStorageWrapper {
     }
 
     function getPreviousCouponInOrderedList(uint256 couponID) internal view returns (uint256 previousCouponID_) {
-        uint256 orderedListLength = getCouponsOrderedListTotal();
+        uint256 orderedListLength = getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp());
 
         if (orderedListLength < 2) return (0);
 
         if (getCouponFromOrderedListAt(0) == couponID) return (0);
 
+        orderedListLength--;
         uint256 previousCouponId = 0;
 
         for (uint256 index = 0; index < orderedListLength; index++) {
             previousCouponId = getCouponFromOrderedListAt(index);
-            if (index + 1 < orderedListLength) {
-                uint256 couponId = getCouponFromOrderedListAt(index + 1);
-                if (couponId == couponID) break;
-            }
+            uint256 couponId = getCouponFromOrderedListAt(index + 1);
+            if (couponId == couponID) break;
         }
 
         return previousCouponId;

--- a/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {
+    COUPON_CORPORATE_ACTION_TYPE,
+    COUPON_LISTING_TASK_TYPE,
+    SNAPSHOT_RESULT_ID,
+    SNAPSHOT_TASK_TYPE
+} from "../../../constants/values.sol";
+import { BondStorageWrapper } from "../BondStorageWrapper.sol";
+import { CorporateActionsStorageWrapper } from "../../core/CorporateActionsStorageWrapper.sol";
+import { ERC1410StorageWrapper } from "../ERC1410StorageWrapper.sol";
+import { ERC20StorageWrapper } from "../ERC20StorageWrapper.sol";
+import { ERC3643StorageWrapper } from "../../core/ERC3643StorageWrapper.sol";
+import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
+import { IBondTypes } from "../../../facets/layer_2/bond/IBondTypes.sol";
+import { ICoupon } from "../../../facets/layer_2/coupon/ICoupon.sol";
+import { ICouponTypes } from "../../../facets/layer_2/coupon/ICouponTypes.sol";
+import { NominalValueStorageWrapper } from "../nominalValue/NominalValueStorageWrapper.sol";
+import { Pagination } from "../../../infrastructure/utils/Pagination.sol";
+import { ScheduledTasksStorageWrapper } from "../ScheduledTasksStorageWrapper.sol";
+import { SnapshotsStorageWrapper } from "../SnapshotsStorageWrapper.sol";
+import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
+import { _COUPON_STORAGE_POSITION } from "../../../constants/storagePositions.sol";
+
+/// @title Coupon Storage Wrapper
+/// @notice Library for managing Coupon storage operations.
+/// @dev Provides structured access to CouponDataStorage at a dedicated storage slot.
+library CouponStorageWrapper {
+    struct CouponDataStorage {
+        uint256[] couponsOrderedListByIds;
+    }
+
+    function setCoupon(
+        ICouponTypes.Coupon memory newCoupon
+    ) internal returns (bytes32 corporateActionId_, uint256 couponID_) {
+        (corporateActionId_, couponID_) = CorporateActionsStorageWrapper.addCorporateAction(
+            COUPON_CORPORATE_ACTION_TYPE,
+            abi.encode(newCoupon)
+        );
+
+        initCoupon(corporateActionId_, newCoupon);
+
+        emit ICoupon.CouponSet(corporateActionId_, couponID_, EvmAccessors.getMsgSender(), newCoupon);
+    }
+
+    function cancelCoupon(uint256 couponId) internal returns (bool success_) {
+        ICouponTypes.RegisteredCoupon memory registeredCoupon;
+        bytes32 corporateActionId;
+        (registeredCoupon, corporateActionId, ) = getCoupon(couponId);
+        if (registeredCoupon.coupon.executionDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
+            revert ICoupon.CouponAlreadyExecuted(corporateActionId, couponId);
+        }
+        CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
+        success_ = true;
+        emit ICoupon.CouponCancelled(couponId, EvmAccessors.getMsgSender());
+    }
+
+    function initCoupon(bytes32 actionId, ICouponTypes.Coupon memory newCoupon) internal {
+        if (actionId == bytes32(0)) {
+            revert ICoupon.CouponCreationFailed();
+        }
+        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newCoupon.recordDate, SNAPSHOT_TASK_TYPE);
+        ScheduledTasksStorageWrapper.addScheduledSnapshot(newCoupon.recordDate, actionId);
+        if (newCoupon.fixingDate == 0) return;
+        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newCoupon.fixingDate, COUPON_LISTING_TASK_TYPE);
+        ScheduledTasksStorageWrapper.addScheduledCouponListing(newCoupon.fixingDate, actionId);
+    }
+
+    function addToCouponsOrderedList(uint256 couponID) internal {
+        _couponStorage().couponsOrderedListByIds.push(couponID);
+    }
+
+    function updateCouponRate(
+        uint256 couponID,
+        ICouponTypes.Coupon memory coupon,
+        uint256 rate,
+        uint8 rateDecimals
+    ) internal {
+        coupon.rate = rate;
+        coupon.rateDecimals = rateDecimals;
+        coupon.rateStatus = ICouponTypes.RateCalculationStatus.SET;
+
+        CorporateActionsStorageWrapper.updateCorporateActionData(
+            CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(COUPON_CORPORATE_ACTION_TYPE, couponID - 1),
+            abi.encode(coupon)
+        );
+    }
+
+    function getCoupon(
+        uint256 couponID
+    )
+        internal
+        view
+        returns (ICouponTypes.RegisteredCoupon memory registeredCoupon_, bytes32 corporateActionId_, bool isDisabled_)
+    {
+        corporateActionId_ = CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(
+            COUPON_CORPORATE_ACTION_TYPE,
+            couponID - 1
+        );
+        bytes memory data;
+        (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
+
+        require(data.length > 0, "ICouponTypes: Coupon not found");
+        (registeredCoupon_.coupon) = abi.decode(data, (ICouponTypes.Coupon));
+
+        registeredCoupon_.snapshotId = CorporateActionsStorageWrapper.getUintResultAt(
+            corporateActionId_,
+            SNAPSHOT_RESULT_ID
+        );
+    }
+
+    function getCouponFor(
+        uint256 couponID,
+        address account
+    ) internal view returns (ICouponTypes.CouponFor memory couponFor_) {
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , bool isDisabled) = getCoupon(couponID);
+
+        couponFor_.coupon = registeredCoupon.coupon;
+        couponFor_.isDisabled = isDisabled;
+
+        if (registeredCoupon.coupon.recordDate < TimeTravelStorageWrapper.getBlockTimestamp() && !isDisabled) {
+            couponFor_.recordDateReached = true;
+            couponFor_.tokenBalance = (registeredCoupon.snapshotId != 0)
+                ? SnapshotsStorageWrapper.getTotalBalanceOfAtSnapshot(registeredCoupon.snapshotId, account)
+                : ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
+                    account,
+                    TimeTravelStorageWrapper.getBlockTimestamp()
+                );
+            couponFor_.decimals = ERC20StorageWrapper.decimalsAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp());
+            couponFor_.nominalValue = NominalValueStorageWrapper._getNominalValue();
+        }
+
+        couponFor_.couponAmount = _calculateCouponAmount(
+            registeredCoupon.coupon,
+            couponFor_.tokenBalance,
+            couponFor_.decimals,
+            couponFor_.recordDateReached
+        );
+    }
+
+    function getCouponAmountFor(
+        uint256 couponID,
+        address account
+    ) internal view returns (ICouponTypes.CouponAmountFor memory couponAmountFor_) {
+        return getCouponFor(couponID, account).couponAmount;
+    }
+
+    function getCouponCount() internal view returns (uint256 couponCount_) {
+        return CorporateActionsStorageWrapper.getCorporateActionCountByType(COUPON_CORPORATE_ACTION_TYPE);
+    }
+
+    function getCouponHolders(
+        uint256 couponID,
+        uint256 pageIndex,
+        uint256 pageLength
+    ) internal view returns (address[] memory holders_) {
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = getCoupon(couponID);
+
+        if (registeredCoupon.coupon.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return holders_;
+
+        if (registeredCoupon.snapshotId != 0)
+            return SnapshotsStorageWrapper.tokenHoldersAt(registeredCoupon.snapshotId, pageIndex, pageLength);
+
+        return ERC1410StorageWrapper.getTokenHolders(pageIndex, pageLength);
+    }
+
+    function getTotalCouponHolders(uint256 couponID) internal view returns (uint256 total_) {
+        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = getCoupon(couponID);
+
+        if (registeredCoupon.coupon.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return 0;
+
+        if (registeredCoupon.snapshotId != 0)
+            return SnapshotsStorageWrapper.totalTokenHoldersAt(registeredCoupon.snapshotId);
+
+        return ERC1410StorageWrapper.getTotalTokenHolders();
+    }
+
+    function getCouponFromOrderedListAt(uint256 pos) internal view returns (uint256 couponID_) {
+        if (pos >= getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp())) return 0;
+
+        uint256 actualOrderedListLengthTotal = getCouponsOrderedListTotal();
+        if (pos < actualOrderedListLengthTotal) {
+            uint256 deprecatedTotal = BondStorageWrapper.DEPRECATED_getCouponsOrderedListTotal();
+            if (pos < deprecatedTotal) {
+                return BondStorageWrapper.DEPRECATED_getCouponsOrderedListByPosition(pos);
+            }
+            return _couponStorage().couponsOrderedListByIds[pos - deprecatedTotal];
+        }
+
+        uint256 pendingIndexOffset = pos - actualOrderedListLengthTotal;
+        uint256 index = ScheduledTasksStorageWrapper.getScheduledCouponListingCount() - 1 - pendingIndexOffset;
+        return ScheduledTasksStorageWrapper.getScheduledCouponListingIdAtIndex(index);
+    }
+
+    function getCouponsOrderedList(
+        uint256 pageIndex,
+        uint256 pageLength
+    ) internal view returns (uint256[] memory couponIDs_) {
+        (uint256 start, uint256 end) = Pagination.getStartAndEnd(pageIndex, pageLength);
+
+        couponIDs_ = new uint256[](
+            Pagination.getSize(
+                start,
+                end,
+                getCouponsOrderedListTotalAdjustedAt(TimeTravelStorageWrapper.getBlockTimestamp())
+            )
+        );
+
+        uint256 length = couponIDs_.length;
+        for (uint256 i; i < length; ) {
+            unchecked {
+                couponIDs_[i] = getCouponFromOrderedListAt(start + i);
+                ++i;
+            }
+        }
+    }
+
+    function getCouponsOrderedListTotalAdjustedAt(uint256 timestamp) internal view returns (uint256 total_) {
+        return
+            getCouponsOrderedListTotal() +
+            ScheduledTasksStorageWrapper.getPendingScheduledCouponListingTotalAt(timestamp);
+    }
+
+    function getCouponsOrderedListTotal() internal view returns (uint256 total_) {
+        total_ =
+            _couponStorage().couponsOrderedListByIds.length +
+            BondStorageWrapper.DEPRECATED_getCouponsOrderedListTotal();
+    }
+
+    function getPreviousCouponInOrderedList(uint256 couponID) internal view returns (uint256 previousCouponID_) {
+        uint256 orderedListLength = getCouponsOrderedListTotal();
+
+        if (orderedListLength < 2) return (0);
+
+        if (getCouponFromOrderedListAt(0) == couponID) return (0);
+
+        uint256 previousCouponId = 0;
+
+        for (uint256 index = 0; index < orderedListLength; index++) {
+            previousCouponId = getCouponFromOrderedListAt(index);
+            if (index + 1 < orderedListLength) {
+                uint256 couponId = getCouponFromOrderedListAt(index + 1);
+                if (couponId == couponID) break;
+            }
+        }
+
+        return previousCouponId;
+    }
+
+    function _calculateCouponAmount(
+        ICouponTypes.Coupon memory coupon,
+        uint256 tokenBalance,
+        uint8 decimals,
+        bool recordDateReached
+    ) private view returns (ICouponTypes.CouponAmountFor memory couponAmountFor_) {
+        if (!recordDateReached) return couponAmountFor_;
+
+        uint256 period = coupon.endDate - coupon.startDate;
+        uint256 nominalValue = NominalValueStorageWrapper._getNominalValue();
+        uint8 nominalValueDecimals = NominalValueStorageWrapper._getNominalValueDecimals();
+
+        couponAmountFor_.recordDateReached = true;
+        couponAmountFor_.numerator = tokenBalance * nominalValue * coupon.rate * period;
+        couponAmountFor_.denominator = 10 ** (decimals + nominalValueDecimals + coupon.rateDecimals) * 365 days;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function _couponStorage() private pure returns (CouponDataStorage storage cs_) {
+        bytes32 position = _COUPON_STORAGE_POSITION;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            cs_.slot := position
+        }
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_1/corporateAction/CorporateActions.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/corporateAction/CorporateActions.sol
@@ -2,10 +2,8 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { ICorporateActions } from "./ICorporateActions.sol";
-import { _CORPORATE_ACTION_ROLE } from "../../../constants/roles.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
 import { CorporateActionsStorageWrapper } from "../../../domain/core/CorporateActionsStorageWrapper.sol";
-import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract CorporateActions is ICorporateActions, Modifiers {
     function getCorporateAction(

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/Bond.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/Bond.sol
@@ -104,7 +104,6 @@ abstract contract Bond is IBondManagement, TimestampProvider, Modifiers {
         onlyListedAllowed(_tokenHolder)
         onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)
         onlyValidMaturityDate(_getBlockTimestamp())
-        onlyValidMaturityDate(_getBlockTimestamp())
     {
         ERC1410StorageWrapper.redeemByPartition(_partition, _tokenHolder, EvmAccessors.getMsgSender(), _amount, "", "");
     }

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/Bond.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/Bond.sol
@@ -2,27 +2,22 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IBondManagement } from "./IBondManagement.sol";
-import { IBondTypes } from "./IBondTypes.sol";
 import { IKyc } from "../../layer_1/kyc/IKyc.sol";
-import { IBond } from "../../layer_2/bond/IBond.sol";
-import { _CORPORATE_ACTION_ROLE, _BOND_MANAGER_ROLE, _MATURITY_REDEEMER_ROLE } from "../../../constants/roles.sol";
-import { COUPON_CORPORATE_ACTION_TYPE, KPI_BOND_REDEEM_BALANCE } from "../../../constants/values.sol";
+import { _BOND_MANAGER_ROLE, _MATURITY_REDEEMER_ROLE } from "../../../constants/roles.sol";
+import { KPI_BOND_REDEEM_BALANCE } from "../../../constants/values.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
 import { BondStorageWrapper } from "../../../domain/asset/BondStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../../domain/asset/ERC1410StorageWrapper.sol";
-import { InterestRateStorageWrapper } from "../../../domain/asset/InterestRateStorageWrapper.sol";
 import { TimestampProvider } from "../../../infrastructure/utils/TimestampProvider.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 import { _checkUnexpectedError } from "../../../infrastructure/utils/UnexpectedError.sol";
-
-error InterestRateIsKpiLinked();
 
 /**
  * @title Bond
  * @dev Abstract contract for bond-specific operations
  *
- * Provides functionality for bond maturity redemption, coupon management,
- * and maturity date updates. Integrates with clearing, kyc, and control list modifiers.
+ * Provides functionality for bond maturity redemption and maturity date updates.
+ * Integrates with clearing, kyc, and control list modifiers.
  *
  * @notice Inherit from this contract to gain access to bond management functions
  * @author Asset Tokenization Studio Team
@@ -115,55 +110,6 @@ abstract contract Bond is IBondManagement, TimestampProvider, Modifiers {
     }
 
     /**
-     * @dev Sets a new coupon for the bond
-     *
-     * Requirements:
-     * - Contract must not be paused
-     * - Caller must have CORPORATE_ACTION_ROLE
-     * - Coupon dates must be valid
-     * - Record and fixing dates must be valid timestamps
-     *
-     * @param _newCoupon The new coupon data
-     * @return couponID_ The created coupon identifier
-     *
-     * Emits CouponSet event on success
-     */
-    function setCoupon(
-        IBondTypes.Coupon calldata _newCoupon
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(_CORPORATE_ACTION_ROLE)
-        onlyValidDates(_newCoupon.startDate, _newCoupon.endDate)
-        onlyValidDates(_newCoupon.recordDate, _newCoupon.executionDate)
-        onlyValidDates(_newCoupon.fixingDate, _newCoupon.executionDate)
-        onlyValidTimestamp(_newCoupon.recordDate)
-        onlyValidTimestamp(_newCoupon.fixingDate)
-        returns (uint256 couponID_)
-    {
-        IBondTypes.Coupon memory coupon = _prepareCoupon(_newCoupon);
-        bytes32 corporateActionID;
-        (corporateActionID, couponID_) = BondStorageWrapper.setCoupon(coupon);
-    }
-
-    function cancelCoupon(
-        uint256 _couponId
-    )
-        external
-        override
-        onlyUnpaused
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponId - 1)
-        onlyRole(_CORPORATE_ACTION_ROLE)
-        returns (bool success_)
-    {
-        (success_) = BondStorageWrapper.cancelCoupon(_couponId);
-        if (success_) {
-            emit IBond.CouponCancelled(_couponId, EvmAccessors.getMsgSender());
-        }
-    }
-
-    /**
      * @dev Updates the bond maturity date
      *
      * Requirements:
@@ -189,16 +135,5 @@ abstract contract Bond is IBondManagement, TimestampProvider, Modifiers {
         emit MaturityDateUpdated(address(this), _newMaturityDate, BondStorageWrapper.getMaturityDate());
         BondStorageWrapper.setMaturityDate(_newMaturityDate);
         return true;
-    }
-
-    function _prepareCoupon(IBondTypes.Coupon calldata _newCoupon) internal virtual returns (IBondTypes.Coupon memory) {
-        // For KPI-linked rate bonds, rate must be PENDING (0), rate must be 0, and rateDecimals must be 0
-        if (
-            InterestRateStorageWrapper.isKpiLinkedRateInitialized() &&
-            (_newCoupon.rateStatus != IBondTypes.RateCalculationStatus.PENDING ||
-                _newCoupon.rate != 0 ||
-                _newCoupon.rateDecimals != 0)
-        ) revert InterestRateIsKpiLinked();
-        return _newCoupon;
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/BondRead.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/BondRead.sol
@@ -2,86 +2,15 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IBondRead } from "./IBondRead.sol";
-import { COUPON_CORPORATE_ACTION_TYPE } from "../../../constants/values.sol";
 import { BondStorageWrapper } from "../../../domain/asset/BondStorageWrapper.sol";
 import { TimestampProvider } from "../../../infrastructure/utils/TimestampProvider.sol";
-import { Modifiers } from "../../../services/Modifiers.sol";
 
-abstract contract BondRead is IBondRead, TimestampProvider, Modifiers {
+abstract contract BondRead is IBondRead, TimestampProvider {
     function getBondDetails() external view override returns (BondDetailsData memory bondDetailsData_) {
         return BondStorageWrapper.getBondDetails();
     }
 
-    function getCoupon(
-        uint256 _couponID
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (RegisteredCoupon memory registeredCoupon_, bool isDisabled_)
-    {
-        (registeredCoupon_, , isDisabled_) = BondStorageWrapper.getCoupon(_couponID);
-    }
-
-    function getCouponFor(
-        uint256 _couponID,
-        address _account
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (CouponFor memory couponFor_)
-    {
-        return BondStorageWrapper.getCouponFor(_couponID, _account);
-    }
-
-    function getCouponAmountFor(
-        uint256 _couponID,
-        address _account
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (CouponAmountFor memory couponAmountFor_)
-    {
-        return BondStorageWrapper.getCouponAmountFor(_couponID, _account);
-    }
-
     function getPrincipalFor(address _account) external view override returns (PrincipalFor memory principalFor_) {
         return BondStorageWrapper.getPrincipalFor(_account);
-    }
-
-    function getCouponCount() external view override returns (uint256 couponCount_) {
-        return BondStorageWrapper.getCouponCount();
-    }
-
-    function getCouponHolders(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_) {
-        return BondStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
-    }
-
-    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256) {
-        return BondStorageWrapper.getTotalCouponHolders(_couponID);
-    }
-
-    function getCouponFromOrderedListAt(uint256 _pos) external view returns (uint256 couponID_) {
-        return BondStorageWrapper.getCouponFromOrderedListAt(_pos);
-    }
-
-    function getCouponsOrderedList(
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (uint256[] memory couponIDs_) {
-        return BondStorageWrapper.getCouponsOrderedList(_pageIndex, _pageLength);
-    }
-
-    function getCouponsOrderedListTotal() external view returns (uint256 total_) {
-        return BondStorageWrapper.getCouponsOrderedListTotalAdjustedAt(_getBlockTimestamp());
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/IBond.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/IBond.sol
@@ -11,16 +11,4 @@ import { IBondRead } from "./IBondRead.sol";
 /// @dev DO NOT inherit this interface from any facet contract. Each facet must `is` exactly
 ///      its per-facet interface (`IBondManagement` or `IBondRead`). This umbrella contains
 ///      no function declarations of its own.
-interface IBond is IBondTypes, IBondManagement, IBondRead {
-    /**
-     * @notice Emitted when a coupon is cancelled.
-     * @param couponId Identifier of the cancelled coupon.
-     * @param operator Address that performed the cancellation.
-     */
-    event CouponCancelled(uint256 couponId, address indexed operator);
-
-    /**
-     * @notice Coupon execution failed because the coupon has already been executed or cancelled.
-     */
-    error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId);
-}
+interface IBond is IBondTypes, IBondManagement, IBondRead {}

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/IBondManagement.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/IBondManagement.sol
@@ -22,20 +22,8 @@ interface IBondManagement is IBondTypes {
     function redeemAtMaturityByPartition(address _tokenHolder, bytes32 _partition, uint256 _amount) external;
 
     /**
-     * @notice Sets a new coupon for the bond
-     * @param _newCoupon The new coupon to be set
-     */
-    function setCoupon(IBondTypes.Coupon calldata _newCoupon) external returns (uint256 couponID_);
-
-    /**
      * @notice Updates the maturity date of the bond.
      * @param _maturityDate The new maturity date to be set.
      */
     function updateMaturityDate(uint256 _maturityDate) external returns (bool success_);
-
-    /**
-     * @notice Cancels a certain coupon of the bond.
-     * @param _couponID The coupon to be cancelled.
-     */
-    function cancelCoupon(uint256 _couponID) external returns (bool success_);
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/IBondRead.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/IBondRead.sol
@@ -12,62 +12,7 @@ interface IBondRead is IBondTypes {
     function getBondDetails() external view returns (IBondTypes.BondDetailsData memory bondDetailsData_);
 
     /**
-     * @notice Retrieves a registered coupon by its ID
-     */
-    function getCoupon(
-        uint256 _couponID
-    ) external view returns (IBondTypes.RegisteredCoupon memory registeredCoupon_, bool isDisabled_);
-
-    /**
-     * @notice Retrieves coupon information for a specific account and coupon ID
-     * @dev Return value includes user balance at cupon record date
-     */
-    function getCouponFor(
-        uint256 _couponID,
-        address _account
-    ) external view returns (IBondTypes.CouponFor memory couponFor_);
-
-    /**
-     * @notice Retrieves coupon amount numerator and denominator for a specific account
-     * and coupon ID
-     */
-    function getCouponAmountFor(
-        uint256 _couponID,
-        address _account
-    ) external view returns (IBondTypes.CouponAmountFor memory couponAmountFor_);
-
-    /**
      * @notice Retrieves principal numerator and denominator for a specific account
      */
     function getPrincipalFor(address _account) external view returns (IBondTypes.PrincipalFor memory principalFor_);
-
-    /**
-     * @notice Retrieves the total number of coupons set for the bond
-     * @dev Pending coupons are included in the count
-     */
-    function getCouponCount() external view returns (uint256 couponCount_);
-
-    /**
-     * @notice Retrieves a paginated list of coupon holders for a specific coupon ID
-     */
-    function getCouponHolders(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_);
-
-    /**
-     * @notice Retrieves the total number of coupon holders for a specific coupon ID
-     * @dev It is the list of token holders at the snapshot taken at the record date
-     */
-    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256);
-
-    function getCouponFromOrderedListAt(uint256 _pos) external view returns (uint256 couponID_);
-
-    function getCouponsOrderedList(
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (uint256[] memory couponIDs_);
-
-    function getCouponsOrderedListTotal() external view returns (uint256 total_);
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/bond/IBondTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/bond/IBondTypes.sol
@@ -4,47 +4,12 @@ pragma solidity >=0.8.0 <0.9.0;
 /// @title IBondTypes
 /// @notice Single source of truth for all Bond domain types (structs, enums, events, errors)
 interface IBondTypes {
-    enum RateCalculationStatus {
-        PENDING,
-        SET
-    }
-
     struct BondDetailsData {
         bytes3 currency;
         uint256 nominalValue;
         uint8 nominalValueDecimals;
         uint256 startingDate;
         uint256 maturityDate;
-    }
-
-    struct Coupon {
-        uint256 recordDate;
-        uint256 executionDate;
-        uint256 startDate;
-        uint256 endDate;
-        uint256 fixingDate;
-        uint256 rate;
-        uint8 rateDecimals;
-        RateCalculationStatus rateStatus;
-    }
-
-    struct RegisteredCoupon {
-        Coupon coupon;
-        uint256 snapshotId;
-    }
-
-    struct CouponFor {
-        uint256 tokenBalance;
-        uint8 decimals;
-        bool recordDateReached;
-        Coupon coupon;
-        bool isDisabled;
-    }
-
-    struct CouponAmountFor {
-        uint256 numerator;
-        uint256 denominator;
-        bool recordDateReached;
     }
 
     struct PrincipalFor {
@@ -58,13 +23,5 @@ interface IBondTypes {
         uint256 indexed previousMaturityDate
     );
 
-    event CouponSet(
-        bytes32 indexed corporateActionId,
-        uint256 indexed couponId,
-        address indexed operator,
-        Coupon coupon
-    );
-
-    error CouponCreationFailed();
     error BondMaturityDateWrong();
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
@@ -7,6 +7,7 @@ import { _CORPORATE_ACTION_ROLE } from "../../../constants/roles.sol";
 import { COUPON_CORPORATE_ACTION_TYPE } from "../../../constants/values.sol";
 import { CouponStorageWrapper } from "../../../domain/asset/coupon/CouponStorageWrapper.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
+import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 
 abstract contract Coupon is ICoupon, Modifiers {
     function setCoupon(
@@ -136,7 +137,9 @@ abstract contract Coupon is ICoupon, Modifiers {
     }
 
     function getCouponsOrderedListTotal() external view override returns (uint256 total_) {
-        total_ = CouponStorageWrapper.getCouponsOrderedListTotal();
+        total_ = CouponStorageWrapper.getCouponsOrderedListTotalAdjustedAt(
+            TimeTravelStorageWrapper.getBlockTimestamp()
+        );
     }
 
     function _prepareCoupon(

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ICoupon } from "./ICoupon.sol";
+import { ICouponTypes } from "./ICouponTypes.sol";
+import { _CORPORATE_ACTION_ROLE } from "../../../constants/roles.sol";
+import { COUPON_CORPORATE_ACTION_TYPE } from "../../../constants/values.sol";
+import { CouponStorageWrapper } from "../../../domain/asset/coupon/CouponStorageWrapper.sol";
+import { Modifiers } from "../../../services/Modifiers.sol";
+
+abstract contract Coupon is ICoupon, Modifiers {
+    function setCoupon(
+        ICouponTypes.Coupon calldata _newCoupon
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(_CORPORATE_ACTION_ROLE)
+        onlyValidDates(_newCoupon.startDate, _newCoupon.endDate)
+        onlyValidDates(_newCoupon.recordDate, _newCoupon.executionDate)
+        onlyValidDates(_newCoupon.fixingDate, _newCoupon.executionDate)
+        onlyValidTimestamp(_newCoupon.recordDate)
+        onlyValidTimestamp(_newCoupon.fixingDate)
+        returns (uint256 couponID_)
+    {
+        ICouponTypes.Coupon memory prepared = _prepareCoupon(_newCoupon);
+        (, couponID_) = CouponStorageWrapper.setCoupon(prepared);
+    }
+
+    function cancelCoupon(
+        uint256 _couponID
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(_CORPORATE_ACTION_ROLE)
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (bool success_)
+    {
+        success_ = CouponStorageWrapper.cancelCoupon(_couponID);
+    }
+
+    function getCoupon(
+        uint256 _couponID
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (ICouponTypes.RegisteredCoupon memory registeredCoupon_, bool isDisabled_)
+    {
+        (registeredCoupon_, , isDisabled_) = CouponStorageWrapper.getCoupon(_couponID);
+    }
+
+    function getCouponFor(
+        uint256 _couponID,
+        address _account
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (ICouponTypes.CouponFor memory couponFor_)
+    {
+        couponFor_ = CouponStorageWrapper.getCouponFor(_couponID, _account);
+    }
+
+    function getCouponsFor(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory accounts_)
+    {
+        address[] memory holders = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
+        accounts_ = holders;
+        couponFor_ = new ICouponTypes.CouponFor[](holders.length);
+        for (uint256 i; i < holders.length; ) {
+            couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function getCouponAmountFor(
+        uint256 _couponID,
+        address _account
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (ICouponTypes.CouponAmountFor memory couponAmountFor_)
+    {
+        couponAmountFor_ = CouponStorageWrapper.getCouponAmountFor(_couponID, _account);
+    }
+
+    function getCouponCount() external view override returns (uint256 couponCount_) {
+        couponCount_ = CouponStorageWrapper.getCouponCount();
+    }
+
+    function getCouponHolders(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (address[] memory holders_)
+    {
+        holders_ = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
+    }
+
+    function getTotalCouponHolders(
+        uint256 _couponID
+    ) external view override onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1) returns (uint256) {
+        return CouponStorageWrapper.getTotalCouponHolders(_couponID);
+    }
+
+    function getCouponFromOrderedListAt(uint256 _pos) external view override returns (uint256 couponID_) {
+        couponID_ = CouponStorageWrapper.getCouponFromOrderedListAt(_pos);
+    }
+
+    function getCouponsOrderedList(
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view override returns (uint256[] memory couponIDs_) {
+        couponIDs_ = CouponStorageWrapper.getCouponsOrderedList(_pageIndex, _pageLength);
+    }
+
+    function getCouponsOrderedListTotal() external view override returns (uint256 total_) {
+        total_ = CouponStorageWrapper.getCouponsOrderedListTotal();
+    }
+
+    function _prepareCoupon(
+        ICouponTypes.Coupon calldata _newCoupon
+    ) internal view virtual returns (ICouponTypes.Coupon memory coupon_) {
+        coupon_ = _newCoupon;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/CouponFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/CouponFacetBase.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { Coupon } from "./Coupon.sol";
+import { ICoupon } from "./ICoupon.sol";
+import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+
+abstract contract CouponFacetBase is Coupon, IStaticFunctionSelectors {
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        staticFunctionSelectors_ = new bytes4[](12);
+        uint256 selectorIndex;
+        staticFunctionSelectors_[selectorIndex++] = this.setCoupon.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.cancelCoupon.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCoupon.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponFor.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponsFor.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponAmountFor.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponCount.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponHolders.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getTotalCouponHolders.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponFromOrderedListAt.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponsOrderedList.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getCouponsOrderedListTotal.selector;
+    }
+
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        staticInterfaceIds_ = new bytes4[](1);
+        uint256 selectorsIndex;
+        staticInterfaceIds_[selectorsIndex++] = type(ICoupon).interfaceId;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
@@ -31,6 +31,10 @@ interface ICoupon is ICouponTypes {
     /// @notice Raised when coupon creation fails
     error CouponCreationFailed();
 
+    /// @notice Raised when a coupon ID does not resolve to an existing corporate action
+    /// @param couponID The coupon identifier that was not found
+    error CouponNotFound(uint256 couponID);
+
     /// @notice Sets a new coupon for the security
     /// @param _newCoupon The new coupon to be set
     /// @return couponID_ The created coupon identifier

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ICouponTypes } from "./ICouponTypes.sol";
+
+/// @title ICoupon
+/// @notice Interface for coupon management functionality
+interface ICoupon is ICouponTypes {
+    /// @notice Emitted when a coupon is set
+    /// @param corporateActionId The ID of the corporate action
+    /// @param couponId The ID of the coupon
+    /// @param operator The address of the operator who set the coupon
+    /// @param coupon The coupon data that was set
+    event CouponSet(
+        bytes32 indexed corporateActionId,
+        uint256 indexed couponId,
+        address indexed operator,
+        Coupon coupon
+    );
+
+    /// @notice Emitted when a coupon is cancelled
+    /// @param couponId The ID of the cancelled coupon
+    /// @param operator The address of the operator who cancelled the coupon
+    event CouponCancelled(uint256 indexed couponId, address indexed operator);
+
+    /// @notice Raised when attempting to execute a coupon that has already been executed
+    /// @param corporateActionId The ID of the corporate action
+    /// @param couponId The ID of the coupon
+    error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId);
+
+    /// @notice Raised when coupon creation fails
+    error CouponCreationFailed();
+
+    /// @notice Sets a new coupon for the security
+    /// @param _newCoupon The new coupon to be set
+    /// @return couponID_ The created coupon identifier
+    function setCoupon(Coupon calldata _newCoupon) external returns (uint256 couponID_);
+
+    /// @notice Cancels an existing coupon
+    /// @param _couponID The ID of the coupon to be cancelled
+    /// @return success_ Whether the cancellation was successful
+    function cancelCoupon(uint256 _couponID) external returns (bool success_);
+
+    /// @notice Retrieves a registered coupon by its ID
+    /// @param _couponID The ID of the coupon to retrieve
+    /// @return registeredCoupon_ The registered coupon data
+    /// @return isDisabled_ Whether the coupon is disabled
+    function getCoupon(
+        uint256 _couponID
+    ) external view returns (RegisteredCoupon memory registeredCoupon_, bool isDisabled_);
+
+    /// @notice Retrieves coupon information for a specific account and coupon ID
+    /// @dev Return value includes user balance at coupon record date
+    /// @param _couponID The ID of the coupon
+    /// @param _account The account address
+    /// @return couponFor_ Coupon information for the specified account
+    function getCouponFor(uint256 _couponID, address _account) external view returns (CouponFor memory couponFor_);
+
+    /// @notice Retrieves coupon information for a specific coupon ID
+    /// @param _couponID The ID of the coupon
+    /// @param _pageIndex The page index for pagination
+    /// @param _pageLength The number of records per page
+    /// @return couponFor_ List of coupon information for accounts corresponding to the coupon ID
+    /// @return accounts_ List of account addresses corresponding to the coupon information
+    function getCouponsFor(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (CouponFor[] memory couponFor_, address[] memory accounts_);
+
+    /// @notice Retrieves coupon amount numerator and denominator for a specific account and coupon ID
+    /// @param _couponID The ID of the coupon
+    /// @param _account The account address
+    /// @return couponAmountFor_ Coupon amount information for the specified account
+    function getCouponAmountFor(
+        uint256 _couponID,
+        address _account
+    ) external view returns (CouponAmountFor memory couponAmountFor_);
+
+    /// @notice Retrieves the total number of coupons set for the security
+    /// @return couponCount_ The total count of coupons
+    function getCouponCount() external view returns (uint256 couponCount_);
+
+    /// @notice Retrieves a paginated list of coupon holders for a specific coupon ID
+    /// @param _couponID The ID of the coupon
+    /// @param _pageIndex The page index for pagination
+    /// @param _pageLength The number of holders per page
+    /// @return holders_ Array of holder addresses
+    function getCouponHolders(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (address[] memory holders_);
+
+    /// @notice Retrieves the total number of coupon holders for a specific coupon ID
+    /// @dev It is the list of token holders at the snapshot taken at the record date
+    /// @param _couponID The ID of the coupon
+    /// @return The total number of coupon holders
+    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256);
+
+    /// @notice Retrieves a coupon ID from the ordered list at a specific position
+    /// @param _pos The position in the ordered coupon list
+    /// @return couponID_ The coupon ID at the specified position
+    function getCouponFromOrderedListAt(uint256 _pos) external view returns (uint256 couponID_);
+
+    /// @notice Retrieves a paginated list of coupon IDs in order
+    /// @param _pageIndex The page index for pagination
+    /// @param _pageLength The number of coupons per page
+    /// @return couponIDs_ Array of coupon IDs for the specified page
+    function getCouponsOrderedList(
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (uint256[] memory couponIDs_);
+
+    /// @notice Retrieves the total number of coupons in the ordered list
+    /// @return total_ The total count of coupons
+    function getCouponsOrderedListTotal() external view returns (uint256 total_);
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/ICouponTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/ICouponTypes.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/// @title ICouponTypes
+/// @notice Single source of truth for all Coupon domain types (structs, enums)
+interface ICouponTypes {
+    /// @notice Status of the coupon rate calculation process
+    enum RateCalculationStatus {
+        PENDING,
+        SET
+    }
+
+    /// @notice Core coupon data structure
+    /// @dev Stores all relevant dates and rate information for a coupon payment
+    struct Coupon {
+        uint256 recordDate;
+        uint256 executionDate;
+        uint256 startDate;
+        uint256 endDate;
+        uint256 fixingDate;
+        uint256 rate;
+        uint8 rateDecimals;
+        RateCalculationStatus rateStatus;
+    }
+
+    /// @notice Registered coupon with snapshot reference
+    /// @dev Links a coupon to a specific token holder snapshot
+    struct RegisteredCoupon {
+        Coupon coupon;
+        uint256 snapshotId;
+    }
+
+    /// @notice Coupon information for a specific account
+    /// @dev Contains coupon details and account-specific data
+    struct CouponFor {
+        uint256 tokenBalance;
+        uint256 nominalValue;
+        uint8 decimals;
+        bool recordDateReached;
+        Coupon coupon;
+        CouponAmountFor couponAmount;
+        bool isDisabled;
+    }
+
+    /// @notice Coupon payment amount representation
+    /// @dev Expressed as a fraction to handle rounding and precision
+    struct CouponAmountFor {
+        uint256 numerator;
+        uint256 denominator;
+        bool recordDateReached;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/fixedRate/CouponFixedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/fixedRate/CouponFixedRateFacet.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFacetBase } from "../CouponFacetBase.sol";
+import { ICouponTypes } from "../ICouponTypes.sol";
+import { IFixedRate } from "../../interestRate/fixedRate/IFixedRate.sol";
+import { InterestRateStorageWrapper } from "../../../../domain/asset/InterestRateStorageWrapper.sol";
+import { _COUPON_FIXED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
+
+contract CouponFixedRateFacet is CouponFacetBase {
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _COUPON_FIXED_RATE_RESOLVER_KEY;
+    }
+
+    function _prepareCoupon(
+        ICouponTypes.Coupon calldata _newCoupon
+    ) internal view override returns (ICouponTypes.Coupon memory coupon_) {
+        if (
+            _newCoupon.rateStatus != ICouponTypes.RateCalculationStatus.PENDING ||
+            _newCoupon.rate != 0 ||
+            _newCoupon.rateDecimals != 0
+        ) {
+            revert IFixedRate.InterestRateIsFixed();
+        }
+        coupon_ = _newCoupon;
+        (coupon_.rate, coupon_.rateDecimals) = InterestRateStorageWrapper.getRate();
+        coupon_.rateStatus = ICouponTypes.RateCalculationStatus.SET;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/kpiLinkedRate/CouponKpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/kpiLinkedRate/CouponKpiLinkedRateFacet.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFacetBase } from "../CouponFacetBase.sol";
+import { _COUPON_KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
+
+contract CouponKpiLinkedRateFacet is CouponFacetBase {
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _COUPON_KPI_LINKED_RATE_RESOLVER_KEY;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/kpiLinkedRate/CouponKpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/kpiLinkedRate/CouponKpiLinkedRateFacet.sol
@@ -2,10 +2,25 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { CouponFacetBase } from "../CouponFacetBase.sol";
+import { ICouponTypes } from "../ICouponTypes.sol";
+import { IKpiLinkedRate } from "../../interestRate/kpiLinkedRate/IKpiLinkedRate.sol";
 import { _COUPON_KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract CouponKpiLinkedRateFacet is CouponFacetBase {
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _COUPON_KPI_LINKED_RATE_RESOLVER_KEY;
+    }
+
+    function _prepareCoupon(
+        ICouponTypes.Coupon calldata _newCoupon
+    ) internal view override returns (ICouponTypes.Coupon memory coupon_) {
+        if (
+            _newCoupon.rateStatus != ICouponTypes.RateCalculationStatus.PENDING ||
+            _newCoupon.rate != 0 ||
+            _newCoupon.rateDecimals != 0
+        ) {
+            revert IKpiLinkedRate.InterestRateIsKpiLinked();
+        }
+        coupon_ = _newCoupon;
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/standard/CouponFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/standard/CouponFacet.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFacetBase } from "../CouponFacetBase.sol";
+import { _COUPON_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
+
+contract CouponFacet is CouponFacetBase {
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _COUPON_RESOLVER_KEY;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/sustainabilityPerformanceTargetRate/CouponSustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/sustainabilityPerformanceTargetRate/CouponSustainabilityPerformanceTargetRateFacet.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFacetBase } from "../CouponFacetBase.sol";
+// prettier-ignore
+// solhint-disable-next-line max-line-length
+import { _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
+
+contract CouponSustainabilityPerformanceTargetRateFacet is CouponFacetBase {
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/sustainabilityPerformanceTargetRate/CouponSustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/sustainabilityPerformanceTargetRate/CouponSustainabilityPerformanceTargetRateFacet.sol
@@ -2,6 +2,10 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { CouponFacetBase } from "../CouponFacetBase.sol";
+import { ICouponTypes } from "../ICouponTypes.sol";
+// prettier-ignore
+// solhint-disable-next-line max-line-length
+import { ISustainabilityPerformanceTargetRate } from "../../interestRate/sustainabilityPerformanceTargetRate/ISustainabilityPerformanceTargetRate.sol";
 // prettier-ignore
 // solhint-disable-next-line max-line-length
 import { _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
@@ -9,5 +13,18 @@ import { _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY } from "../
 contract CouponSustainabilityPerformanceTargetRateFacet is CouponFacetBase {
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
+    }
+
+    function _prepareCoupon(
+        ICouponTypes.Coupon calldata _newCoupon
+    ) internal view override returns (ICouponTypes.Coupon memory coupon_) {
+        if (
+            _newCoupon.rateStatus != ICouponTypes.RateCalculationStatus.PENDING ||
+            _newCoupon.rate != 0 ||
+            _newCoupon.rateDecimals != 0
+        ) {
+            revert ISustainabilityPerformanceTargetRate.InterestRateIsSustainabilityPerformanceTargetRate();
+        }
+        coupon_ = _newCoupon;
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/equity/Equity.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/equity/Equity.sol
@@ -9,10 +9,7 @@ import {
 } from "../../../constants/values.sol";
 import { IEquity } from "./IEquity.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
-import { CorporateActionsStorageWrapper } from "../../../domain/core/CorporateActionsStorageWrapper.sol";
-import { AdjustBalancesStorageWrapper } from "../../../domain/asset/AdjustBalancesStorageWrapper.sol";
-import { ScheduledTasksStorageWrapper } from "../../../domain/asset/ScheduledTasksStorageWrapper.sol";
-import { EquityStorageWrapper, EquityDataStorage } from "../../../domain/asset/EquityStorageWrapper.sol";
+import { EquityStorageWrapper } from "../../../domain/asset/EquityStorageWrapper.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract Equity is IEquity, Modifiers {

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
@@ -25,6 +25,7 @@ interface IKpiLinkedRate {
 
     error WrongInterestRateValues(InterestRate interestRate);
     error WrongImpactDataValues(ImpactData impactData);
+    error InterestRateIsKpiLinked();
 
     // solhint-disable-next-line func-name-mixedcase
     function initialize_KpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/sustainabilityPerformanceTargetRate/ISustainabilityPerformanceTargetRate.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/sustainabilityPerformanceTargetRate/ISustainabilityPerformanceTargetRate.sol
@@ -31,6 +31,7 @@ interface ISustainabilityPerformanceTargetRate {
 
     error NotExistingProject(address);
     error ProvidedListsLengthMismatch(uint256 impactDataLength, uint256 projectsLength);
+    error InterestRateIsSustainabilityPerformanceTargetRate();
 
     // solhint-disable-next-line func-name-mixedcase
     function initialize_SustainabilityPerformanceTargetRate(

--- a/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAFacetBase.sol
@@ -9,13 +9,11 @@ import { BondUSA } from "./BondUSA.sol";
 abstract contract BondUSAFacetBase is BondUSA, IStaticFunctionSelectors {
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](6);
+        staticFunctionSelectors_ = new bytes4[](4);
         staticFunctionSelectors_[selectorIndex++] = this._initialize_bondUSA.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setCoupon.selector;
         staticFunctionSelectors_[selectorIndex++] = this.updateMaturityDate.selector;
         staticFunctionSelectors_[selectorIndex++] = this.redeemAtMaturityByPartition.selector;
         staticFunctionSelectors_[selectorIndex++] = this.fullRedeemAtMaturity.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.cancelCoupon.selector;
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {

--- a/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAReadFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAReadFacetBase.sol
@@ -10,21 +10,12 @@ import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticF
 abstract contract BondUSAReadFacetBase is BondRead, IStaticFunctionSelectors, Security {
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](14);
+        staticFunctionSelectors_ = new bytes4[](5);
         staticFunctionSelectors_[selectorIndex++] = this.getBondDetails.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCoupon.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponFor.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getPrincipalFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponAmountFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponHolders.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getTotalCouponHolders.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getSecurityRegulationData.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getSecurityHolders.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getTotalSecurityHolders.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponFromOrderedListAt.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponsOrderedList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCouponsOrderedListTotal.selector;
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {

--- a/packages/ats/contracts/contracts/facets/layer_3/bondUSA/fixedRate/BondUSAFixedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/bondUSA/fixedRate/BondUSAFixedRateFacet.sol
@@ -3,27 +3,9 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { _BOND_FIXED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 import { BondUSAFacetBase } from "../BondUSAFacetBase.sol";
-import { IBondTypes } from "../../../layer_2/bond/IBondTypes.sol";
-import { IFixedRate } from "../../../layer_2/interestRate/fixedRate/IFixedRate.sol";
-import { InterestRateStorageWrapper } from "../../../../domain/asset/InterestRateStorageWrapper.sol";
 
 contract BondUSAFixedRateFacet is BondUSAFacetBase {
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _BOND_FIXED_RATE_RESOLVER_KEY;
-    }
-
-    function _prepareCoupon(
-        IBondTypes.Coupon calldata _newCoupon
-    ) internal view override returns (IBondTypes.Coupon memory coupon_) {
-        if (
-            _newCoupon.rateStatus != IBondTypes.RateCalculationStatus.PENDING ||
-            _newCoupon.rate != 0 ||
-            _newCoupon.rateDecimals != 0
-        ) {
-            revert IFixedRate.InterestRateIsFixed();
-        }
-        coupon_ = _newCoupon;
-        (coupon_.rate, coupon_.rateDecimals) = InterestRateStorageWrapper.getRate();
-        coupon_.rateStatus = IBondTypes.RateCalculationStatus.SET;
     }
 }

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IBondRead.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IBondRead.sol
@@ -17,62 +17,7 @@ interface TRexIBondRead is IBondTypes {
     function getBondDetails() external view returns (IBondTypes.BondDetailsData memory bondDetailsData_);
 
     /**
-     * @notice Retrieves a registered coupon by its ID
-     */
-    function getCoupon(
-        uint256 _couponID
-    ) external view returns (IBondTypes.RegisteredCoupon memory registeredCoupon_, bool isDisabled_);
-
-    /**
-     * @notice Retrieves coupon information for a specific account and coupon ID
-     * @dev Return value includes user balance at cupon record date
-     */
-    function getCouponFor(
-        uint256 _couponID,
-        address _account
-    ) external view returns (IBondTypes.CouponFor memory couponFor_);
-
-    /**
-     * @notice Retrieves coupon amount numerator and denominator for a specific account
-     * and coupon ID
-     */
-    function getCouponAmountFor(
-        uint256 _couponID,
-        address _account
-    ) external view returns (IBondTypes.CouponAmountFor memory couponAmountFor_);
-
-    /**
      * @notice Retrieves principal numerator and denominator for a specific account
      */
     function getPrincipalFor(address _account) external view returns (IBondTypes.PrincipalFor memory principalFor_);
-
-    /**
-     * @notice Retrieves the total number of coupons set for the bond
-     * @dev Pending coupons are included in the count
-     */
-    function getCouponCount() external view returns (uint256 couponCount_);
-
-    /**
-     * @notice Retrieves a paginated list of coupon holders for a specific coupon ID
-     */
-    function getCouponHolders(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_);
-
-    /**
-     * @notice Retrieves the total number of coupon holders for a specific coupon ID
-     * @dev It is the list of token holders at the snapshot taken at the record date
-     */
-    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256);
-
-    function getCouponFromOrderedListAt(uint256 _pos) external view returns (uint256 couponID_);
-
-    function getCouponsOrderedList(
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (uint256[] memory couponIDs_);
-
-    function getCouponsOrderedListTotal() external view returns (uint256 total_);
 }

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IBondTypes.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IBondTypes.sol
@@ -9,47 +9,12 @@ pragma solidity ^0.8.17;
 /// @title IBondTypes
 /// @notice Single source of truth for all Bond domain types (structs, enums, events, errors)
 interface TRexIBondTypes {
-    enum RateCalculationStatus {
-        PENDING,
-        SET
-    }
-
     struct BondDetailsData {
         bytes3 currency;
         uint256 nominalValue;
         uint8 nominalValueDecimals;
         uint256 startingDate;
         uint256 maturityDate;
-    }
-
-    struct Coupon {
-        uint256 recordDate;
-        uint256 executionDate;
-        uint256 startDate;
-        uint256 endDate;
-        uint256 fixingDate;
-        uint256 rate;
-        uint8 rateDecimals;
-        RateCalculationStatus rateStatus;
-    }
-
-    struct RegisteredCoupon {
-        Coupon coupon;
-        uint256 snapshotId;
-    }
-
-    struct CouponFor {
-        uint256 tokenBalance;
-        uint8 decimals;
-        bool recordDateReached;
-        Coupon coupon;
-        bool isDisabled;
-    }
-
-    struct CouponAmountFor {
-        uint256 numerator;
-        uint256 denominator;
-        bool recordDateReached;
     }
 
     struct PrincipalFor {
@@ -63,13 +28,5 @@ interface TRexIBondTypes {
         uint256 indexed previousMaturityDate
     );
 
-    event CouponSet(
-        bytes32 indexed corporateActionId,
-        uint256 indexed couponId,
-        address indexed operator,
-        Coupon coupon
-    );
-
-    error CouponCreationFailed();
     error BondMaturityDateWrong();
 }

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
@@ -30,6 +30,7 @@ interface TRexIKpiLinkedRate {
 
     error WrongInterestRateValues(InterestRate interestRate);
     error WrongImpactDataValues(ImpactData impactData);
+    error InterestRateIsKpiLinked();
 
     // solhint-disable-next-line func-name-mixedcase
     function initialize_KpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;

--- a/packages/ats/contracts/contracts/factory/Factory.sol
+++ b/packages/ats/contracts/contracts/factory/Factory.sol
@@ -31,6 +31,7 @@ import { IBondUSA } from "../facets/layer_3/bondUSA/IBondUSA.sol";
 import { IBondRead } from "../facets/layer_2/bond/IBondRead.sol";
 import { IProceedRecipients } from "../facets/layer_2/proceedRecipient/IProceedRecipients.sol";
 import { INominalValue } from "../facets/layer_2/nominalValue/INominalValue.sol";
+import { ScheduledTasksStorageWrapper } from "../domain/asset/ScheduledTasksStorageWrapper.sol";
 import { IProtectedPartitions } from "../facets/layer_1/protectedPartition/IProtectedPartitions.sol";
 import { IExternalPauseManagement } from "../facets/layer_1/externalPause/IExternalPauseManagement.sol";
 import {
@@ -111,6 +112,7 @@ contract Factory is IFactory {
 
     modifier checkBondDates(uint256 startingDate, uint256 maturityDate) {
         CorporateActionsStorageWrapper.requireValidDates(startingDate, maturityDate);
+        ScheduledTasksStorageWrapper.requireValidTimestamp(maturityDate);
         _;
     }
 

--- a/packages/ats/contracts/contracts/test/mocks/MockBond.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockBond.sol
@@ -2,107 +2,27 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IBondRead } from "../../facets/layer_2/bond/IBondRead.sol";
+import { IBondTypes } from "../../facets/layer_2/bond/IBondTypes.sol";
 
 contract MockBond is IBondRead {
-    // --- Storage ---
-    BondDetailsData private _bondDetails;
-    mapping(uint256 => RegisteredCoupon) private _coupons;
-    mapping(uint256 => mapping(address => CouponFor)) private _couponFor;
-    mapping(uint256 => mapping(address => CouponAmountFor)) private _couponAmountFor;
-    mapping(address => PrincipalFor) private _principalFor;
-    uint256 private _couponCount;
-    uint256[] private _couponsOrderedList;
-    mapping(uint256 => address[]) private _couponHolders;
+    IBondTypes.BondDetailsData private _bondDetails;
+    mapping(address => IBondTypes.PrincipalFor) private _principalFor;
 
-    // --- Errors ---
-    error IndexOutOfBounds(uint256 index, uint256 length);
-
-    // --- Setters (mock__ prefix to avoid naming collisions with IBondRead) ---
     // solhint-disable func-name-mixedcase
-    function mock__setBondDetails(BondDetailsData calldata data) external {
+    function mock__setBondDetails(IBondTypes.BondDetailsData calldata data) external {
         _bondDetails = data;
     }
-    function mock__setCoupon(uint256 id, RegisteredCoupon calldata data) external {
-        _coupons[id] = data;
-    }
-    function mock__setCouponFor(uint256 id, address account, CouponFor calldata data) external {
-        _couponFor[id][account] = data;
-    }
-    function mock__setCouponAmountFor(uint256 id, address account, CouponAmountFor calldata data) external {
-        _couponAmountFor[id][account] = data;
-    }
-    function mock__setPrincipalFor(address account, PrincipalFor calldata data) external {
+
+    function mock__setPrincipalFor(address account, IBondTypes.PrincipalFor calldata data) external {
         _principalFor[account] = data;
-    }
-    function mock__setCouponCount(uint256 count) external {
-        _couponCount = count;
-    }
-    function mock__setCouponHolders(uint256 id, address[] calldata holders) external {
-        delete _couponHolders[id];
-        for (uint256 i; i < holders.length; i++) _couponHolders[id].push(holders[i]);
-    }
-    function mock__setCouponsOrderedList(uint256[] calldata list) external {
-        delete _couponsOrderedList;
-        for (uint256 i; i < list.length; i++) _couponsOrderedList.push(list[i]);
     }
     // solhint-enable func-name-mixedcase
 
-    // --- IBondRead view functions ---
-    function getBondDetails() external view override returns (BondDetailsData memory) {
+    function getBondDetails() external view override returns (IBondTypes.BondDetailsData memory) {
         return _bondDetails;
     }
-    function getCoupon(uint256 id) external view override returns (RegisteredCoupon memory, bool) {
-        return (_coupons[id], false);
-    }
-    function getCouponFor(uint256 id, address account) external view override returns (CouponFor memory) {
-        return _couponFor[id][account];
-    }
-    function getCouponAmountFor(uint256 id, address account) external view override returns (CouponAmountFor memory) {
-        return _couponAmountFor[id][account];
-    }
-    function getPrincipalFor(address account) external view override returns (PrincipalFor memory) {
+
+    function getPrincipalFor(address account) external view override returns (IBondTypes.PrincipalFor memory) {
         return _principalFor[account];
-    }
-    function getCouponCount() external view override returns (uint256) {
-        return _couponCount;
-    }
-    function getTotalCouponHolders(uint256 id) external view override returns (uint256) {
-        return _couponHolders[id].length;
-    }
-    function getCouponsOrderedListTotal() external view override returns (uint256) {
-        return _couponsOrderedList.length;
-    }
-
-    function getCouponHolders(
-        uint256 id,
-        uint256 pageIndex,
-        uint256 pageLength
-    ) external view override returns (address[] memory) {
-        address[] storage holders = _couponHolders[id];
-        uint256 start = pageIndex * pageLength;
-        if (start >= holders.length) return new address[](0);
-        uint256 end = start + pageLength;
-        if (end > holders.length) end = holders.length;
-        address[] memory page = new address[](end - start);
-        for (uint256 i; i < page.length; i++) page[i] = holders[start + i];
-        return page;
-    }
-
-    function getCouponFromOrderedListAt(uint256 pos) external view override returns (uint256) {
-        if (pos >= _couponsOrderedList.length) revert IndexOutOfBounds(pos, _couponsOrderedList.length);
-        return _couponsOrderedList[pos];
-    }
-
-    function getCouponsOrderedList(
-        uint256 pageIndex,
-        uint256 pageLength
-    ) external view override returns (uint256[] memory) {
-        uint256 start = pageIndex * pageLength;
-        if (start >= _couponsOrderedList.length) return new uint256[](0);
-        uint256 end = start + pageLength;
-        if (end > _couponsOrderedList.length) end = _couponsOrderedList.length;
-        uint256[] memory page = new uint256[](end - start);
-        for (uint256 i; i < page.length; i++) page[i] = _couponsOrderedList[start + i];
-        return page;
     }
 }

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponFacetTimeTravel.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFacet } from "../../../../facets/layer_2/coupon/standard/CouponFacet.sol";
+
+contract CouponFacetTimeTravel is CouponFacet {}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponFixedRateFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponFixedRateFacetTimeTravel.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { CouponFixedRateFacet } from "../../../../facets/layer_2/coupon/fixedRate/CouponFixedRateFacet.sol";
+
+contract CouponFixedRateFacetTimeTravel is CouponFixedRateFacet {}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponKpiLinkedRateFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponKpiLinkedRateFacetTimeTravel.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+// prettier-ignore
+// solhint-disable-next-line max-line-length
+import { CouponKpiLinkedRateFacet } from "../../../../facets/layer_2/coupon/kpiLinkedRate/CouponKpiLinkedRateFacet.sol";
+
+contract CouponKpiLinkedRateFacetTimeTravel is CouponKpiLinkedRateFacet {}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponSustainabilityPerformanceTargetRateFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/coupon/CouponSustainabilityPerformanceTargetRateFacetTimeTravel.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+// prettier-ignore
+// solhint-disable-next-line max-line-length
+import { CouponSustainabilityPerformanceTargetRateFacet } from "../../../../facets/layer_2/coupon/sustainabilityPerformanceTargetRate/CouponSustainabilityPerformanceTargetRateFacet.sol";
+
+contract CouponSustainabilityPerformanceTargetRateFacetTimeTravel is CouponSustainabilityPerformanceTargetRateFacet {}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/eRC1594/ERC1594KpiLinkedRateFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/eRC1594/ERC1594KpiLinkedRateFacetTimeTravel.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ERC1594Facet } from "../../../../facets/layer_1/ERC1400/ERC1594/ERC1594Facet.sol";
+import { TimeTravelProvider } from "../../timeTravel/TimeTravelProvider.sol";
+import { TimestampProvider } from "../../../../infrastructure/utils/TimestampProvider.sol";
+
+contract ERC1594KpiLinkedRateFacetTimeTravel is ERC1594Facet, TimeTravelProvider {
+    function _getBlockTimestamp() internal view override(TimestampProvider, TimeTravelProvider) returns (uint256) {
+        return TimeTravelProvider._getBlockTimestamp();
+    }
+
+    function _getBlockNumber() internal view override(TimestampProvider, TimeTravelProvider) returns (uint256) {
+        return TimeTravelProvider._getBlockNumber();
+    }
+}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/eRC1594/ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/eRC1594/ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ERC1594Facet } from "../../../../facets/layer_1/ERC1400/ERC1594/ERC1594Facet.sol";
+import { TimeTravelProvider } from "../../timeTravel/TimeTravelProvider.sol";
+import { TimestampProvider } from "../../../../infrastructure/utils/TimestampProvider.sol";
+
+contract ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel is ERC1594Facet, TimeTravelProvider {
+    function _getBlockTimestamp() internal view override(TimestampProvider, TimeTravelProvider) returns (uint256) {
+        return TimeTravelProvider._getBlockTimestamp();
+    }
+
+    function _getBlockNumber() internal view override(TimestampProvider, TimeTravelProvider) returns (uint256) {
+        return TimeTravelProvider._getBlockNumber();
+    }
+}

--- a/packages/ats/contracts/contracts/test/testTimeTravel/timeTravel/TimeTravelFacet.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/timeTravel/TimeTravelFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../../../infrastructure/utils/EvmAccessors.sol";
+import { BondStorageWrapper } from "../../../domain/asset/BondStorageWrapper.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
 import { ITimeTravel } from "../ITimeTravel.sol";
 import { TimeTravelProvider } from "./TimeTravelProvider.sol";
@@ -41,6 +42,11 @@ contract TimeTravelFacet is IStaticFunctionSelectors, ITimeTravel, TimeTravelPro
         emit SystemBlocknumberReset();
     }
 
+    // solhint-disable-next-line func-name-mixedcase
+    function testOnlyAddDeprecatedCoupon(uint256 _couponID) external {
+        BondStorageWrapper.DEPRECATED_pushCouponOrderedListId(_couponID);
+    }
+
     function blockTimestamp() external view override returns (uint256) {
         return TimeTravelStorageWrapper.getBlockTimestamp();
     }
@@ -65,13 +71,14 @@ contract TimeTravelFacet is IStaticFunctionSelectors, ITimeTravel, TimeTravelPro
         returns (bytes4[] memory staticFunctionSelectors_)
     {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](6);
+        staticFunctionSelectors_ = new bytes4[](7);
         staticFunctionSelectors_[selectorIndex++] = this.changeSystemTimestamp.selector;
         staticFunctionSelectors_[selectorIndex++] = this.resetSystemTimestamp.selector;
         staticFunctionSelectors_[selectorIndex++] = this.blockTimestamp.selector;
         staticFunctionSelectors_[selectorIndex++] = this.checkBlockChainid.selector;
         staticFunctionSelectors_[selectorIndex++] = this.changeSystemBlocknumber.selector;
         staticFunctionSelectors_[selectorIndex++] = this.resetSystemBlocknumber.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.testOnlyAddDeprecatedCoupon.selector;
     }
 
     function getStaticInterfaceIds() external pure virtual override returns (bytes4[] memory staticInterfaceIds_) {

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-14T13:14:03.761Z
+ * Generated: 2026-04-14T15:09:42.335Z
  * Facets: 73
  * Infrastructure: 2
  *
@@ -419,6 +419,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AccountHasNoRole(address,bytes32)",
         },
         selector: "0xa1180aad",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "FactorIsZero",
@@ -3445,6 +3450,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x3a11c78b",
       },
       {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
         name: "SnapshotIdDoesNotExists",
         signature: {
           full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
@@ -3640,6 +3650,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponCreationFailed",
         signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
         selector: "0x3a11c78b",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "InterestRateIsFixed",
@@ -3845,6 +3860,16 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x3a11c78b",
       },
       {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
+        name: "InterestRateIsKpiLinked",
+        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
+        selector: "0x68eba14f",
+      },
+      {
         name: "SnapshotIdDoesNotExists",
         signature: {
           full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
@@ -4041,6 +4066,19 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponCreationFailed",
         signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
         selector: "0x3a11c78b",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
+        name: "InterestRateIsSustainabilityPerformanceTargetRate",
+        signature: {
+          full: "error InterestRateIsSustainabilityPerformanceTargetRate()",
+          canonical: "InterestRateIsSustainabilityPerformanceTargetRate()",
+        },
+        selector: "0x4f56f79f",
       },
       {
         name: "SnapshotIdDoesNotExists",
@@ -6284,6 +6322,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "BrokenClockMode",
         signature: { full: "error BrokenClockMode()", canonical: "BrokenClockMode()" },
         selector: "0xb2b9e563",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "FutureLookup",
@@ -8824,6 +8867,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x0dc149f0",
       },
       {
+        name: "InterestRateIsKpiLinked",
+        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
+        selector: "0x68eba14f",
+      },
+      {
         name: "TokenIsPaused",
         signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
         selector: "0x649815a5",
@@ -8913,6 +8961,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AccountHasNoRole(address,bytes32)",
         },
         selector: "0xa1180aad",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "InvalidDate",
@@ -9014,6 +9067,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AccountHasNoRole(address,bytes32)",
         },
         selector: "0xa1180aad",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "InvalidDate",
@@ -10344,6 +10402,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x10210dec",
       },
       {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
         name: "TokenIsPaused",
         signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
         selector: "0x649815a5",
@@ -10427,6 +10490,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x10210dec",
       },
       {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
         name: "TokenIsPaused",
         signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
         selector: "0x649815a5",
@@ -10507,6 +10575,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AccessControlRequired(bytes32,address)",
         },
         selector: "0x10210dec",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
       },
       {
         name: "TokenIsPaused",
@@ -10757,6 +10830,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xa1180aad",
       },
       {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
         name: "SnapshotIdDoesNotExists",
         signature: {
           full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
@@ -11003,6 +11081,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "AlreadyInitialized",
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
+      },
+      {
+        name: "InterestRateIsSustainabilityPerformanceTargetRate",
+        signature: {
+          full: "error InterestRateIsSustainabilityPerformanceTargetRate()",
+          canonical: "InterestRateIsSustainabilityPerformanceTargetRate()",
+        },
+        selector: "0x4f56f79f",
       },
       {
         name: "NotExistingProject",

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-13T16:54:56.424Z
- * Facets: 69
+ * Generated: 2026-04-14T13:14:03.761Z
+ * Facets: 73
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -37,6 +37,10 @@ import {
   ClearingTransferFacet__factory,
   ControlListFacet__factory,
   CorporateActionsFacet__factory,
+  CouponFacet__factory,
+  CouponFixedRateFacet__factory,
+  CouponKpiLinkedRateFacet__factory,
+  CouponSustainabilityPerformanceTargetRateFacet__factory,
   DiamondFacet__factory,
   ERC1410IssuerFacet__factory,
   ERC1410ManagementFacet__factory,
@@ -106,6 +110,10 @@ import {
   ClearingTransferFacetTimeTravel__factory,
   ControlListFacetTimeTravel__factory,
   CorporateActionsFacetTimeTravel__factory,
+  CouponFacetTimeTravel__factory,
+  CouponFixedRateFacetTimeTravel__factory,
+  CouponKpiLinkedRateFacetTimeTravel__factory,
+  CouponSustainabilityPerformanceTargetRateFacetTimeTravel__factory,
   DiamondFacetTimeTravel__factory,
   ERC1410IssuerFacetTimeTravel__factory,
   ERC1410ManagementFacetTimeTravel__factory,
@@ -450,14 +458,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x86d59729",
       },
       {
-        name: "cancelCoupon",
-        signature: {
-          full: "function cancelCoupon(uint256 _couponId) returns (bool success_)",
-          canonical: "cancelCoupon(uint256)",
-        },
-        selector: "0x0459fafb",
-      },
-      {
         name: "fullRedeemAtMaturity",
         signature: {
           full: "function fullRedeemAtMaturity(address _tokenHolder)",
@@ -474,14 +474,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8a647211",
       },
       {
-        name: "setCoupon",
-        signature: {
-          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
-          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        selector: "0xb16fd0cc",
-      },
-      {
         name: "updateMaturityDate",
         signature: {
           full: "function updateMaturityDate(uint256 _newMaturityDate) returns (bool success_)",
@@ -491,22 +483,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponCancelled",
-        signature: {
-          full: "event CouponCancelled(uint256 couponId, address indexed operator)",
-          canonical: "CouponCancelled(uint256,address)",
-        },
-        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
-      },
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "DelegateVotesChanged",
         signature: {
@@ -589,30 +565,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
       {
-        name: "CouponAlreadyExecuted",
-        signature: {
-          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
-          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
-        },
-        selector: "0xae5a5af7",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
         name: "InsufficientBalance",
         signature: {
           full: "error InsufficientBalance(address account, uint256 balance, uint256 value, bytes32 partition)",
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
-      },
-      {
-        name: "InterestRateIsKpiLinked",
-        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
-        selector: "0x68eba14f",
       },
       {
         name: "InvalidKycStatus",
@@ -662,22 +620,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "WalletRecovered",
         signature: { full: "error WalletRecovered()", canonical: "WalletRecovered()" },
         selector: "0xf9f9bcf9",
-      },
-      {
-        name: "WrongDates",
-        signature: {
-          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
-          canonical: "WrongDates(uint256,uint256)",
-        },
-        selector: "0x1c94559c",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -707,14 +649,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x86d59729",
       },
       {
-        name: "cancelCoupon",
-        signature: {
-          full: "function cancelCoupon(uint256 _couponId) returns (bool success_)",
-          canonical: "cancelCoupon(uint256)",
-        },
-        selector: "0x0459fafb",
-      },
-      {
         name: "fullRedeemAtMaturity",
         signature: {
           full: "function fullRedeemAtMaturity(address _tokenHolder)",
@@ -731,14 +665,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8a647211",
       },
       {
-        name: "setCoupon",
-        signature: {
-          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
-          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        selector: "0xb16fd0cc",
-      },
-      {
         name: "updateMaturityDate",
         signature: {
           full: "function updateMaturityDate(uint256 _newMaturityDate) returns (bool success_)",
@@ -748,22 +674,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponCancelled",
-        signature: {
-          full: "event CouponCancelled(uint256 couponId, address indexed operator)",
-          canonical: "CouponCancelled(uint256,address)",
-        },
-        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
-      },
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "DelegateVotesChanged",
         signature: {
@@ -846,30 +756,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
       {
-        name: "CouponAlreadyExecuted",
-        signature: {
-          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
-          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
-        },
-        selector: "0xae5a5af7",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
         name: "InsufficientBalance",
         signature: {
           full: "error InsufficientBalance(address account, uint256 balance, uint256 value, bytes32 partition)",
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
-      },
-      {
-        name: "InterestRateIsFixed",
-        signature: { full: "error InterestRateIsFixed()", canonical: "InterestRateIsFixed()" },
-        selector: "0x849d4eb8",
       },
       {
         name: "InvalidKycStatus",
@@ -919,22 +811,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "WalletRecovered",
         signature: { full: "error WalletRecovered()", canonical: "WalletRecovered()" },
         selector: "0xf9f9bcf9",
-      },
-      {
-        name: "WrongDates",
-        signature: {
-          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
-          canonical: "WrongDates(uint256,uint256)",
-        },
-        selector: "0x1c94559c",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -964,14 +840,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x86d59729",
       },
       {
-        name: "cancelCoupon",
-        signature: {
-          full: "function cancelCoupon(uint256 _couponId) returns (bool success_)",
-          canonical: "cancelCoupon(uint256)",
-        },
-        selector: "0x0459fafb",
-      },
-      {
         name: "fullRedeemAtMaturity",
         signature: {
           full: "function fullRedeemAtMaturity(address _tokenHolder)",
@@ -988,14 +856,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8a647211",
       },
       {
-        name: "setCoupon",
-        signature: {
-          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
-          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        selector: "0xb16fd0cc",
-      },
-      {
         name: "updateMaturityDate",
         signature: {
           full: "function updateMaturityDate(uint256 _newMaturityDate) returns (bool success_)",
@@ -1005,22 +865,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponCancelled",
-        signature: {
-          full: "event CouponCancelled(uint256 couponId, address indexed operator)",
-          canonical: "CouponCancelled(uint256,address)",
-        },
-        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
-      },
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "DelegateVotesChanged",
         signature: {
@@ -1103,30 +947,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
       {
-        name: "CouponAlreadyExecuted",
-        signature: {
-          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
-          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
-        },
-        selector: "0xae5a5af7",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
         name: "InsufficientBalance",
         signature: {
           full: "error InsufficientBalance(address account, uint256 balance, uint256 value, bytes32 partition)",
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
-      },
-      {
-        name: "InterestRateIsKpiLinked",
-        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
-        selector: "0x68eba14f",
       },
       {
         name: "InvalidKycStatus",
@@ -1178,22 +1004,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xf9f9bcf9",
       },
       {
-        name: "WrongDates",
-        signature: {
-          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
-          canonical: "WrongDates(uint256,uint256)",
-        },
-        selector: "0x1c94559c",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
-      },
-      {
         name: "ZeroAddressNotAllowed",
         signature: { full: "error ZeroAddressNotAllowed()", canonical: "ZeroAddressNotAllowed()" },
         selector: "0x8579befe",
@@ -1220,70 +1030,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getCoupon",
-        signature: {
-          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
-          canonical: "getCoupon(uint256)",
-        },
-        selector: "0x936e3169",
-      },
-      {
-        name: "getCouponAmountFor",
-        signature: {
-          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
-          canonical: "getCouponAmountFor(uint256,address)",
-        },
-        selector: "0x439efc2e",
-      },
-      {
-        name: "getCouponCount",
-        signature: {
-          full: "function getCouponCount() view returns (uint256 couponCount_)",
-          canonical: "getCouponCount()",
-        },
-        selector: "0x468bb240",
-      },
-      {
-        name: "getCouponFor",
-        signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, bool isDisabled) couponFor_)",
-          canonical: "getCouponFor(uint256,address)",
-        },
-        selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponFromOrderedListAt",
-        signature: {
-          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
-          canonical: "getCouponFromOrderedListAt(uint256)",
-        },
-        selector: "0x65a88a2c",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsOrderedList",
-        signature: {
-          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
-          canonical: "getCouponsOrderedList(uint256,uint256)",
-        },
-        selector: "0xd7133de1",
-      },
-      {
-        name: "getCouponsOrderedListTotal",
-        signature: {
-          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
-          canonical: "getCouponsOrderedListTotal()",
-        },
-        selector: "0xee1d26eb",
-      },
-      {
         name: "getPrincipalFor",
         signature: {
           full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
@@ -1308,14 +1054,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8fda5afe",
       },
       {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "getTotalSecurityHolders",
         signature: {
           full: "function getTotalSecurityHolders() view returns (uint256)",
@@ -1325,14 +1063,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "MaturityDateUpdated",
         signature: {
@@ -1344,48 +1074,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     errors: [
       {
-        name: "AccessControlRequired",
-        signature: {
-          full: "error AccessControlRequired(bytes32 role, address sender)",
-          canonical: "AccessControlRequired(bytes32,address)",
-        },
-        selector: "0x10210dec",
-      },
-      {
         name: "BondMaturityDateWrong",
         signature: { full: "error BondMaturityDateWrong()", canonical: "BondMaturityDateWrong()" },
         selector: "0x67d08758",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
-        name: "SnapshotIdDoesNotExists",
-        signature: {
-          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
-          canonical: "SnapshotIdDoesNotExists(uint256)",
-        },
-        selector: "0x8e81eb83",
-      },
-      {
-        name: "SnapshotIdNull",
-        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
-        selector: "0xf128004d",
-      },
-      {
-        name: "UnexpectedError",
-        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
-        selector: "0xc9622656",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
     ],
     factory: (signer) => new BondUSAReadFacet__factory(getLibLinks("clearingReadOps") as any, signer),
@@ -1410,70 +1101,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getCoupon",
-        signature: {
-          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
-          canonical: "getCoupon(uint256)",
-        },
-        selector: "0x936e3169",
-      },
-      {
-        name: "getCouponAmountFor",
-        signature: {
-          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
-          canonical: "getCouponAmountFor(uint256,address)",
-        },
-        selector: "0x439efc2e",
-      },
-      {
-        name: "getCouponCount",
-        signature: {
-          full: "function getCouponCount() view returns (uint256 couponCount_)",
-          canonical: "getCouponCount()",
-        },
-        selector: "0x468bb240",
-      },
-      {
-        name: "getCouponFor",
-        signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, bool isDisabled) couponFor_)",
-          canonical: "getCouponFor(uint256,address)",
-        },
-        selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponFromOrderedListAt",
-        signature: {
-          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
-          canonical: "getCouponFromOrderedListAt(uint256)",
-        },
-        selector: "0x65a88a2c",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsOrderedList",
-        signature: {
-          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
-          canonical: "getCouponsOrderedList(uint256,uint256)",
-        },
-        selector: "0xd7133de1",
-      },
-      {
-        name: "getCouponsOrderedListTotal",
-        signature: {
-          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
-          canonical: "getCouponsOrderedListTotal()",
-        },
-        selector: "0xee1d26eb",
-      },
-      {
         name: "getPrincipalFor",
         signature: {
           full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
@@ -1498,14 +1125,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8fda5afe",
       },
       {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "getTotalSecurityHolders",
         signature: {
           full: "function getTotalSecurityHolders() view returns (uint256)",
@@ -1515,14 +1134,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "MaturityDateUpdated",
         signature: {
@@ -1534,48 +1145,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     errors: [
       {
-        name: "AccessControlRequired",
-        signature: {
-          full: "error AccessControlRequired(bytes32 role, address sender)",
-          canonical: "AccessControlRequired(bytes32,address)",
-        },
-        selector: "0x10210dec",
-      },
-      {
         name: "BondMaturityDateWrong",
         signature: { full: "error BondMaturityDateWrong()", canonical: "BondMaturityDateWrong()" },
         selector: "0x67d08758",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
-        name: "SnapshotIdDoesNotExists",
-        signature: {
-          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
-          canonical: "SnapshotIdDoesNotExists(uint256)",
-        },
-        selector: "0x8e81eb83",
-      },
-      {
-        name: "SnapshotIdNull",
-        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
-        selector: "0xf128004d",
-      },
-      {
-        name: "UnexpectedError",
-        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
-        selector: "0xc9622656",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
     ],
     factory: (signer) => new BondUSAReadFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
@@ -1600,70 +1172,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getCoupon",
-        signature: {
-          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
-          canonical: "getCoupon(uint256)",
-        },
-        selector: "0x936e3169",
-      },
-      {
-        name: "getCouponAmountFor",
-        signature: {
-          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
-          canonical: "getCouponAmountFor(uint256,address)",
-        },
-        selector: "0x439efc2e",
-      },
-      {
-        name: "getCouponCount",
-        signature: {
-          full: "function getCouponCount() view returns (uint256 couponCount_)",
-          canonical: "getCouponCount()",
-        },
-        selector: "0x468bb240",
-      },
-      {
-        name: "getCouponFor",
-        signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, bool isDisabled) couponFor_)",
-          canonical: "getCouponFor(uint256,address)",
-        },
-        selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponFromOrderedListAt",
-        signature: {
-          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
-          canonical: "getCouponFromOrderedListAt(uint256)",
-        },
-        selector: "0x65a88a2c",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsOrderedList",
-        signature: {
-          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
-          canonical: "getCouponsOrderedList(uint256,uint256)",
-        },
-        selector: "0xd7133de1",
-      },
-      {
-        name: "getCouponsOrderedListTotal",
-        signature: {
-          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
-          canonical: "getCouponsOrderedListTotal()",
-        },
-        selector: "0xee1d26eb",
-      },
-      {
         name: "getPrincipalFor",
         signature: {
           full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
@@ -1688,14 +1196,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8fda5afe",
       },
       {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "getTotalSecurityHolders",
         signature: {
           full: "function getTotalSecurityHolders() view returns (uint256)",
@@ -1705,14 +1205,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "MaturityDateUpdated",
         signature: {
@@ -1724,48 +1216,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     errors: [
       {
-        name: "AccessControlRequired",
-        signature: {
-          full: "error AccessControlRequired(bytes32 role, address sender)",
-          canonical: "AccessControlRequired(bytes32,address)",
-        },
-        selector: "0x10210dec",
-      },
-      {
         name: "BondMaturityDateWrong",
         signature: { full: "error BondMaturityDateWrong()", canonical: "BondMaturityDateWrong()" },
         selector: "0x67d08758",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
-        name: "SnapshotIdDoesNotExists",
-        signature: {
-          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
-          canonical: "SnapshotIdDoesNotExists(uint256)",
-        },
-        selector: "0x8e81eb83",
-      },
-      {
-        name: "SnapshotIdNull",
-        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
-        selector: "0xf128004d",
-      },
-      {
-        name: "UnexpectedError",
-        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
-        selector: "0xc9622656",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
     ],
     factory: (signer) => new BondUSAReadKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
@@ -1790,70 +1243,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getCoupon",
-        signature: {
-          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
-          canonical: "getCoupon(uint256)",
-        },
-        selector: "0x936e3169",
-      },
-      {
-        name: "getCouponAmountFor",
-        signature: {
-          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
-          canonical: "getCouponAmountFor(uint256,address)",
-        },
-        selector: "0x439efc2e",
-      },
-      {
-        name: "getCouponCount",
-        signature: {
-          full: "function getCouponCount() view returns (uint256 couponCount_)",
-          canonical: "getCouponCount()",
-        },
-        selector: "0x468bb240",
-      },
-      {
-        name: "getCouponFor",
-        signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, bool isDisabled) couponFor_)",
-          canonical: "getCouponFor(uint256,address)",
-        },
-        selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponFromOrderedListAt",
-        signature: {
-          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
-          canonical: "getCouponFromOrderedListAt(uint256)",
-        },
-        selector: "0x65a88a2c",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsOrderedList",
-        signature: {
-          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
-          canonical: "getCouponsOrderedList(uint256,uint256)",
-        },
-        selector: "0xd7133de1",
-      },
-      {
-        name: "getCouponsOrderedListTotal",
-        signature: {
-          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
-          canonical: "getCouponsOrderedListTotal()",
-        },
-        selector: "0xee1d26eb",
-      },
-      {
         name: "getPrincipalFor",
         signature: {
           full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
@@ -1878,14 +1267,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8fda5afe",
       },
       {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "getTotalSecurityHolders",
         signature: {
           full: "function getTotalSecurityHolders() view returns (uint256)",
@@ -1895,14 +1276,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "MaturityDateUpdated",
         signature: {
@@ -1914,48 +1287,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     errors: [
       {
-        name: "AccessControlRequired",
-        signature: {
-          full: "error AccessControlRequired(bytes32 role, address sender)",
-          canonical: "AccessControlRequired(bytes32,address)",
-        },
-        selector: "0x10210dec",
-      },
-      {
         name: "BondMaturityDateWrong",
         signature: { full: "error BondMaturityDateWrong()", canonical: "BondMaturityDateWrong()" },
         selector: "0x67d08758",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
-        name: "SnapshotIdDoesNotExists",
-        signature: {
-          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
-          canonical: "SnapshotIdDoesNotExists(uint256)",
-        },
-        selector: "0x8e81eb83",
-      },
-      {
-        name: "SnapshotIdNull",
-        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
-        selector: "0xf128004d",
-      },
-      {
-        name: "UnexpectedError",
-        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
-        selector: "0xc9622656",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
     ],
     factory: (signer) =>
@@ -1985,14 +1319,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x86d59729",
       },
       {
-        name: "cancelCoupon",
-        signature: {
-          full: "function cancelCoupon(uint256 _couponId) returns (bool success_)",
-          canonical: "cancelCoupon(uint256)",
-        },
-        selector: "0x0459fafb",
-      },
-      {
         name: "fullRedeemAtMaturity",
         signature: {
           full: "function fullRedeemAtMaturity(address _tokenHolder)",
@@ -2009,14 +1335,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8a647211",
       },
       {
-        name: "setCoupon",
-        signature: {
-          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
-          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        selector: "0xb16fd0cc",
-      },
-      {
         name: "updateMaturityDate",
         signature: {
           full: "function updateMaturityDate(uint256 _newMaturityDate) returns (bool success_)",
@@ -2026,22 +1344,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     events: [
-      {
-        name: "CouponCancelled",
-        signature: {
-          full: "event CouponCancelled(uint256 couponId, address indexed operator)",
-          canonical: "CouponCancelled(uint256,address)",
-        },
-        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
-      },
-      {
-        name: "CouponSet",
-        signature: {
-          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
-          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
-        },
-        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
-      },
       {
         name: "DelegateVotesChanged",
         signature: {
@@ -2124,30 +1426,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
       {
-        name: "CouponAlreadyExecuted",
-        signature: {
-          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
-          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
-        },
-        selector: "0xae5a5af7",
-      },
-      {
-        name: "CouponCreationFailed",
-        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
-        selector: "0x3a11c78b",
-      },
-      {
         name: "InsufficientBalance",
         signature: {
           full: "error InsufficientBalance(address account, uint256 balance, uint256 value, bytes32 partition)",
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
-      },
-      {
-        name: "InterestRateIsKpiLinked",
-        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
-        selector: "0x68eba14f",
       },
       {
         name: "InvalidKycStatus",
@@ -2197,22 +1481,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "WalletRecovered",
         signature: { full: "error WalletRecovered()", canonical: "WalletRecovered()" },
         selector: "0xf9f9bcf9",
-      },
-      {
-        name: "WrongDates",
-        signature: {
-          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
-          canonical: "WrongDates(uint256,uint256)",
-        },
-        selector: "0x1c94559c",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -4021,6 +3289,806 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     factory: (signer) => new CorporateActionsFacet__factory(signer),
     timeTravelFactory: (signer) => new CorporateActionsFacetTimeTravel__factory(signer),
+  },
+
+  CouponFacet: {
+    name: "CouponFacet",
+    resolverKey: {
+      name: "_COUPON_RESOLVER_KEY",
+      value: "0xa404f705370f56f56364ac9aa1092c1002b2bfcd7020c1bb5ca7489f8061efa7",
+    },
+    inheritance: ["CouponFacetBase"],
+    methods: [
+      {
+        name: "cancelCoupon",
+        signature: {
+          full: "function cancelCoupon(uint256 _couponID) returns (bool success_)",
+          canonical: "cancelCoupon(uint256)",
+        },
+        selector: "0x0459fafb",
+      },
+      {
+        name: "getCoupon",
+        signature: {
+          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
+          canonical: "getCoupon(uint256)",
+        },
+        selector: "0x936e3169",
+      },
+      {
+        name: "getCouponAmountFor",
+        signature: {
+          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
+          canonical: "getCouponAmountFor(uint256,address)",
+        },
+        selector: "0x439efc2e",
+      },
+      {
+        name: "getCouponCount",
+        signature: {
+          full: "function getCouponCount() view returns (uint256 couponCount_)",
+          canonical: "getCouponCount()",
+        },
+        selector: "0x468bb240",
+      },
+      {
+        name: "getCouponFor",
+        signature: {
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          canonical: "getCouponFor(uint256,address)",
+        },
+        selector: "0xbba7b56d",
+      },
+      {
+        name: "getCouponFromOrderedListAt",
+        signature: {
+          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
+          canonical: "getCouponFromOrderedListAt(uint256)",
+        },
+        selector: "0x65a88a2c",
+      },
+      {
+        name: "getCouponHolders",
+        signature: {
+          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getCouponHolders(uint256,uint256,uint256)",
+        },
+        selector: "0xa92e8371",
+      },
+      {
+        name: "getCouponsFor",
+        signature: {
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          canonical: "getCouponsFor(uint256,uint256,uint256)",
+        },
+        selector: "0x7327ad90",
+      },
+      {
+        name: "getCouponsOrderedList",
+        signature: {
+          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
+          canonical: "getCouponsOrderedList(uint256,uint256)",
+        },
+        selector: "0xd7133de1",
+      },
+      {
+        name: "getCouponsOrderedListTotal",
+        signature: {
+          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
+          canonical: "getCouponsOrderedListTotal()",
+        },
+        selector: "0xee1d26eb",
+      },
+      {
+        name: "getTotalCouponHolders",
+        signature: {
+          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
+          canonical: "getTotalCouponHolders(uint256)",
+        },
+        selector: "0xec116ae3",
+      },
+      {
+        name: "setCoupon",
+        signature: {
+          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
+          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        selector: "0xb16fd0cc",
+      },
+    ],
+    events: [
+      {
+        name: "CouponCancelled",
+        signature: {
+          full: "event CouponCancelled(uint256 indexed couponId, address indexed operator)",
+          canonical: "CouponCancelled(uint256,address)",
+        },
+        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
+      },
+      {
+        name: "CouponSet",
+        signature: {
+          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
+          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "CouponAlreadyExecuted",
+        signature: {
+          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
+          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
+        },
+        selector: "0xae5a5af7",
+      },
+      {
+        name: "CouponCreationFailed",
+        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
+        selector: "0x3a11c78b",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongDates",
+        signature: {
+          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
+          canonical: "WrongDates(uint256,uint256)",
+        },
+        selector: "0x1c94559c",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+    ],
+    factory: (signer) => new CouponFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) => new CouponFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
+
+  CouponFixedRateFacet: {
+    name: "CouponFixedRateFacet",
+    resolverKey: {
+      name: "_COUPON_FIXED_RATE_RESOLVER_KEY",
+      value: "0x2e0b1146e97bc72f92441d75c9cfa74185548319741c7f292fe0014252933ae9",
+    },
+    inheritance: ["CouponFacetBase"],
+    methods: [
+      {
+        name: "cancelCoupon",
+        signature: {
+          full: "function cancelCoupon(uint256 _couponID) returns (bool success_)",
+          canonical: "cancelCoupon(uint256)",
+        },
+        selector: "0x0459fafb",
+      },
+      {
+        name: "getCoupon",
+        signature: {
+          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
+          canonical: "getCoupon(uint256)",
+        },
+        selector: "0x936e3169",
+      },
+      {
+        name: "getCouponAmountFor",
+        signature: {
+          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
+          canonical: "getCouponAmountFor(uint256,address)",
+        },
+        selector: "0x439efc2e",
+      },
+      {
+        name: "getCouponCount",
+        signature: {
+          full: "function getCouponCount() view returns (uint256 couponCount_)",
+          canonical: "getCouponCount()",
+        },
+        selector: "0x468bb240",
+      },
+      {
+        name: "getCouponFor",
+        signature: {
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          canonical: "getCouponFor(uint256,address)",
+        },
+        selector: "0xbba7b56d",
+      },
+      {
+        name: "getCouponFromOrderedListAt",
+        signature: {
+          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
+          canonical: "getCouponFromOrderedListAt(uint256)",
+        },
+        selector: "0x65a88a2c",
+      },
+      {
+        name: "getCouponHolders",
+        signature: {
+          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getCouponHolders(uint256,uint256,uint256)",
+        },
+        selector: "0xa92e8371",
+      },
+      {
+        name: "getCouponsFor",
+        signature: {
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          canonical: "getCouponsFor(uint256,uint256,uint256)",
+        },
+        selector: "0x7327ad90",
+      },
+      {
+        name: "getCouponsOrderedList",
+        signature: {
+          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
+          canonical: "getCouponsOrderedList(uint256,uint256)",
+        },
+        selector: "0xd7133de1",
+      },
+      {
+        name: "getCouponsOrderedListTotal",
+        signature: {
+          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
+          canonical: "getCouponsOrderedListTotal()",
+        },
+        selector: "0xee1d26eb",
+      },
+      {
+        name: "getTotalCouponHolders",
+        signature: {
+          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
+          canonical: "getTotalCouponHolders(uint256)",
+        },
+        selector: "0xec116ae3",
+      },
+      {
+        name: "setCoupon",
+        signature: {
+          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
+          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        selector: "0xb16fd0cc",
+      },
+    ],
+    events: [
+      {
+        name: "CouponCancelled",
+        signature: {
+          full: "event CouponCancelled(uint256 indexed couponId, address indexed operator)",
+          canonical: "CouponCancelled(uint256,address)",
+        },
+        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
+      },
+      {
+        name: "CouponSet",
+        signature: {
+          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
+          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "CouponAlreadyExecuted",
+        signature: {
+          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
+          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
+        },
+        selector: "0xae5a5af7",
+      },
+      {
+        name: "CouponCreationFailed",
+        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
+        selector: "0x3a11c78b",
+      },
+      {
+        name: "InterestRateIsFixed",
+        signature: { full: "error InterestRateIsFixed()", canonical: "InterestRateIsFixed()" },
+        selector: "0x849d4eb8",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongDates",
+        signature: {
+          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
+          canonical: "WrongDates(uint256,uint256)",
+        },
+        selector: "0x1c94559c",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+    ],
+    factory: (signer) => new CouponFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new CouponFixedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
+
+  CouponKpiLinkedRateFacet: {
+    name: "CouponKpiLinkedRateFacet",
+    resolverKey: {
+      name: "_COUPON_KPI_LINKED_RATE_RESOLVER_KEY",
+      value: "0x45f4a1774eac5a47f3cbc755bf5332ca30d8a6bb0330d479c77590dd0d5aab18",
+    },
+    inheritance: ["CouponFacetBase"],
+    methods: [
+      {
+        name: "cancelCoupon",
+        signature: {
+          full: "function cancelCoupon(uint256 _couponID) returns (bool success_)",
+          canonical: "cancelCoupon(uint256)",
+        },
+        selector: "0x0459fafb",
+      },
+      {
+        name: "getCoupon",
+        signature: {
+          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
+          canonical: "getCoupon(uint256)",
+        },
+        selector: "0x936e3169",
+      },
+      {
+        name: "getCouponAmountFor",
+        signature: {
+          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
+          canonical: "getCouponAmountFor(uint256,address)",
+        },
+        selector: "0x439efc2e",
+      },
+      {
+        name: "getCouponCount",
+        signature: {
+          full: "function getCouponCount() view returns (uint256 couponCount_)",
+          canonical: "getCouponCount()",
+        },
+        selector: "0x468bb240",
+      },
+      {
+        name: "getCouponFor",
+        signature: {
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          canonical: "getCouponFor(uint256,address)",
+        },
+        selector: "0xbba7b56d",
+      },
+      {
+        name: "getCouponFromOrderedListAt",
+        signature: {
+          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
+          canonical: "getCouponFromOrderedListAt(uint256)",
+        },
+        selector: "0x65a88a2c",
+      },
+      {
+        name: "getCouponHolders",
+        signature: {
+          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getCouponHolders(uint256,uint256,uint256)",
+        },
+        selector: "0xa92e8371",
+      },
+      {
+        name: "getCouponsFor",
+        signature: {
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          canonical: "getCouponsFor(uint256,uint256,uint256)",
+        },
+        selector: "0x7327ad90",
+      },
+      {
+        name: "getCouponsOrderedList",
+        signature: {
+          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
+          canonical: "getCouponsOrderedList(uint256,uint256)",
+        },
+        selector: "0xd7133de1",
+      },
+      {
+        name: "getCouponsOrderedListTotal",
+        signature: {
+          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
+          canonical: "getCouponsOrderedListTotal()",
+        },
+        selector: "0xee1d26eb",
+      },
+      {
+        name: "getTotalCouponHolders",
+        signature: {
+          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
+          canonical: "getTotalCouponHolders(uint256)",
+        },
+        selector: "0xec116ae3",
+      },
+      {
+        name: "setCoupon",
+        signature: {
+          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
+          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        selector: "0xb16fd0cc",
+      },
+    ],
+    events: [
+      {
+        name: "CouponCancelled",
+        signature: {
+          full: "event CouponCancelled(uint256 indexed couponId, address indexed operator)",
+          canonical: "CouponCancelled(uint256,address)",
+        },
+        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
+      },
+      {
+        name: "CouponSet",
+        signature: {
+          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
+          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "CouponAlreadyExecuted",
+        signature: {
+          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
+          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
+        },
+        selector: "0xae5a5af7",
+      },
+      {
+        name: "CouponCreationFailed",
+        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
+        selector: "0x3a11c78b",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongDates",
+        signature: {
+          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
+          canonical: "WrongDates(uint256,uint256)",
+        },
+        selector: "0x1c94559c",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+    ],
+    factory: (signer) => new CouponKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new CouponKpiLinkedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
+
+  CouponSustainabilityPerformanceTargetRateFacet: {
+    name: "CouponSustainabilityPerformanceTargetRateFacet",
+    resolverKey: {
+      name: "_COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY",
+      value: "0x435034f1d262736f434867e5f70c71157492ebd5a90e9e4455b2868f5bda6b6e",
+    },
+    inheritance: ["CouponFacetBase"],
+    methods: [
+      {
+        name: "cancelCoupon",
+        signature: {
+          full: "function cancelCoupon(uint256 _couponID) returns (bool success_)",
+          canonical: "cancelCoupon(uint256)",
+        },
+        selector: "0x0459fafb",
+      },
+      {
+        name: "getCoupon",
+        signature: {
+          full: "function getCoupon(uint256 _couponID) view returns (((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, uint256 snapshotId) registeredCoupon_, bool isDisabled_)",
+          canonical: "getCoupon(uint256)",
+        },
+        selector: "0x936e3169",
+      },
+      {
+        name: "getCouponAmountFor",
+        signature: {
+          full: "function getCouponAmountFor(uint256 _couponID, address _account) view returns ((uint256 numerator, uint256 denominator, bool recordDateReached) couponAmountFor_)",
+          canonical: "getCouponAmountFor(uint256,address)",
+        },
+        selector: "0x439efc2e",
+      },
+      {
+        name: "getCouponCount",
+        signature: {
+          full: "function getCouponCount() view returns (uint256 couponCount_)",
+          canonical: "getCouponCount()",
+        },
+        selector: "0x468bb240",
+      },
+      {
+        name: "getCouponFor",
+        signature: {
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          canonical: "getCouponFor(uint256,address)",
+        },
+        selector: "0xbba7b56d",
+      },
+      {
+        name: "getCouponFromOrderedListAt",
+        signature: {
+          full: "function getCouponFromOrderedListAt(uint256 _pos) view returns (uint256 couponID_)",
+          canonical: "getCouponFromOrderedListAt(uint256)",
+        },
+        selector: "0x65a88a2c",
+      },
+      {
+        name: "getCouponHolders",
+        signature: {
+          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getCouponHolders(uint256,uint256,uint256)",
+        },
+        selector: "0xa92e8371",
+      },
+      {
+        name: "getCouponsFor",
+        signature: {
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          canonical: "getCouponsFor(uint256,uint256,uint256)",
+        },
+        selector: "0x7327ad90",
+      },
+      {
+        name: "getCouponsOrderedList",
+        signature: {
+          full: "function getCouponsOrderedList(uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] couponIDs_)",
+          canonical: "getCouponsOrderedList(uint256,uint256)",
+        },
+        selector: "0xd7133de1",
+      },
+      {
+        name: "getCouponsOrderedListTotal",
+        signature: {
+          full: "function getCouponsOrderedListTotal() view returns (uint256 total_)",
+          canonical: "getCouponsOrderedListTotal()",
+        },
+        selector: "0xee1d26eb",
+      },
+      {
+        name: "getTotalCouponHolders",
+        signature: {
+          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
+          canonical: "getTotalCouponHolders(uint256)",
+        },
+        selector: "0xec116ae3",
+      },
+      {
+        name: "setCoupon",
+        signature: {
+          full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
+          canonical: "setCoupon((uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        selector: "0xb16fd0cc",
+      },
+    ],
+    events: [
+      {
+        name: "CouponCancelled",
+        signature: {
+          full: "event CouponCancelled(uint256 indexed couponId, address indexed operator)",
+          canonical: "CouponCancelled(uint256,address)",
+        },
+        topic0: "0xf3f7ee3ec63ca38fe59a56a06f6d730ef89a41b7819ca5c04dda2205c4f2a712",
+      },
+      {
+        name: "CouponSet",
+        signature: {
+          full: "event CouponSet(bytes32 indexed corporateActionId, uint256 indexed couponId, address indexed operator, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon)",
+          canonical: "CouponSet(bytes32,uint256,address,(uint256,uint256,uint256,uint256,uint256,uint256,uint8,uint8))",
+        },
+        topic0: "0xbeb7fdc8c5c160b79de3e9c869bf2f6b287cbe29eb05d7623537a427231942ee",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "CouponAlreadyExecuted",
+        signature: {
+          full: "error CouponAlreadyExecuted(bytes32 corporateActionId, uint256 couponId)",
+          canonical: "CouponAlreadyExecuted(bytes32,uint256)",
+        },
+        selector: "0xae5a5af7",
+      },
+      {
+        name: "CouponCreationFailed",
+        signature: { full: "error CouponCreationFailed()", canonical: "CouponCreationFailed()" },
+        selector: "0x3a11c78b",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongDates",
+        signature: {
+          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
+          canonical: "WrongDates(uint256,uint256)",
+        },
+        selector: "0x1c94559c",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+    ],
+    factory: (signer) =>
+      new CouponSustainabilityPerformanceTargetRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new CouponSustainabilityPerformanceTargetRateFacetTimeTravel__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
   },
 
   DiamondFacet: {
@@ -11006,6 +11074,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "function resetSystemTimestamp()", canonical: "resetSystemTimestamp()" },
         selector: "0x8f145250",
       },
+      {
+        name: "testOnlyAddDeprecatedCoupon",
+        signature: {
+          full: "function testOnlyAddDeprecatedCoupon(uint256 _couponID)",
+          canonical: "testOnlyAddDeprecatedCoupon(uint256)",
+        },
+        selector: "0xa1435b5a",
+      },
     ],
     events: [
       {
@@ -11709,7 +11785,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 69 as const;
+export const TOTAL_FACETS = 73 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).
@@ -12175,6 +12251,11 @@ export const STORAGE_WRAPPER_REGISTRY: Record<string, StorageWrapperDefinition> 
     methods: [],
   },
 
+  CouponStorageWrapper: {
+    name: "CouponStorageWrapper",
+    methods: [],
+  },
+
   EquityStorageWrapper: {
     name: "EquityStorageWrapper",
     methods: [],
@@ -12330,7 +12411,7 @@ export const STORAGE_WRAPPER_REGISTRY: Record<string, StorageWrapperDefinition> 
 /**
  * Total number of storage wrapper contracts in the registry.
  */
-export const TOTAL_STORAGE_WRAPPERS = 32 as const;
+export const TOTAL_STORAGE_WRAPPERS = 33 as const;
 
 /**
  * All role identifiers extracted from contracts.

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -82,6 +82,7 @@ const BOND_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "CouponFacet",
   "LockFacet",
   "NominalValueFacet",
   "ProceedRecipientsFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -88,6 +88,7 @@ const BOND_FIXED_RATE_FACETS = [
   "SsiManagementFacet",
 
   // Interest Rate (rate-specific)
+  "CouponFixedRateFacet",
   "FixedRateFacet",
 
   // Jurisdiction-Specific

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -92,6 +92,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   "TransferAndLockFacet",
 
   // Interest Rate (rate-specific - keep variant names)
+  "CouponKpiLinkedRateFacet",
   "KpiLinkedRateFacet",
   "KpisKpiLinkedRateFacet",
 

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -92,6 +92,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   "TransferAndLockFacet",
 
   // Interest Rate (rate-specific - keep variant names)
+  "CouponSustainabilityPerformanceTargetRateFacet",
   "SustainabilityPerformanceTargetRateFacet",
   "KpisSustainabilityPerformanceTargetRateFacet",
 

--- a/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
@@ -106,10 +106,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "EmptyResolver",
-        );
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("EmptyResolver");
       });
 
       it("GIVEN empty resolver WHEN deploying bond THEN reverts with EmptyResolver", async () => {
@@ -127,10 +124,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "EmptyResolver",
-        );
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("EmptyResolver");
       });
 
       it("GIVEN valid resolver WHEN deploying equity THEN passes checkResolver validation", async () => {
@@ -163,10 +157,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "WrongISIN",
-        );
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("WrongISIN");
       });
 
       it("GIVEN ISIN with length > 12 WHEN deploying equity THEN reverts with WrongISIN", async () => {
@@ -182,10 +173,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "WrongISIN",
-        );
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("WrongISIN");
       });
 
       it("GIVEN empty ISIN WHEN deploying bond THEN reverts with WrongISIN", async () => {
@@ -203,29 +191,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "WrongISIN",
-        );
-      });
-
-      it("GIVEN invalid ISIN checksum WHEN deploying equity THEN reverts with WrongISINChecksum", async () => {
-        const equityData = {
-          security: getSecurityData(businessLogicResolver, {
-            erc20MetadataInfo: { isin: "US0378331009" }, // Wrong checksum digit
-            rbacs: init_rbacs,
-          }),
-          equityDetails: getEquityDetails(),
-        };
-        equityData.security.resolverProxyConfiguration = {
-          key: EQUITY_CONFIG_ID,
-          version: 1,
-        };
-
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "WrongISINChecksum",
-        );
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("WrongISIN");
       });
 
       it("GIVEN invalid ISIN checksum WHEN deploying equity THEN reverts with WrongISIN", async () => {
@@ -282,10 +248,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "NoInitialAdmins",
-        );
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
       });
 
       it("GIVEN rbacs with only zero address as admin WHEN deploying bond THEN reverts with NoInitialAdmins", async () => {
@@ -309,10 +272,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "NoInitialAdmins",
-        );
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
       });
 
       it("GIVEN rbacs with no admin role WHEN deploying equity THEN reverts with NoInitialAdmins", async () => {
@@ -334,10 +294,7 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
-          factory,
-          "NoInitialAdmins",
-        );
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
       });
 
       it("GIVEN rbacs with admin role having valid address after zero address WHEN deploying equity THEN passes validation", async () => {
@@ -504,67 +461,6 @@ describe("Factory Tests", () => {
     });
   });
 
-  describe("Generic Proxy tests", () => {
-    it("GIVEN an empty Resolver WHEN deploying a new resolverProxy THEN transaction fails", async () => {
-      await expect(factory.deployProxy(ADDRESS_ZERO, EQUITY_CONFIG_ID, 1, init_rbacs)).to.be.revertedWithCustomError(
-        factory,
-        "EmptyResolver",
-      );
-    });
-
-    it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
-      await expect(factory.deployProxy(businessLogicResolver, EQUITY_CONFIG_ID, 1, [])).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
-    });
-
-    it("GIVEN the proper information WHEN deploying a new resolverProxy THEN transaction succeeds", async () => {
-      const expectedProxyAddress = await factory
-        .getFunction("deployProxy")
-        .staticCall(businessLogicResolver, EQUITY_CONFIG_ID, 1, init_rbacs);
-
-      const tx = factory.deployProxy(businessLogicResolver, EQUITY_CONFIG_ID, 1, init_rbacs);
-      await expect(tx).to.emit(factory, "ProxyDeployed");
-
-      const result = await tx;
-      const receipt = await result.wait();
-
-      const deployedProxyEvent = receipt!.logs
-        .map((log) => {
-          try {
-            return factory.interface.parseLog({
-              topics: log.topics as string[],
-              data: log.data,
-            });
-          } catch {
-            return null;
-          }
-        })
-        .find((parsed) => parsed?.name === "ProxyDeployed");
-
-      const proxyAddress = deployedProxyEvent!.args!.proxyAddress;
-      const resolver = deployedProxyEvent!.args!.resolver;
-      const configKey = deployedProxyEvent!.args!.configKey;
-      const version = deployedProxyEvent!.args!.version;
-      const rbac = deployedProxyEvent!.args!.rbac;
-
-      expect(proxyAddress).not.to.equal(ADDRESS_ZERO);
-      expect(proxyAddress).to.equal(expectedProxyAddress);
-      expect(resolver).to.equal(businessLogicResolver);
-      expect(configKey).to.equal(EQUITY_CONFIG_ID);
-      expect(version).to.equal(1);
-      expect(rbac.length).to.equal(init_rbacs.length);
-
-      for (let i = 0; i < init_rbacs.length; i++) {
-        expect(rbac[i][0]).to.be.equal(listOfRoles[i]);
-        expect(rbac[i][1].length).to.equal(listOfMembers.length);
-        expect(rbac[i][1][0]).to.be.equal(listOfMembers[0]);
-        expect(rbac[i][1][1]).to.be.equal(listOfMembers[1]);
-      }
-    });
-  });
-
   describe("Equity tests", () => {
     it("GIVEN an empty Resolver WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const equityData = {
@@ -579,16 +475,13 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "EmptyResolver",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("EmptyResolver");
     });
 
     it("GIVEN a wrong ISIN WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const equityData = {
         security: getSecurityData(businessLogicResolver, {
-          erc20MetadataInfo: { isin: "short" },
+          erc20MetadataInfo: { isin: "invalid_isin" },
         }),
         equityDetails: getEquityDetails(),
       };
@@ -603,12 +496,9 @@ describe("Factory Tests", () => {
         factory.deployEquity(equityData, factoryRegulationData, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(factory, "WrongISIN");
+      ).to.be.rejectedWith("WrongISIN");
       equityData.security.erc20MetadataInfo.isin = "SJ5633813321";
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISINChecksum",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISINChecksum");
     });
 
     it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -623,10 +513,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN wrong regulation type WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -776,16 +663,13 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "EmptyResolver",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("EmptyResolver");
     });
 
     it("GIVEN a wrong ISIN WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const bondData = {
         security: getSecurityData(businessLogicResolver, {
-          erc20MetadataInfo: { isin: "wrong_isin" },
+          erc20MetadataInfo: { isin: "invalid_isin" },
           rbacs: init_rbacs,
         }),
         bondDetails: await getBondDetails(),
@@ -799,15 +683,9 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
       bondData.security.erc20MetadataInfo.isin = "SJ5633813321";
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISINChecksum",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISINChecksum");
     });
 
     it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -824,10 +702,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN incorrect maturity or starting date WHEN deploying a new bond THEN transaction fails", async () => {
@@ -848,19 +723,13 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongDates",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongDates");
 
       const currentTimeInSeconds = Math.floor(new Date().getTime() / 1000) + 1;
       bondData.bondDetails.startingDate = currentTimeInSeconds - 10000;
       bondData.bondDetails.maturityDate = bondData.bondDetails.startingDate + 10;
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongTimestamp",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongTimestamp");
     });
 
     it("GIVEN the proper information WHEN deploying a new bond THEN transaction succeeds", async () => {
@@ -930,7 +799,8 @@ describe("Factory Tests", () => {
       expect(bondDetails.nominalValueDecimals).to.be.deep.equal(bondData.bondDetails.nominalValueDecimals);
       expect(bondDetails.startingDate).to.be.deep.equal(bondData.bondDetails.startingDate);
       expect(bondDetails.maturityDate).to.be.deep.equal(bondData.bondDetails.maturityDate);
-      const couponCount = await bondFacet.getCouponCount();
+      const couponFacet = await ethers.getContractAt("CouponFacet", bondAddress);
+      const couponCount = await couponFacet.getCouponCount();
       expect(couponCount).to.equal(0);
 
       // Coupon count assertion removed - no automatic coupons created
@@ -1043,10 +913,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
     });
 
     it("GIVEN an ISIN with length greater than 12 WHEN deploying equity THEN transaction fails with WrongISIN", async () => {
@@ -1064,10 +931,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
     });
 
     it("GIVEN an empty ISIN WHEN deploying equity THEN transaction fails with WrongISIN", async () => {
@@ -1085,10 +949,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
     });
 
     it("GIVEN an ISIN with wrong length WHEN deploying bond THEN transaction fails with WrongISIN", async () => {
@@ -1108,10 +969,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
     });
   });
 
@@ -1184,17 +1042,14 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(
-        factory,
-        "EmptyResolver",
-      );
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("EmptyResolver");
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondFixedRate THEN transaction fails", async () => {
       const bondFixedRateData = {
         bondData: {
           security: getSecurityData(businessLogicResolver, {
-            erc20MetadataInfo: { isin: "short" },
+            erc20MetadataInfo: { isin: "invalid_isin" },
             rbacs: init_rbacs,
           }),
           bondDetails: await getBondDetails(),
@@ -1213,7 +1068,7 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(factory, "WrongISIN");
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("WrongISIN");
     });
 
     it("GIVEN no admin WHEN deploying BondFixedRate THEN transaction fails", async () => {
@@ -1236,10 +1091,7 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondFixedRate THEN transaction fails", async () => {
@@ -1538,17 +1390,14 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
-        factory,
-        "EmptyResolver",
-      );
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("EmptyResolver");
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
       const bondKpiLinkedRateData = {
         bondData: {
           security: getSecurityData(businessLogicResolver, {
-            erc20MetadataInfo: { isin: "short" },
+            erc20MetadataInfo: { isin: "invalid_isin" },
             rbacs: init_rbacs,
           }),
           bondDetails: await getBondDetails(),
@@ -1580,10 +1429,7 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
-        factory,
-        "WrongISIN",
-      );
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("WrongISIN");
     });
 
     it("GIVEN no admin WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
@@ -1619,10 +1465,7 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
@@ -1761,9 +1604,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(
-        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
-      ).to.be.revertedWithCustomError(factory, "EmptyResolver");
+      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
+        "EmptyResolver",
+      );
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1800,9 +1643,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(
-        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
-      ).to.be.revertedWithCustomError(factory, "WrongISINChecksum");
+      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
+        "WrongISIN",
+      );
     });
 
     it("GIVEN no admin WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1836,9 +1679,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(
-        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
-      ).to.be.revertedWithCustomError(factory, "NoInitialAdmins");
+      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1910,10 +1753,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN rbacs with only zero address as admin WHEN deploying equity THEN transaction fails", async () => {
@@ -1937,10 +1777,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN rbacs with multiple roles but no admin role WHEN deploying equity THEN transaction fails", async () => {
@@ -1968,10 +1805,7 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
-        factory,
-        "NoInitialAdmins",
-      );
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
     });
 
     it("GIVEN rbacs with admin role having zero address followed by valid address WHEN deploying equity THEN transaction succeeds", async () => {

--- a/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
@@ -106,7 +106,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("EmptyResolver");
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "EmptyResolver",
+        );
       });
 
       it("GIVEN empty resolver WHEN deploying bond THEN reverts with EmptyResolver", async () => {
@@ -124,7 +127,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("EmptyResolver");
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "EmptyResolver",
+        );
       });
 
       it("GIVEN valid resolver WHEN deploying equity THEN passes checkResolver validation", async () => {
@@ -157,7 +163,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("WrongISIN");
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "WrongISIN",
+        );
       });
 
       it("GIVEN ISIN with length > 12 WHEN deploying equity THEN reverts with WrongISIN", async () => {
@@ -173,7 +182,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("WrongISIN");
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "WrongISIN",
+        );
       });
 
       it("GIVEN empty ISIN WHEN deploying bond THEN reverts with WrongISIN", async () => {
@@ -191,7 +203,29 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("WrongISIN");
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "WrongISIN",
+        );
+      });
+
+      it("GIVEN invalid ISIN checksum WHEN deploying equity THEN reverts with WrongISINChecksum", async () => {
+        const equityData = {
+          security: getSecurityData(businessLogicResolver, {
+            erc20MetadataInfo: { isin: "US0378331009" }, // Wrong checksum digit
+            rbacs: init_rbacs,
+          }),
+          equityDetails: getEquityDetails(),
+        };
+        equityData.security.resolverProxyConfiguration = {
+          key: EQUITY_CONFIG_ID,
+          version: 1,
+        };
+
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "WrongISINChecksum",
+        );
       });
 
       it("GIVEN invalid ISIN checksum WHEN deploying equity THEN reverts with WrongISIN", async () => {
@@ -248,7 +282,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "NoInitialAdmins",
+        );
       });
 
       it("GIVEN rbacs with only zero address as admin WHEN deploying bond THEN reverts with NoInitialAdmins", async () => {
@@ -272,7 +309,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployBond(bondData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
+        await expect(factory.deployBond(bondData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "NoInitialAdmins",
+        );
       });
 
       it("GIVEN rbacs with no admin role WHEN deploying equity THEN reverts with NoInitialAdmins", async () => {
@@ -294,7 +334,10 @@ describe("Factory Tests", () => {
           version: 1,
         };
 
-        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.rejectedWith("NoInitialAdmins");
+        await expect(factory.deployEquity(equityData, getRegulationData())).to.be.revertedWithCustomError(
+          factory,
+          "NoInitialAdmins",
+        );
       });
 
       it("GIVEN rbacs with admin role having valid address after zero address WHEN deploying equity THEN passes validation", async () => {
@@ -461,6 +504,67 @@ describe("Factory Tests", () => {
     });
   });
 
+  describe("Generic Proxy tests", () => {
+    it("GIVEN an empty Resolver WHEN deploying a new resolverProxy THEN transaction fails", async () => {
+      await expect(factory.deployProxy(ADDRESS_ZERO, EQUITY_CONFIG_ID, 1, init_rbacs)).to.be.revertedWithCustomError(
+        factory,
+        "EmptyResolver",
+      );
+    });
+
+    it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
+      await expect(factory.deployProxy(businessLogicResolver, EQUITY_CONFIG_ID, 1, [])).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
+    });
+
+    it("GIVEN the proper information WHEN deploying a new resolverProxy THEN transaction succeeds", async () => {
+      const expectedProxyAddress = await factory
+        .getFunction("deployProxy")
+        .staticCall(businessLogicResolver, EQUITY_CONFIG_ID, 1, init_rbacs);
+
+      const tx = factory.deployProxy(businessLogicResolver, EQUITY_CONFIG_ID, 1, init_rbacs);
+      await expect(tx).to.emit(factory, "ProxyDeployed");
+
+      const result = await tx;
+      const receipt = await result.wait();
+
+      const deployedProxyEvent = receipt!.logs
+        .map((log) => {
+          try {
+            return factory.interface.parseLog({
+              topics: log.topics as string[],
+              data: log.data,
+            });
+          } catch {
+            return null;
+          }
+        })
+        .find((parsed) => parsed?.name === "ProxyDeployed");
+
+      const proxyAddress = deployedProxyEvent!.args!.proxyAddress;
+      const resolver = deployedProxyEvent!.args!.resolver;
+      const configKey = deployedProxyEvent!.args!.configKey;
+      const version = deployedProxyEvent!.args!.version;
+      const rbac = deployedProxyEvent!.args!.rbac;
+
+      expect(proxyAddress).not.to.equal(ADDRESS_ZERO);
+      expect(proxyAddress).to.equal(expectedProxyAddress);
+      expect(resolver).to.equal(businessLogicResolver);
+      expect(configKey).to.equal(EQUITY_CONFIG_ID);
+      expect(version).to.equal(1);
+      expect(rbac.length).to.equal(init_rbacs.length);
+
+      for (let i = 0; i < init_rbacs.length; i++) {
+        expect(rbac[i][0]).to.be.equal(listOfRoles[i]);
+        expect(rbac[i][1].length).to.equal(listOfMembers.length);
+        expect(rbac[i][1][0]).to.be.equal(listOfMembers[0]);
+        expect(rbac[i][1][1]).to.be.equal(listOfMembers[1]);
+      }
+    });
+  });
+
   describe("Equity tests", () => {
     it("GIVEN an empty Resolver WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const equityData = {
@@ -475,13 +579,16 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("EmptyResolver");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "EmptyResolver",
+      );
     });
 
     it("GIVEN a wrong ISIN WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const equityData = {
         security: getSecurityData(businessLogicResolver, {
-          erc20MetadataInfo: { isin: "invalid_isin" },
+          erc20MetadataInfo: { isin: "short" },
         }),
         equityDetails: getEquityDetails(),
       };
@@ -496,9 +603,12 @@ describe("Factory Tests", () => {
         factory.deployEquity(equityData, factoryRegulationData, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.rejectedWith("WrongISIN");
+      ).to.be.revertedWithCustomError(factory, "WrongISIN");
       equityData.security.erc20MetadataInfo.isin = "SJ5633813321";
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISINChecksum");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISINChecksum",
+      );
     });
 
     it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -513,7 +623,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN wrong regulation type WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -663,13 +776,16 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("EmptyResolver");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "EmptyResolver",
+      );
     });
 
     it("GIVEN a wrong ISIN WHEN deploying a new resolverProxy THEN transaction fails", async () => {
       const bondData = {
         security: getSecurityData(businessLogicResolver, {
-          erc20MetadataInfo: { isin: "invalid_isin" },
+          erc20MetadataInfo: { isin: "wrong_isin" },
           rbacs: init_rbacs,
         }),
         bondDetails: await getBondDetails(),
@@ -683,9 +799,15 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
       bondData.security.erc20MetadataInfo.isin = "SJ5633813321";
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISINChecksum");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISINChecksum",
+      );
     });
 
     it("GIVEN no admin WHEN deploying a new resolverProxy THEN transaction fails", async () => {
@@ -702,7 +824,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN incorrect maturity or starting date WHEN deploying a new bond THEN transaction fails", async () => {
@@ -723,13 +848,19 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongDates");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongDates",
+      );
 
       const currentTimeInSeconds = Math.floor(new Date().getTime() / 1000) + 1;
       bondData.bondDetails.startingDate = currentTimeInSeconds - 10000;
       bondData.bondDetails.maturityDate = bondData.bondDetails.startingDate + 10;
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongTimestamp");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongTimestamp",
+      );
     });
 
     it("GIVEN the proper information WHEN deploying a new bond THEN transaction succeeds", async () => {
@@ -913,7 +1044,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
     });
 
     it("GIVEN an ISIN with length greater than 12 WHEN deploying equity THEN transaction fails with WrongISIN", async () => {
@@ -931,7 +1065,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
     });
 
     it("GIVEN an empty ISIN WHEN deploying equity THEN transaction fails with WrongISIN", async () => {
@@ -949,7 +1086,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
     });
 
     it("GIVEN an ISIN with wrong length WHEN deploying bond THEN transaction fails with WrongISIN", async () => {
@@ -969,7 +1109,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployBond(bondData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
     });
   });
 
@@ -1042,14 +1185,17 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("EmptyResolver");
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(
+        factory,
+        "EmptyResolver",
+      );
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondFixedRate THEN transaction fails", async () => {
       const bondFixedRateData = {
         bondData: {
           security: getSecurityData(businessLogicResolver, {
-            erc20MetadataInfo: { isin: "invalid_isin" },
+            erc20MetadataInfo: { isin: "short" },
             rbacs: init_rbacs,
           }),
           bondDetails: await getBondDetails(),
@@ -1068,7 +1214,7 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(factory, "WrongISIN");
     });
 
     it("GIVEN no admin WHEN deploying BondFixedRate THEN transaction fails", async () => {
@@ -1091,7 +1237,10 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployBondFixedRate(bondFixedRateData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondFixedRate THEN transaction fails", async () => {
@@ -1390,14 +1539,17 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("EmptyResolver");
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
+        factory,
+        "EmptyResolver",
+      );
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
       const bondKpiLinkedRateData = {
         bondData: {
           security: getSecurityData(businessLogicResolver, {
-            erc20MetadataInfo: { isin: "invalid_isin" },
+            erc20MetadataInfo: { isin: "short" },
             rbacs: init_rbacs,
           }),
           bondDetails: await getBondDetails(),
@@ -1429,7 +1581,10 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("WrongISIN");
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
+        factory,
+        "WrongISIN",
+      );
     });
 
     it("GIVEN no admin WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
@@ -1465,7 +1620,10 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployBondKpiLinkedRate(bondKpiLinkedRateData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondKpiLinkedRate THEN transaction fails", async () => {
@@ -1604,9 +1762,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
-        "EmptyResolver",
-      );
+      await expect(
+        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
+      ).to.be.revertedWithCustomError(factory, "EmptyResolver");
     });
 
     it("GIVEN wrong ISIN WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1643,9 +1801,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
-        "WrongISIN",
-      );
+      await expect(
+        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
+      ).to.be.revertedWithCustomError(factory, "WrongISINChecksum");
     });
 
     it("GIVEN no admin WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1679,9 +1837,9 @@ describe("Factory Tests", () => {
         version: 1,
       };
 
-      await expect(factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData)).to.be.rejectedWith(
-        "NoInitialAdmins",
-      );
+      await expect(
+        factory.deployBondSustainabilityPerformanceTargetRate(bondSustainabilityData),
+      ).to.be.revertedWithCustomError(factory, "NoInitialAdmins");
     });
 
     it("GIVEN wrong regulation type WHEN deploying BondSustainabilityPerformanceTargetRate THEN transaction fails", async () => {
@@ -1753,7 +1911,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN rbacs with only zero address as admin WHEN deploying equity THEN transaction fails", async () => {
@@ -1777,7 +1938,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN rbacs with multiple roles but no admin role WHEN deploying equity THEN transaction fails", async () => {
@@ -1805,7 +1969,10 @@ describe("Factory Tests", () => {
 
       const factoryRegulationData = getRegulationData();
 
-      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.rejectedWith("NoInitialAdmins");
+      await expect(factory.deployEquity(equityData, factoryRegulationData)).to.be.revertedWithCustomError(
+        factory,
+        "NoInitialAdmins",
+      );
     });
 
     it("GIVEN rbacs with admin role having zero address followed by valid address WHEN deploying equity THEN transaction succeeds", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/bond.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/bond.test.ts
@@ -8,28 +8,16 @@ import {
   BondUSAFacet,
   AccessControl,
   Pause,
-  Lock,
   type IERC1410,
   Kyc,
   SsiManagement,
-  IHold,
   ControlList,
   ClearingActionsFacet,
-  FreezeFacet,
-  ClearingTransferFacet,
   BondUSAReadFacet,
   TimeTravelFacet as TimeTravel,
   IERC3643,
 } from "@contract-types";
-import {
-  DEFAULT_PARTITION,
-  ATS_ROLES,
-  TIME_PERIODS_S,
-  ADDRESS_ZERO,
-  ZERO,
-  EMPTY_HEX_BYTES,
-  EMPTY_STRING,
-} from "@scripts";
+import { DEFAULT_PARTITION, ATS_ROLES, TIME_PERIODS_S, ADDRESS_ZERO, ZERO, EMPTY_STRING } from "@scripts";
 import { SecurityType } from "@scripts/domain";
 import { getBondDetails, getDltTimestamp, grantRoleAndPauseToken } from "@test";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
@@ -44,29 +32,8 @@ let maturityDate = 0;
 const amount = numberOfUnits;
 const _PARTITION_ID = "0x0000000000000000000000000000000000000000000000000000000000000002";
 
-let couponRecordDateInSeconds = 0;
-let couponExecutionDateInSeconds = 0;
-const couponRate = 50;
-const couponRateDecimals = 1;
-const couponPeriod = TIME_PERIODS_S.WEEK;
-let couponFixingDateInSeconds = 0;
-let couponEndDateInSeconds = 0;
-let couponStartDateInSeconds = 0;
 const EMPTY_VC_ID = EMPTY_STRING;
-const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const DECIMALS = 6;
-const couponRateStatus = 1;
-
-let couponData = {
-  recordDate: couponRecordDateInSeconds.toString(),
-  executionDate: couponExecutionDateInSeconds.toString(),
-  rate: couponRate,
-  rateDecimals: couponRateDecimals,
-  startDate: couponStartDateInSeconds.toString(),
-  endDate: couponEndDateInSeconds.toString(),
-  fixingDate: couponFixingDateInSeconds.toString(),
-  rateStatus: couponRateStatus,
-};
 
 describe("Bond Tests", () => {
   let diamond: ResolverProxy;
@@ -79,16 +46,12 @@ describe("Bond Tests", () => {
   let bondReadFacet: BondUSAReadFacet;
   let accessControlFacet: AccessControl;
   let pauseFacet: Pause;
-  let lockFacet: Lock;
-  let holdFacet: IHold;
   let erc1410Facet: IERC1410;
   let timeTravelFacet: TimeTravel;
   let kycFacet: Kyc;
   let ssiManagementFacet: SsiManagement;
   let controlListFacet: ControlList;
   let clearingActionsFacet: ClearingActionsFacet;
-  let freezeFacet: FreezeFacet;
-  let clearingTransferFacet: ClearingTransferFacet;
   let erc3643Facet: IERC3643;
 
   async function deploySecurityFixture(isMultiPartition = false) {
@@ -153,8 +116,7 @@ describe("Bond Tests", () => {
 
     accessControlFacet = await ethers.getContractAt("AccessControl", diamond.target, signer_A);
     pauseFacet = await ethers.getContractAt("Pause", diamond.target, signer_A);
-    lockFacet = await ethers.getContractAt("Lock", diamond.target, signer_A);
-    holdFacet = await ethers.getContractAt("IHold", diamond.target, signer_A);
+
     erc1410Facet = await ethers.getContractAt("IERC1410", diamond.target, signer_A);
     timeTravelFacet = await ethers.getContractAt("TimeTravelFacet", diamond.target, signer_A);
     kycFacet = await ethers.getContractAt("Kyc", diamond.target, signer_B);
@@ -166,9 +128,6 @@ describe("Bond Tests", () => {
     controlListFacet = await ethers.getContractAt("ControlList", diamond.target, signer_D);
     clearingActionsFacet = await ethers.getContractAt("ClearingActionsFacet", diamond.target, signer_A);
 
-    freezeFacet = await ethers.getContractAt("FreezeFacet", diamond.target, signer_A);
-    clearingTransferFacet = await ethers.getContractAt("ClearingTransferFacet", diamond.target, signer_A);
-
     await kycFacet.grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
   }
 
@@ -179,22 +138,6 @@ describe("Bond Tests", () => {
   });
 
   beforeEach(async () => {
-    const currentTimestamp = await getDltTimestamp();
-    couponRecordDateInSeconds = currentTimestamp + 400;
-    couponExecutionDateInSeconds = currentTimestamp + 1200;
-    couponFixingDateInSeconds = currentTimestamp + 1200;
-    couponEndDateInSeconds = couponFixingDateInSeconds - 1;
-    couponStartDateInSeconds = couponEndDateInSeconds - couponPeriod;
-    couponData = {
-      recordDate: couponRecordDateInSeconds.toString(),
-      executionDate: couponExecutionDateInSeconds.toString(),
-      rate: couponRate,
-      rateDecimals: couponRateDecimals,
-      startDate: couponStartDateInSeconds.toString(),
-      endDate: couponEndDateInSeconds.toString(),
-      fixingDate: couponFixingDateInSeconds.toString(),
-      rateStatus: 1,
-    };
     await loadFixture(deploySecurityFixture);
   });
 
@@ -224,7 +167,7 @@ describe("Bond Tests", () => {
       };
       await expect(
         bondFacet._initialize_bondUSA(await getBondDetails(), regulationData, additionalSecurityData),
-      ).to.be.revertedWithCustomError(bondFacet, "AlreadyInitialized");
+      ).to.be.rejectedWith("AlreadyInitialized");
     });
   });
 
@@ -390,890 +333,90 @@ describe("Bond Tests", () => {
       });
     });
 
-    describe("Coupons", () => {
-      it("GIVEN an account without corporateActions role WHEN setCoupon THEN transaction fails with AccountHasNoRole", async () => {
-        // set coupon fails
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData)).to.be.revertedWithCustomError(
-          accessControlFacet,
-          "AccountHasNoRole",
-        );
-      });
+    describe("Multi Partition", () => {
+      it("GIVEN token holder WHEN getting principal For THEN succeeds", async () => {
+        await deploySecurityFixture(true);
 
-      it("GIVEN a paused Token WHEN setCoupon THEN transaction fails with TokenIsPaused", async () => {
-        // Granting Role to account C and Pause
-        await grantRoleAndPauseToken(
-          accessControlFacet,
-          pauseFacet,
-          ATS_ROLES._CORPORATE_ACTION_ROLE,
-          signer_A,
-          signer_B,
-          signer_C.address,
-        );
-
-        // set coupon fails
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData)).to.be.revertedWithCustomError(
-          pauseFacet,
-          "TokenIsPaused",
-        );
-      });
-
-      it("GIVEN an account with corporateActions role WHEN setCoupon with wrong dates THEN transaction fails", async () => {
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-        // set coupon
-        const wrongcouponData_1 = {
-          recordDate: couponExecutionDateInSeconds.toString(),
-          executionDate: couponRecordDateInSeconds.toString(),
-          rate: couponRate,
-          rateDecimals: couponRateDecimals,
-          startDate: couponStartDateInSeconds.toString(),
-          endDate: couponEndDateInSeconds.toString(),
-          fixingDate: couponFixingDateInSeconds.toString(),
-          rateStatus: couponRateStatus,
-        };
-
-        await expect(bondFacet.connect(signer_C).setCoupon(wrongcouponData_1)).to.be.revertedWithCustomError(
-          bondFacet,
-          "WrongDates",
-        );
-
-        const wrongcouponData_2 = {
-          recordDate: ((await ethers.provider.getBlock("latest"))!.timestamp - 1).toString(),
-          executionDate: couponExecutionDateInSeconds.toString(),
-          rate: couponRate,
-          rateDecimals: couponRateDecimals,
-          startDate: couponStartDateInSeconds.toString(),
-          endDate: couponEndDateInSeconds.toString(),
-          fixingDate: couponFixingDateInSeconds.toString(),
-          rateStatus: couponRateStatus,
-        };
-
-        await expect(bondFacet.connect(signer_C).setCoupon(wrongcouponData_2)).to.be.revertedWithCustomError(
-          bondFacet,
-          "WrongTimestamp",
-        );
-      });
-
-      it("GIVEN an account with corporateActions role WHEN setCoupon with period THEN period is stored correctly", async () => {
-        await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-        // Create coupon with specific period
-        const customPeriod = 3 * 24 * 60 * 60; // 3 days in seconds
-        const customStartDate = couponEndDateInSeconds - customPeriod;
-        const customCouponData = {
-          recordDate: couponRecordDateInSeconds.toString(),
-          executionDate: couponExecutionDateInSeconds.toString(),
-          rate: couponRate,
-          rateDecimals: couponRateDecimals,
-          startDate: customStartDate.toString(),
-          endDate: couponEndDateInSeconds.toString(),
-          fixingDate: couponFixingDateInSeconds.toString(),
-          rateStatus: couponRateStatus,
-        };
-
-        // Set coupon and verify event includes period
-        await expect(bondFacet.connect(signer_C).setCoupon(customCouponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            customStartDate,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-
-        // Verify coupon data includes period
-        const [registeredCoupon] = await bondReadFacet.getCoupon(1);
-        expect(registeredCoupon.coupon.endDate).to.equal(couponEndDateInSeconds);
-        expect(registeredCoupon.coupon.startDate).to.equal(customStartDate);
-
-        // Verify couponFor data includes period
-        const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-        expect(couponFor.coupon.endDate).to.equal(couponEndDateInSeconds);
-        expect(couponFor.coupon.startDate).to.equal(customStartDate);
-      });
-
-      it("GIVEN an account with corporateActions role WHEN setCoupon with period 0 THEN transaction succeeds", async () => {
-        // Granting Role to account C
-        accessControlFacet = accessControlFacet.connect(signer_A);
-        await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-        // Using account C (with role)
-        bondFacet = bondFacet.connect(signer_C);
-
-        // Test minimum valid period (exactly 1 day)
-        const minValidPeriodCouponData = {
-          recordDate: couponRecordDateInSeconds.toString(),
-          executionDate: couponExecutionDateInSeconds.toString(),
-          rate: couponRate,
-          rateDecimals: couponRateDecimals,
-          startDate: couponEndDateInSeconds.toString(),
-          endDate: couponEndDateInSeconds.toString(),
-          fixingDate: couponFixingDateInSeconds.toString(),
-          rateStatus: couponRateStatus,
-        };
-
-        await expect(bondFacet.setCoupon(minValidPeriodCouponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            couponEndDateInSeconds,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-      });
-
-      it("GIVEN an account with corporateActions role WHEN setCoupon THEN transaction succeeds", async () => {
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-        // set coupon
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            couponStartDateInSeconds,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-
-        // check list members
-        await expect(bondReadFacet.getCoupon(1000)).to.be.revertedWithCustomError(bondReadFacet, "WrongIndexForAction");
-
-        const listCount = await bondReadFacet.getCouponCount();
-        const [registeredCoupon] = await bondReadFacet.getCoupon(1);
-        const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-        const couponAmountFor = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
-        const couponTotalHolders = await bondReadFacet.getTotalCouponHolders(1);
-        const couponHolders = await bondReadFacet.getCouponHolders(1, 0, couponTotalHolders);
-
-        expect(listCount).to.equal(1);
-        expect(registeredCoupon.snapshotId).to.equal(0);
-        expect(registeredCoupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
-        expect(registeredCoupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
-        expect(registeredCoupon.coupon.rate).to.equal(couponRate);
-        expect(registeredCoupon.coupon.rateDecimals).to.equal(couponRateDecimals);
-        expect(registeredCoupon.coupon.startDate).to.equal(couponStartDateInSeconds);
-        expect(registeredCoupon.coupon.endDate).to.equal(couponEndDateInSeconds);
-        expect(registeredCoupon.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
-        expect(registeredCoupon.coupon.rateStatus).to.equal(couponRateStatus);
-
-        expect(couponFor.coupon.recordDate).to.equal(couponRecordDateInSeconds);
-        expect(couponFor.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
-        expect(couponFor.coupon.rate).to.equal(couponRate);
-        expect(couponFor.coupon.rateDecimals).to.equal(couponRateDecimals);
-        expect(couponFor.coupon.startDate).to.equal(couponStartDateInSeconds);
-        expect(couponFor.coupon.endDate).to.equal(couponEndDateInSeconds);
-        expect(couponFor.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
-        expect(couponFor.coupon.rateStatus).to.equal(couponRateStatus);
-
-        expect(couponFor.tokenBalance).to.equal(0);
-        expect(couponFor.recordDateReached).to.equal(false);
-        expect(couponTotalHolders).to.equal(0);
-        expect(couponHolders.length).to.equal(couponTotalHolders);
-        expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
-        expect(couponAmountFor.numerator).to.equal(0);
-        expect(couponAmountFor.denominator).to.equal(0);
-      });
-
-      it("GIVEN an account with corporateActions role WHEN setCoupon and lock THEN transaction succeeds", async () => {
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._LOCKER_ROLE, signer_C.address);
         await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-        // issue and lock
-        const TotalAmount = numberOfUnits;
-        const LockedAmount = TotalAmount - 5;
 
         await erc1410Facet.connect(signer_C).issueByPartition({
           partition: DEFAULT_PARTITION,
           tokenHolder: signer_A.address,
-          value: TotalAmount,
+          value: amount,
           data: "0x",
         });
 
-        await lockFacet.connect(signer_C).lock(LockedAmount, signer_A.address, MAX_UINT256);
+        await erc1410Facet.connect(signer_C).issueByPartition({
+          partition: _PARTITION_ID,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
 
-        // set coupon
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            couponStartDateInSeconds,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-
-        // check list members
-        await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-        await accessControlFacet.connect(signer_A).revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-        const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-        const couponAmountFor = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
+        const principalFor = await bondReadFacet.getPrincipalFor(signer_A.address);
         const bondDetails = await bondReadFacet.getBondDetails();
-        const couponTotalHolders = await bondReadFacet.getTotalCouponHolders(1);
-        const couponHolders = await bondReadFacet.getCouponHolders(1, 0, couponTotalHolders);
-        const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
 
-        expect(couponFor.tokenBalance).to.equal(TotalAmount);
-        expect(couponFor.recordDateReached).to.equal(true);
-        expect(couponTotalHolders).to.equal(1);
-        expect(couponHolders.length).to.equal(couponTotalHolders);
-        expect([...couponHolders]).to.have.members([signer_A.address]);
-        expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
-        expect(couponAmountFor.numerator).to.equal(
-          couponFor.tokenBalance * bondDetails.nominalValue * couponFor.coupon.rate * period,
-        );
-        expect(couponAmountFor.denominator).to.equal(
-          10n ** (couponFor.decimals + bondDetails.nominalValueDecimals + couponFor.coupon.rateDecimals) *
-            BigInt(YEAR_SECONDS),
-        );
+        expect(principalFor.numerator).to.equal(bondDetails.nominalValue * BigInt(amount) * 2n);
+        expect(principalFor.denominator).to.equal(10n ** (bondDetails.nominalValueDecimals + BigInt(DECIMALS)));
       });
 
-      it("GIVEN an account with corporateActions role WHEN setCoupon and hold THEN transaction succeeds", async () => {
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+      it("GIVEN a new diamond contract with multi-partition WHEN redeemAtMaturityByPartition is called THEN transaction success", async () => {
+        await deploySecurityFixture(true);
         await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+        await erc1410Facet.connect(signer_C).issueByPartition({
+          partition: _PARTITION_ID,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
 
-        // issue and hold
-        const TotalAmount = numberOfUnits;
-        const HeldAmount = TotalAmount - 5;
+        await timeTravelFacet.changeSystemTimestamp(maturityDate + 1);
 
+        await expect(bondFacet.redeemAtMaturityByPartition(signer_A.address, _PARTITION_ID, amount))
+          .to.emit(bondFacet, "RedeemedByPartition")
+          .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x");
+      });
+
+      it("GIVEN a new diamond contract with multi-partition WHEN redeemAtMaturityByPartition is called THEN transaction success", async () => {
+        await deploySecurityFixture(true);
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+        await erc1410Facet.connect(signer_C).issueByPartition({
+          partition: _PARTITION_ID,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
         await erc1410Facet.connect(signer_C).issueByPartition({
           partition: DEFAULT_PARTITION,
           tokenHolder: signer_A.address,
-          value: TotalAmount,
+          value: amount,
           data: "0x",
         });
 
-        const hold = {
-          amount: HeldAmount,
-          expirationTimestamp: MAX_UINT256,
-          escrow: signer_B.address,
-          to: ADDRESS_ZERO,
-          data: "0x",
-        };
+        await timeTravelFacet.changeSystemTimestamp(maturityDate + 1);
 
-        await holdFacet.createHoldByPartition(DEFAULT_PARTITION, hold);
-
-        // set coupon
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            couponStartDateInSeconds,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-
-        // check list members
-        await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-        await accessControlFacet.connect(signer_A).revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-        const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-        const couponAmountFor = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
-        const bondDetails = await bondReadFacet.getBondDetails();
-        const couponTotalHolders = await bondReadFacet.getTotalCouponHolders(1);
-        const couponHolders = await bondReadFacet.getCouponHolders(1, 0, couponTotalHolders);
-        const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
-
-        expect(couponFor.tokenBalance).to.equal(TotalAmount);
-        expect(couponFor.recordDateReached).to.equal(true);
-        expect(couponTotalHolders).to.equal(1);
-        expect(couponHolders.length).to.equal(couponTotalHolders);
-        expect([...couponHolders]).to.have.members([signer_A.address]);
-        expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
-        expect(couponAmountFor.numerator).to.equal(
-          couponFor.tokenBalance * bondDetails.nominalValue * couponFor.coupon.rate * period,
-        );
-        expect(couponAmountFor.denominator).to.equal(
-          10n ** (couponFor.decimals + bondDetails.nominalValueDecimals + couponFor.coupon.rateDecimals) *
-            BigInt(YEAR_SECONDS),
-        );
-      });
-
-      it("GIVEN an account with bondManager role WHEN setMaturityDate THEN transaction succeeds", async () => {
-        // * Arrange
-        // Granting Role to account C
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._BOND_MANAGER_ROLE, signer_C.address);
-        // Get maturity date
-        const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
-        // New maturity date
-        const newMaturityDate = maturityDateBefore + 86400n;
-
-        await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate))
-          .to.emit(bondFacet, "MaturityDateUpdated")
-          .withArgs(bondFacet.target, newMaturityDate, maturityDateBefore);
-        // check date
-        const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
-        expect(maturityDateAfter).not.to.be.equal(maturityDateBefore);
-        expect(maturityDateAfter).to.be.equal(newMaturityDate);
-      });
-
-      it("GIVEN an account with bondManager role WHEN setMaturityDate to earlier date THEN transaction fails", async () => {
-        // * Arrange
-        // Granting Role to account C
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._BOND_MANAGER_ROLE, signer_C.address);
-        // Get maturity date
-        const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
-        // New maturity date (earlier than current)
-        // New maturity date (earlier than current)
-        const dayBeforeCurrentMaturity = maturityDateBefore - 86400n;
-
-        // * Act & Assert
-        // Set maturity date
-        await expect(
-          bondFacet.connect(signer_C).updateMaturityDate(dayBeforeCurrentMaturity),
-        ).to.be.revertedWithCustomError(bondFacet, "BondMaturityDateWrong");
-        // Ensure maturity date is not updated
-        const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
-        expect(maturityDateAfter).to.be.equal(maturityDateBefore);
-      });
-
-      it("GIVEN an account without bondManager role WHEN setMaturityDate THEN transaction fails with AccountHasNoRole", async () => {
-        // * Arrange
-        // Get maturity date
-        const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
-        // New maturity date
-        const newMaturityDate = maturityDateBefore + 86400n;
-
-        // * Act & Assert
-        // Set maturity date
-        await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate)).to.be.revertedWithCustomError(
-          accessControlFacet,
-          "AccountHasNoRole",
-        );
-        // Ensure maturity date is not updated
-        const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
-        expect(maturityDateAfter).to.be.equal(maturityDateBefore);
-      });
-
-      it("GIVEN a paused Token WHEN setMaturityDate THEN transaction fails with TokenIsPaused", async () => {
-        // * Arrange
-        // Granting Role to account C and Pause
-        await grantRoleAndPauseToken(
-          accessControlFacet,
-          pauseFacet,
-          ATS_ROLES._BOND_MANAGER_ROLE,
-          signer_A,
-          signer_B,
-          signer_C.address,
-        );
-        // Get maturity date
-        const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
-        // New maturity date
-        const newMaturityDate = maturityDateBefore + 86400n;
-
-        // * Act & Assert
-        // Set maturity date
-        await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate)).to.be.revertedWithCustomError(
-          pauseFacet,
-          "TokenIsPaused",
-        );
-        // Ensure maturity date is not updated
-        const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
-        expect(maturityDateAfter).to.be.equal(maturityDateBefore);
-      });
-
-      it("Given a coupon and account with normal, cleared, held, locked and frozen balance WHEN  getCouponFor THEN sum of balances is correct", async () => {
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._LOCKER_ROLE, signer_C.address);
-        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-        const totalAmount = numberOfUnits;
-        const lockedAmount = totalAmount / 5;
-        const heldAmount = totalAmount / 5;
-        const frozenAmount = totalAmount / 5;
-        const clearedAmount = totalAmount / 5;
-
-        await erc1410Facet.connect(signer_C).issueByPartition({
-          partition: DEFAULT_PARTITION,
-          tokenHolder: signer_A.address,
-          value: totalAmount,
-          data: "0x",
-        });
-
-        const hold = {
-          amount: heldAmount,
-          expirationTimestamp: MAX_UINT256,
-          escrow: signer_B.address,
-          to: ADDRESS_ZERO,
-          data: "0x",
-        };
-
-        await holdFacet.createHoldByPartition(DEFAULT_PARTITION, hold);
-        await lockFacet.connect(signer_C).lock(lockedAmount, signer_A.address, MAX_UINT256);
-        await freezeFacet.freezePartialTokens(signer_A.address, frozenAmount);
-        await clearingActionsFacet.activateClearing();
-
-        const clearingOperation = {
-          partition: DEFAULT_PARTITION,
-          expirationTimestamp: (await getDltTimestamp()) + 500,
-          data: EMPTY_HEX_BYTES,
-        };
-
-        await clearingTransferFacet.clearingTransferByPartition(clearingOperation, clearedAmount, signer_D.address);
-
-        // set coupon
-        await expect(bondFacet.connect(signer_C).setCoupon(couponData))
-          .to.emit(bondFacet, "CouponSet")
-          .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
-            couponRecordDateInSeconds,
-            couponExecutionDateInSeconds,
-            couponStartDateInSeconds,
-            couponEndDateInSeconds,
-            couponFixingDateInSeconds,
-            couponRate,
-            couponRateDecimals,
-            couponRateStatus,
-          ]);
-
-        // --- Pre: before record date -> tokenBalance should be 0 and not reached
-        const before = await bondReadFacet.getCouponFor(1, signer_A.address);
-        const couponAmountForBefore = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
-        expect(before.recordDateReached).to.equal(false);
-        expect(before.tokenBalance).to.equal(0);
-        expect(couponAmountForBefore.recordDateReached).to.equal(before.recordDateReached);
-        expect(couponAmountForBefore.numerator).to.equal(0);
-        expect(couponAmountForBefore.denominator).to.equal(0);
-
-        // Forward time to record date
-        await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-        await accessControlFacet.revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-        // --- Post: after record date -> tokenBalance should be sum of balances
-        const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-        const couponAmountForAfter = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
-        const bondDetails = await bondReadFacet.getBondDetails();
-        const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
-        expect(couponFor.recordDateReached).to.equal(true);
-        expect(couponFor.tokenBalance).to.equal(totalAmount); // normal+cleared+held+locked+frozen
-        expect(couponAmountForAfter.recordDateReached).to.equal(couponFor.recordDateReached);
-        expect(couponAmountForAfter.numerator).to.equal(
-          couponFor.tokenBalance * bondDetails.nominalValue * couponFor.coupon.rate * period,
-        );
-        expect(couponAmountForAfter.denominator).to.equal(
-          10n ** (couponFor.decimals + bondDetails.nominalValueDecimals + couponFor.coupon.rateDecimals) *
-            BigInt(YEAR_SECONDS),
-        );
+        await expect(bondFacet.fullRedeemAtMaturity(signer_A.address))
+          .to.emit(bondFacet, "RedeemedByPartition")
+          .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
+          .to.emit(bondFacet, "RedeemedByPartition")
+          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x");
       });
     });
-  });
-  describe("Cancel Coupon", () => {
-    it("GIVEN an account with corporateActions role WHEN cancelling a coupon THEN transaction succeeds", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+    describe("Uncovered Branch Tests", () => {
+      it("GIVEN a token holder with zero balance WHEN fullRedeemAtMaturity is called THEN succeeds without redeeming", async () => {
+        // Create a new user with no tokens
+        const signers = await ethers.getSigners();
+        const newUser = signers[10]; // Use a signer that hasn't been used yet
 
-      await bondFacet.connect(signer_C).setCoupon(couponData);
+        // Grant KYC to new user
+        await kycFacet.grantKyc(newUser.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
 
-      await expect(bondFacet.connect(signer_C).cancelCoupon(1))
-        .to.emit(bondFacet, "CouponCancelled")
-        .withArgs(1, signer_C.address);
-      const isDisabled = (await bondReadFacet.getCoupon(1)).isDisabled_;
-      expect(isDisabled).to.equal(true);
-      const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-      expect(couponFor.isDisabled).to.equal(true);
-    });
+        // Move time past maturity
+        await timeTravelFacet.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
 
-    it("GIVEN a coupon after execution date WHEN cancelCoupon THEN transaction fails with CorporateActionAlreadyExecuted", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
-
-      await bondFacet.connect(signer_C).setCoupon(couponData);
-
-      // Time travel past execution date
-      await timeTravelFacet.changeSystemTimestamp(couponExecutionDateInSeconds + 1);
-
-      // Attempt to cancel after execution date
-      await expect(bondFacet.connect(signer_C).cancelCoupon(1)).to.be.revertedWithCustomError(
-        bondFacet,
-        "CouponAlreadyExecuted",
-      );
-    });
-
-    it("GIVEN a coupon after record date but before execution date WHEN cancelCoupon THEN transaction succeeds", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
-
-      await bondFacet.connect(signer_C).setCoupon(couponData);
-
-      // Time travel past record date but before execution date
-      await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-
-      // Cancel should succeed as execution date hasn't passed
-      await expect(bondFacet.connect(signer_C).cancelCoupon(1))
-        .to.emit(bondFacet, "CouponCancelled")
-        .withArgs(1, signer_C.address);
-    });
-
-    it("GIVEN an account without corporateActions role WHEN cancelCoupon THEN transaction fails with AccountHasNoRole", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
-
-      await bondFacet.connect(signer_C).setCoupon(couponData);
-
-      await expect(bondFacet.connect(signer_D).cancelCoupon(1)).to.be.rejectedWith("AccountHasNoRole");
-    });
-
-    it("GIVEN a paused Token WHEN cancelCoupon THEN transaction fails with TokenIsPaused", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
-
-      await bondFacet.connect(signer_C).setCoupon(couponData);
-
-      await pauseFacet.connect(signer_B).pause();
-
-      await expect(bondFacet.connect(signer_C).cancelCoupon(1)).to.be.rejectedWith("TokenIsPaused");
-    });
-
-    it("GIVEN no existing coupon WHEN cancelCoupon with invalid ID THEN transaction fails", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
-
-      await expect(bondFacet.connect(signer_C).cancelCoupon(999)).to.be.reverted;
-    });
-  });
-  describe("Multi Partition", () => {
-    it("GIVEN token holder WHEN getting principal For THEN succeeds", async () => {
-      await deploySecurityFixture(true);
-
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: amount,
-        data: "0x",
+        // Call fullRedeemAtMaturity on account with zero balance (signer_A has _MATURITY_REDEEMER_ROLE)
+        await expect(bondFacet.connect(signer_A).fullRedeemAtMaturity(newUser.address)).to.not.be.reverted;
       });
-
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: _PARTITION_ID,
-        tokenHolder: signer_A.address,
-        value: amount,
-        data: "0x",
-      });
-
-      const principalFor = await bondReadFacet.getPrincipalFor(signer_A.address);
-      const bondDetails = await bondReadFacet.getBondDetails();
-
-      expect(principalFor.numerator).to.equal(bondDetails.nominalValue * BigInt(amount) * 2n);
-      expect(principalFor.denominator).to.equal(10n ** (bondDetails.nominalValueDecimals + BigInt(DECIMALS)));
-    });
-
-    it("GIVEN a new diamond contract with multi-partition WHEN redeemAtMaturityByPartition is called THEN transaction success", async () => {
-      await deploySecurityFixture(true);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: _PARTITION_ID,
-        tokenHolder: signer_A.address,
-        value: amount,
-        data: "0x",
-      });
-
-      await timeTravelFacet.changeSystemTimestamp(maturityDate + 1);
-
-      await expect(bondFacet.redeemAtMaturityByPartition(signer_A.address, _PARTITION_ID, amount))
-        .to.emit(bondFacet, "RedeemedByPartition")
-        .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x");
-    });
-
-    it("GIVEN a new diamond contract with multi-partition WHEN redeemAtMaturityByPartition is called THEN transaction success", async () => {
-      await deploySecurityFixture(true);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: _PARTITION_ID,
-        tokenHolder: signer_A.address,
-        value: amount,
-        data: "0x",
-      });
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: amount,
-        data: "0x",
-      });
-
-      await timeTravelFacet.changeSystemTimestamp(maturityDate + 1);
-
-      await expect(bondFacet.fullRedeemAtMaturity(signer_A.address))
-        .to.emit(bondFacet, "RedeemedByPartition")
-        .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
-        .to.emit(bondFacet, "RedeemedByPartition")
-        .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x");
-    });
-
-    it("GIVEN a coupon with snapshot WHEN getCouponHolders is called THEN returns token holders from snapshot", async () => {
-      await deploySecurityFixture(true);
-
-      const TotalAmount = 1000;
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_A.address);
-
-      // Grant KYC to signer_B for issuing tokens later
-      await kycFacet.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
-
-      await erc1410Facet.connect(signer_A).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: TotalAmount,
-        data: "0x",
-      });
-
-      couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-      couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-      const couponData = {
-        recordDate: couponRecordDateInSeconds.toString(),
-        executionDate: couponExecutionDateInSeconds.toString(),
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: couponStartDateInSeconds.toString(),
-        endDate: couponEndDateInSeconds.toString(),
-        fixingDate: couponFixingDateInSeconds.toString(),
-        rateStatus: couponRateStatus,
-      };
-
-      await bondFacet.connect(signer_A).setCoupon(couponData);
-
-      // Time travel past record date
-      await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-
-      // Trigger scheduled tasks by performing an action (issue more tokens to signer_B)
-      await erc1410Facet.connect(signer_A).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_B.address,
-        value: 500,
-        data: "0x",
-      });
-
-      const [registeredCoupon] = await bondReadFacet.getCoupon(1);
-      const couponTotalHolders = await bondReadFacet.getTotalCouponHolders(1);
-      const couponHolders = await bondReadFacet.getCouponHolders(1, 0, couponTotalHolders);
-
-      expect(registeredCoupon.snapshotId).to.be.greaterThan(0); // Snapshot should have been taken
-      expect(couponTotalHolders).to.equal(1);
-      expect([...couponHolders]).to.have.members([signer_A.address]);
-    });
-
-    it("GIVEN a coupon without snapshot WHEN getCouponFor is called after record date THEN uses current balance", async () => {
-      await deploySecurityFixture(true);
-
-      const TotalAmount = 1000;
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_A.address);
-
-      await erc1410Facet.connect(signer_A).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: TotalAmount,
-        data: "0x",
-      });
-
-      couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-      couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-      const couponData = {
-        recordDate: couponRecordDateInSeconds.toString(),
-        executionDate: couponExecutionDateInSeconds.toString(),
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: couponStartDateInSeconds.toString(),
-        endDate: couponEndDateInSeconds.toString(),
-        fixingDate: couponFixingDateInSeconds.toString(),
-        rateStatus: couponRateStatus,
-      };
-
-      await bondFacet.connect(signer_A).setCoupon(couponData);
-
-      // Time travel past record date but DON'T trigger snapshot
-      await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-
-      // Query couponFor without triggering snapshot - should use current balance path
-      const couponFor = await bondReadFacet.getCouponFor(1, signer_A.address);
-      const [registeredCoupon] = await bondReadFacet.getCoupon(1);
-
-      expect(registeredCoupon.snapshotId).to.equal(0); // No snapshot taken
-      expect(couponFor.recordDateReached).to.be.true;
-      expect(couponFor.tokenBalance).to.equal(TotalAmount);
-    });
-
-    it("GIVEN a coupon WHEN getCoupon is called THEN decodes coupon data", async () => {
-      await deploySecurityFixture(true);
-
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
-
-      couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-      couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-      const couponData = {
-        recordDate: couponRecordDateInSeconds.toString(),
-        executionDate: couponExecutionDateInSeconds.toString(),
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: couponStartDateInSeconds.toString(),
-        endDate: couponEndDateInSeconds.toString(),
-        fixingDate: couponFixingDateInSeconds.toString(),
-        rateStatus: couponRateStatus,
-      };
-
-      await bondFacet.connect(signer_A).setCoupon(couponData);
-
-      const [registeredCoupon] = await bondReadFacet.getCoupon(1);
-
-      expect(registeredCoupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
-      expect(registeredCoupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
-      expect(registeredCoupon.coupon.rate).to.equal(couponRate);
-      expect(registeredCoupon.coupon.rateDecimals).to.equal(couponRateDecimals);
-      expect(registeredCoupon.coupon.startDate).to.equal(couponStartDateInSeconds);
-      expect(registeredCoupon.coupon.endDate).to.equal(couponEndDateInSeconds);
-      expect(registeredCoupon.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
-      expect(registeredCoupon.coupon.rateStatus).to.equal(couponRateStatus);
-    });
-
-    it("GIVEN a non-coupon corporate action WHEN getCouponFor is called THEN transaction fails with WrongActionType", async () => {
-      await deploySecurityFixture(true);
-
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
-
-      couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-      couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-      const couponData = {
-        recordDate: couponRecordDateInSeconds.toString(),
-        executionDate: couponExecutionDateInSeconds.toString(),
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: couponStartDateInSeconds.toString(),
-        endDate: couponEndDateInSeconds.toString(),
-        fixingDate: couponFixingDateInSeconds.toString(),
-        rateStatus: couponRateStatus,
-      };
-
-      await bondFacet.connect(signer_A).setCoupon(couponData);
-
-      // Try to access with invalid coupon ID (0 would be invalid or different action type)
-      await expect(bondReadFacet.getCouponFor(999, signer_A.address)).to.be.revertedWithCustomError(
-        bondReadFacet,
-        "WrongIndexForAction",
-      );
-    });
-
-    it("GIVEN a non-coupon corporate action WHEN getCouponAmountFor is called THEN transaction fails with WrongActionType", async () => {
-      await deploySecurityFixture(true);
-
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
-
-      couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-      couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-      const couponData = {
-        recordDate: couponRecordDateInSeconds.toString(),
-        executionDate: couponExecutionDateInSeconds.toString(),
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: couponStartDateInSeconds.toString(),
-        endDate: couponEndDateInSeconds.toString(),
-        fixingDate: couponFixingDateInSeconds.toString(),
-        rateStatus: couponRateStatus,
-      };
-
-      await bondFacet.connect(signer_A).setCoupon(couponData);
-
-      // Try to access with invalid coupon ID
-      await expect(bondReadFacet.getCouponAmountFor(999, signer_A.address)).to.be.revertedWithCustomError(
-        bondReadFacet,
-        "WrongIndexForAction",
-      );
-    });
-  });
-
-  describe("Uncovered Branch Tests", () => {
-    it("GIVEN a token holder with zero balance WHEN fullRedeemAtMaturity is called THEN succeeds without redeeming", async () => {
-      // Create a new user with no tokens
-      const signers = await ethers.getSigners();
-      const newUser = signers[10]; // Use a signer that hasn't been used yet
-
-      // Grant KYC to new user
-      await kycFacet.grantKyc(newUser.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
-
-      // Move time past maturity
-      await timeTravelFacet.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
-
-      // Call fullRedeemAtMaturity on account with zero balance (signer_A has _MATURITY_REDEEMER_ROLE)
-      await expect(bondFacet.connect(signer_A).fullRedeemAtMaturity(newUser.address)).to.not.be.reverted;
-    });
-
-    it("GIVEN invalid startDate > endDate WHEN setCoupon THEN transaction fails with WrongDates", async () => {
-      // Grant corporate action role to signer_C
-      await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      const currentTimestamp = await getDltTimestamp();
-      const invalidCoupon = {
-        recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
-        executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: currentTimestamp + TIME_PERIODS_S.DAY * 3, // startDate > endDate
-        endDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
-        fixingDate: currentTimestamp + TIME_PERIODS_S.DAY,
-        rateStatus: couponRateStatus,
-      };
-
-      await expect(bondFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
-        bondFacet,
-        "WrongDates",
-      );
-    });
-
-    it("GIVEN invalid fixingDate > executionDate WHEN setCoupon THEN transaction fails with WrongDates", async () => {
-      // Grant corporate action role to signer_C
-      await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-      const currentTimestamp = await getDltTimestamp();
-      const invalidCoupon = {
-        recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
-        executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: currentTimestamp,
-        endDate: currentTimestamp + TIME_PERIODS_S.DAY * 3,
-        fixingDate: currentTimestamp + TIME_PERIODS_S.DAY * 3, // fixingDate > executionDate
-        rateStatus: couponRateStatus,
-      };
-
-      await expect(bondFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
-        bondFacet,
-        "WrongDates",
-      );
-    });
-
-    it("GIVEN fixingDate in the past WHEN setCoupon THEN transaction fails with WrongTimestamp", async () => {
-      // Grant corporate action role to signer_C
-      await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-      const currentTimestamp = await getDltTimestamp();
-      const invalidCoupon = {
-        recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
-        executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
-        rate: couponRate,
-        rateDecimals: couponRateDecimals,
-        startDate: currentTimestamp - TIME_PERIODS_S.DAY * 3,
-        endDate: currentTimestamp + TIME_PERIODS_S.DAY * 3,
-        fixingDate: currentTimestamp - TIME_PERIODS_S.DAY, // fixingDate in the past
-        rateStatus: couponRateStatus,
-      };
-
-      await expect(bondFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
-        bondFacet,
-        "WrongTimestamp",
-      );
     });
   });
 });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/fixedRate/bondFixedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/fixedRate/bondFixedRate.test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { ResolverProxy, BondUSAFixedRateFacet, FixedRate, BondUSAReadFacet } from "@contract-types";
+import { ResolverProxy, FixedRate, CouponFacetTimeTravel } from "@contract-types";
 import { dateToUnixTimestamp, ATS_ROLES, TIME_PERIODS_S } from "@scripts";
 import { SecurityType } from "@scripts/domain";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
@@ -32,9 +32,8 @@ describe("Bond Fixed Rate Tests", () => {
   let diamond: ResolverProxy;
   let signer_A: HardhatEthersSigner;
 
-  let bondFixedRateFacet: BondUSAFixedRateFacet;
-  let bondReadFacet: BondUSAReadFacet;
   let fixedRateFacet: FixedRate;
+  let couponFixedRateFacet: CouponFacetTimeTravel;
 
   async function deploySecurityFixture() {
     const base = await deployBondFixedRateTokenFixture();
@@ -49,9 +48,8 @@ describe("Bond Fixed Rate Tests", () => {
       },
     ]);
 
-    bondFixedRateFacet = await ethers.getContractAt("BondUSAFixedRateFacetTimeTravel", diamond.target, signer_A);
-    bondReadFacet = await ethers.getContractAt("BondUSAReadFacetTimeTravel", diamond.target, signer_A);
     fixedRateFacet = await ethers.getContractAt("FixedRate", diamond.target, signer_A);
+    couponFixedRateFacet = await ethers.getContractAt("CouponFixedRateFacetTimeTravel", diamond.target, signer_A);
   }
 
   beforeEach(async () => {
@@ -82,35 +80,26 @@ describe("Bond Fixed Rate Tests", () => {
   it("GIVEN a fixed rate bond WHEN setting a coupon with non pending status THEN transaction fails with InterestRateIsFixed", async () => {
     couponData.rateStatus = 1;
 
-    await expect(bondFixedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-      bondFixedRateFacet,
-      "InterestRateIsFixed",
-    );
+    await expect(couponFixedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsFixed");
   });
 
   it("GIVEN a fixed rate bond WHEN setting a coupon with rate non 0 THEN transaction fails with InterestRateIsFixed", async () => {
     couponData.rate = 1;
 
-    await expect(bondFixedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-      bondFixedRateFacet,
-      "InterestRateIsFixed",
-    );
+    await expect(couponFixedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsFixed");
   });
 
   it("GIVEN a fixed rate bond WHEN setting a coupon with rate decimals non 0 THEN transaction fails with InterestRateIsFixed", async () => {
     couponData.rateDecimals = 1;
 
-    await expect(bondFixedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-      bondFixedRateFacet,
-      "InterestRateIsFixed",
-    );
+    await expect(couponFixedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsFixed");
   });
 
   it("GIVEN a fixed rate bond WHEN setting a coupon with pending status THEN transaction success", async () => {
     const fixedRate = await fixedRateFacet.getRate();
 
-    await expect(bondFixedRateFacet.connect(signer_A).setCoupon(couponData))
-      .to.emit(bondFixedRateFacet, "CouponSet")
+    await expect(couponFixedRateFacet.connect(signer_A).setCoupon(couponData))
+      .to.emit(couponFixedRateFacet, "CouponSet")
       .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_A.address, [
         couponRecordDateInSeconds,
         couponExecutionDateInSeconds,
@@ -122,10 +111,10 @@ describe("Bond Fixed Rate Tests", () => {
         1,
       ]);
 
-    const couponCount = await bondReadFacet.getCouponCount();
+    const couponCount = await couponFixedRateFacet.getCouponCount();
     expect(couponCount).to.equal(1);
 
-    const [registeredCoupon] = await bondReadFacet.getCoupon(1);
+    const registeredCoupon = (await couponFixedRateFacet.getCoupon(1)).registeredCoupon_;
     expect(registeredCoupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
     expect(registeredCoupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
     expect(registeredCoupon.coupon.startDate).to.equal(couponStartDateInSeconds);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
@@ -5,7 +5,6 @@ import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import {
   ResolverProxy,
-  BondUSAKpiLinkedRateFacetTimeTravel,
   KpiLinkedRateFacetTimeTravel,
   TimeTravelFacet,
   ERC1594KpiLinkedRateFacetTimeTravel,
@@ -54,7 +53,6 @@ describe("Bond KpiLinked Rate Tests", () => {
   let signer_B: HardhatEthersSigner;
   let signer_C: HardhatEthersSigner;
 
-  let bondKpiLinkedRateFacet: BondUSAKpiLinkedRateFacetTimeTravel;
   let couponKpiLinkedRateFacet: CouponFacetTimeTravel;
   let kpiLinkedRateFacet: KpiLinkedRateFacetTimeTravel;
   let timeTravelFacet: TimeTravelFacet;
@@ -105,11 +103,6 @@ describe("Bond KpiLinked Rate Tests", () => {
       },
     ]);
 
-    bondKpiLinkedRateFacet = await ethers.getContractAt(
-      "BondUSAKpiLinkedRateFacetTimeTravel",
-      diamond.target,
-      signer_A,
-    );
     couponKpiLinkedRateFacet = await ethers.getContractAt(
       "CouponKpiLinkedRateFacetTimeTravel",
       diamond.target,
@@ -265,7 +258,7 @@ describe("Bond KpiLinked Rate Tests", () => {
 
     it("GIVEN a kpiLinked rate bond WHEN setting a coupon with pending status THEN transaction success", async () => {
       await expect(couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData))
-        .to.emit(bondKpiLinkedRateFacet, "CouponSet")
+        .to.emit(couponKpiLinkedRateFacet, "CouponSet")
         .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_A.address, [
           couponRecordDateInSeconds,
           couponExecutionDateInSeconds,

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
@@ -7,12 +7,12 @@ import {
   ResolverProxy,
   BondUSAKpiLinkedRateFacetTimeTravel,
   KpiLinkedRateFacetTimeTravel,
-  BondUSAReadKpiLinkedRateFacetTimeTravel,
   TimeTravelFacet,
-  ERC1594FacetTimeTravel,
+  ERC1594KpiLinkedRateFacetTimeTravel,
   ProceedRecipientsKpiLinkedRateFacetTimeTravel,
   KpisKpiLinkedRateFacetTimeTravel,
   ScheduledCrossOrderedTasksKpiLinkedRateFacetTimeTravel,
+  CouponFacetTimeTravel,
 } from "@contract-types";
 import { dateToUnixTimestamp, ATS_ROLES, TIME_PERIODS_S } from "@scripts";
 import { SecurityType } from "@scripts/domain";
@@ -55,10 +55,10 @@ describe("Bond KpiLinked Rate Tests", () => {
   let signer_C: HardhatEthersSigner;
 
   let bondKpiLinkedRateFacet: BondUSAKpiLinkedRateFacetTimeTravel;
-  let bondReadFacet: BondUSAReadKpiLinkedRateFacetTimeTravel;
+  let couponKpiLinkedRateFacet: CouponFacetTimeTravel;
   let kpiLinkedRateFacet: KpiLinkedRateFacetTimeTravel;
   let timeTravelFacet: TimeTravelFacet;
-  let erc1594Facet: ERC1594FacetTimeTravel;
+  let erc1594Facet: ERC1594KpiLinkedRateFacetTimeTravel;
   let proceedRecipientsFacet: ProceedRecipientsKpiLinkedRateFacetTimeTravel;
   let kpisFacet: KpisKpiLinkedRateFacetTimeTravel;
   let scheduledTasksFacet: ScheduledCrossOrderedTasksKpiLinkedRateFacetTimeTravel;
@@ -110,9 +110,13 @@ describe("Bond KpiLinked Rate Tests", () => {
       diamond.target,
       signer_A,
     );
-    bondReadFacet = await ethers.getContractAt("BondUSAReadFacetTimeTravel", diamond.target, signer_A);
+    couponKpiLinkedRateFacet = await ethers.getContractAt(
+      "CouponKpiLinkedRateFacetTimeTravel",
+      diamond.target,
+      signer_A,
+    );
     kpiLinkedRateFacet = await ethers.getContractAt("KpiLinkedRateFacetTimeTravel", diamond.target, signer_A);
-    erc1594Facet = await ethers.getContractAt("ERC1594FacetTimeTravel", diamond.target, signer_A);
+    erc1594Facet = await ethers.getContractAt("ERC1594KpiLinkedRateFacetTimeTravel", diamond.target, signer_A);
     timeTravelFacet = await ethers.getContractAt("TimeTravelFacet", diamond.target);
     proceedRecipientsFacet = await ethers.getContractAt(
       "ProceedRecipientsKpiLinkedRateFacetTimeTravel",
@@ -172,9 +176,9 @@ describe("Bond KpiLinked Rate Tests", () => {
     couponID: number,
     accountAddress: string,
   ) {
-    const [registeredCouponPostFixingDate] = await bondReadFacet.getCoupon(couponID);
-    const couponForPostFixingDate = await bondReadFacet.getCouponFor(couponID, accountAddress);
-    const couponAmountForPostFixingDate = await bondReadFacet.getCouponAmountFor(couponID, accountAddress);
+    const registeredCouponPostFixingDate = (await couponKpiLinkedRateFacet.getCoupon(couponID)).registeredCoupon_;
+    const couponForPostFixingDate = await couponKpiLinkedRateFacet.getCouponFor(couponID, accountAddress);
+    const couponAmountForPostFixingDate = await couponKpiLinkedRateFacet.getCouponAmountFor(couponID, accountAddress);
 
     const numerator =
       BigInt(amount) *
@@ -244,32 +248,23 @@ describe("Bond KpiLinked Rate Tests", () => {
     it("GIVEN a kpiLinked rate bond WHEN setting a coupon with non pending status THEN transaction fails with InterestRateIsKpiLinked", async () => {
       couponData.rateStatus = 1;
 
-      await expect(bondKpiLinkedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-        bondKpiLinkedRateFacet,
-        "InterestRateIsKpiLinked",
-      );
+      await expect(couponKpiLinkedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsKpiLinked");
     });
 
     it("GIVEN a kpiLinked rate bond WHEN setting a coupon with rate non 0 THEN transaction fails with InterestRateIsKpiLinked", async () => {
       couponData.rate = 1;
 
-      await expect(bondKpiLinkedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-        bondKpiLinkedRateFacet,
-        "InterestRateIsKpiLinked",
-      );
+      await expect(couponKpiLinkedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsKpiLinked");
     });
 
     it("GIVEN a kpiLinked rate bond WHEN setting a coupon with rate decimals non 0 THEN transaction fails with InterestRateIsKpiLinked", async () => {
       couponData.rateDecimals = 1;
 
-      await expect(bondKpiLinkedRateFacet.setCoupon(couponData)).to.be.revertedWithCustomError(
-        bondKpiLinkedRateFacet,
-        "InterestRateIsKpiLinked",
-      );
+      await expect(couponKpiLinkedRateFacet.setCoupon(couponData)).to.be.rejectedWith("InterestRateIsKpiLinked");
     });
 
     it("GIVEN a kpiLinked rate bond WHEN setting a coupon with pending status THEN transaction success", async () => {
-      await expect(bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData))
+      await expect(couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData))
         .to.emit(bondKpiLinkedRateFacet, "CouponSet")
         .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_A.address, [
           couponRecordDateInSeconds,
@@ -282,10 +277,10 @@ describe("Bond KpiLinked Rate Tests", () => {
           0,
         ]);
 
-      const couponCount = await bondReadFacet.getCouponCount();
+      const couponCount = await couponKpiLinkedRateFacet.getCouponCount();
       expect(couponCount).to.equal(1);
 
-      const [registeredCoupon] = await bondReadFacet.getCoupon(1);
+      const registeredCoupon = (await couponKpiLinkedRateFacet.getCoupon(1)).registeredCoupon_;
       expect(registeredCoupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
       expect(registeredCoupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
       expect(registeredCoupon.coupon.startDate).to.equal(couponStartDateInSeconds);
@@ -299,11 +294,11 @@ describe("Bond KpiLinked Rate Tests", () => {
     it("GIVEN a kpiLinked rate bond WHEN rate is during start Period THEN transaction success and rate is start rate", async () => {
       await setKpiConfiguration(10);
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
-      const [registeredCouponPreFixingDate] = await bondReadFacet.getCoupon(1);
-      const couponForPreFixingDate = await bondReadFacet.getCouponFor(1, signer_A.address);
-      const couponAmountForPreFixingDate = await bondReadFacet.getCouponAmountFor(1, signer_A.address);
+      const registeredCouponPreFixingDate = (await couponKpiLinkedRateFacet.getCoupon(1)).registeredCoupon_;
+      const couponForPreFixingDate = await couponKpiLinkedRateFacet.getCouponFor(1, signer_A.address);
+      const couponAmountForPreFixingDate = await couponKpiLinkedRateFacet.getCouponAmountFor(1, signer_A.address);
 
       expect(registeredCouponPreFixingDate.coupon.rate).to.equal(0);
       expect(registeredCouponPreFixingDate.coupon.rateDecimals).to.equal(0);
@@ -325,7 +320,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       await setKpiConfiguration(-10);
 
       // Test missed penalty when there is a single coupon
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -340,7 +335,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       // Test missed penalty when there are two coupons
       updateCouponDates();
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -371,7 +366,7 @@ describe("Bond KpiLinked Rate Tests", () => {
 
       updateCouponDates();
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -394,7 +389,7 @@ describe("Bond KpiLinked Rate Tests", () => {
 
       updateCouponDates();
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -415,7 +410,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       await kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate);
 
       // Test missed penalty when there is a single coupon
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -435,7 +430,7 @@ describe("Bond KpiLinked Rate Tests", () => {
         signer_C.address,
       );
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
       await checkMinDates(couponData.fixingDate);
@@ -450,7 +445,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
       await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 2, impactData_2, signer_B.address);
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
       await checkMinDates(couponData.fixingDate);
@@ -468,7 +463,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
       await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, impactData, signer_B.address);
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
       await checkMinDates(couponData.fixingDate);
@@ -489,7 +484,7 @@ describe("Bond KpiLinked Rate Tests", () => {
         signer_C.address,
       );
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
       await checkMinDates(couponData.fixingDate);
@@ -504,10 +499,10 @@ describe("Bond KpiLinked Rate Tests", () => {
 
       const originalFixingDate = couponData.fixingDate;
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       couponData.fixingDate = (parseInt(couponData.fixingDate) - 1).toString();
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.recordDate) + 1);
 
@@ -517,45 +512,45 @@ describe("Bond KpiLinked Rate Tests", () => {
 
       await checkMinDates(originalFixingDate);
     });
-  });
 
-  it("GIVEN a cancelled coupon WHEN triggerScheduledCrossOrderedTasks executes THEN coupon is not added in ordered list", async () => {
-    const timestamp = await getDltTimestamp();
+    it("GIVEN a cancelled coupon WHEN triggerScheduledCrossOrderedTasks executes THEN coupon is not added in ordered list", async () => {
+      const timestamp = await getDltTimestamp();
 
-    const coupon1 = {
-      recordDate: (timestamp + TIME_PERIODS_S.WEEK).toString(),
-      executionDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
-      rate: 0,
-      rateDecimals: 0,
-      startDate: timestamp.toString(),
-      endDate: (timestamp + TIME_PERIODS_S.DAY * 7).toString(),
-      fixingDate: (timestamp + TIME_PERIODS_S.WEEK).toString(),
-      rateStatus: 0,
-    };
+      const coupon1 = {
+        recordDate: (timestamp + TIME_PERIODS_S.WEEK).toString(),
+        executionDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
+        rate: 0,
+        rateDecimals: 0,
+        startDate: timestamp.toString(),
+        endDate: (timestamp + TIME_PERIODS_S.DAY * 7).toString(),
+        fixingDate: (timestamp + TIME_PERIODS_S.WEEK).toString(),
+        rateStatus: 0,
+      };
 
-    const coupon2 = {
-      recordDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
-      executionDate: (timestamp + TIME_PERIODS_S.WEEK * 3).toString(),
-      rate: 0,
-      rateDecimals: 0,
-      startDate: timestamp.toString(),
-      endDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
-      fixingDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
-      rateStatus: 0,
-    };
+      const coupon2 = {
+        recordDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
+        executionDate: (timestamp + TIME_PERIODS_S.WEEK * 3).toString(),
+        rate: 0,
+        rateDecimals: 0,
+        startDate: timestamp.toString(),
+        endDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
+        fixingDate: (timestamp + TIME_PERIODS_S.WEEK * 2).toString(),
+        rateStatus: 0,
+      };
 
-    await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon1);
-    await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon2);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon1);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon2);
 
-    await bondKpiLinkedRateFacet.connect(signer_A).cancelCoupon(1);
+      await couponKpiLinkedRateFacet.connect(signer_A).cancelCoupon(1);
 
-    await timeTravelFacet.changeSystemTimestamp(timestamp + TIME_PERIODS_S.WEEK * 3);
+      await timeTravelFacet.changeSystemTimestamp(timestamp + TIME_PERIODS_S.WEEK * 3);
 
-    await scheduledTasksFacet.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+      await scheduledTasksFacet.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
 
-    const orderedList = await bondReadFacet.getCouponsOrderedList(0, 10);
-    expect(orderedList).to.be.an("array").with.lengthOf(1);
-    expect(orderedList[0]).to.equal(2); // couponId 2 is the only one in the ordered list
+      const orderedList = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
+      expect(orderedList).to.be.an("array").with.lengthOf(1);
+      expect(orderedList[0]).to.equal(2); // couponId 2 is the only one in the ordered list
+    });
   });
 
   describe("Bond Read - Ordered List", () => {
@@ -567,7 +562,7 @@ describe("Bond KpiLinked Rate Tests", () => {
 
     describe("getCouponsOrderedListTotal", () => {
       it("should return 0 when no coupons have been created", async () => {
-        const total = await bondReadFacet.getCouponsOrderedListTotal();
+        const total = await couponKpiLinkedRateFacet.getCouponsOrderedListTotal();
         expect(total).to.equal(0);
       });
 
@@ -584,7 +579,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon1);
+        await couponKpiLinkedRateFacet.setCoupon(coupon1);
 
         const coupon2 = {
           recordDate: currentBlockTimestamp + TIME_PERIODS_S.DAY * 3,
@@ -597,7 +592,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon2);
+        await couponKpiLinkedRateFacet.setCoupon(coupon2);
 
         const coupon3 = {
           recordDate: currentBlockTimestamp + TIME_PERIODS_S.DAY * 5,
@@ -610,19 +605,19 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon3);
+        await couponKpiLinkedRateFacet.setCoupon(coupon3);
 
         // Move time forward past all fixing dates
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 6);
 
-        const total = await bondReadFacet.getCouponsOrderedListTotal();
+        const total = await couponKpiLinkedRateFacet.getCouponsOrderedListTotal();
         expect(total).to.equal(3);
       });
     });
 
     describe("getCouponFromOrderedListAt", () => {
       it("should return 0 for invalid position when no coupons exist", async () => {
-        const couponId = await bondReadFacet.getCouponFromOrderedListAt(0);
+        const couponId = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(0);
         expect(couponId).to.equal(0);
       });
 
@@ -639,13 +634,13 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon);
+        await couponKpiLinkedRateFacet.setCoupon(coupon);
 
         // Move time forward past fixing date
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 2);
 
         // Try to get position 1 (second item) when only 1 exists (index 0)
-        const couponId = await bondReadFacet.getCouponFromOrderedListAt(1);
+        const couponId = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(1);
         expect(couponId).to.equal(0);
       });
 
@@ -662,7 +657,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        const tx1 = await bondKpiLinkedRateFacet.setCoupon(coupon1);
+        const tx1 = await couponKpiLinkedRateFacet.setCoupon(coupon1);
         await tx1.wait();
 
         const coupon2 = {
@@ -676,7 +671,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        const tx2 = await bondKpiLinkedRateFacet.setCoupon(coupon2);
+        const tx2 = await couponKpiLinkedRateFacet.setCoupon(coupon2);
         await tx2.wait();
 
         const coupon3 = {
@@ -690,29 +685,29 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        const tx3 = await bondKpiLinkedRateFacet.setCoupon(coupon3);
+        const tx3 = await couponKpiLinkedRateFacet.setCoupon(coupon3);
         await tx3.wait();
 
         // Move time forward past all fixing dates so coupons appear in ordered list
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 6);
 
         // Get coupon at position 0 (first coupon)
-        const couponId0 = await bondReadFacet.getCouponFromOrderedListAt(0);
+        const couponId0 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(0);
         expect(couponId0).to.equal(1);
 
         // Get coupon at position 1 (second coupon)
-        const couponId1 = await bondReadFacet.getCouponFromOrderedListAt(1);
+        const couponId1 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(1);
         expect(couponId1).to.equal(2);
 
         // Get coupon at position 2 (third coupon)
-        const couponId2 = await bondReadFacet.getCouponFromOrderedListAt(2);
+        const couponId2 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(2);
         expect(couponId2).to.equal(3);
       });
     });
 
     describe("getCouponsOrderedList", () => {
       it("should return empty array when no coupons exist", async () => {
-        const coupons = await bondReadFacet.getCouponsOrderedList(0, 10);
+        const coupons = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
         expect(coupons).to.be.an("array").that.is.empty;
       });
 
@@ -729,7 +724,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon1);
+        await couponKpiLinkedRateFacet.setCoupon(coupon1);
 
         const coupon2 = {
           recordDate: currentBlockTimestamp + TIME_PERIODS_S.DAY * 3,
@@ -742,7 +737,7 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon2);
+        await couponKpiLinkedRateFacet.setCoupon(coupon2);
 
         const coupon3 = {
           recordDate: currentBlockTimestamp + TIME_PERIODS_S.DAY * 5,
@@ -755,12 +750,12 @@ describe("Bond KpiLinked Rate Tests", () => {
           rateStatus: 0,
         };
 
-        await bondKpiLinkedRateFacet.setCoupon(coupon3);
+        await couponKpiLinkedRateFacet.setCoupon(coupon3);
 
         // Move time forward past all fixing dates
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 6);
 
-        const coupons = await bondReadFacet.getCouponsOrderedList(0, 10);
+        const coupons = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
         expect(coupons).to.be.an("array").with.lengthOf(3);
         expect(coupons[0]).to.equal(1);
         expect(coupons[1]).to.equal(2);
@@ -781,31 +776,31 @@ describe("Bond KpiLinked Rate Tests", () => {
             rateStatus: 0,
           };
 
-          await bondKpiLinkedRateFacet.setCoupon(coupon);
+          await couponKpiLinkedRateFacet.setCoupon(coupon);
         }
 
         // Move time forward past all fixing dates
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 11);
 
         // Get first page (2 items)
-        const page1 = await bondReadFacet.getCouponsOrderedList(0, 2);
+        const page1 = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 2);
         expect(page1).to.be.an("array").with.lengthOf(2);
         expect(page1[0]).to.equal(1);
         expect(page1[1]).to.equal(2);
 
         // Get second page (2 items)
-        const page2 = await bondReadFacet.getCouponsOrderedList(1, 2);
+        const page2 = await couponKpiLinkedRateFacet.getCouponsOrderedList(1, 2);
         expect(page2).to.be.an("array").with.lengthOf(2);
         expect(page2[0]).to.equal(3);
         expect(page2[1]).to.equal(4);
 
         // Get third page (1 item remaining)
-        const page3 = await bondReadFacet.getCouponsOrderedList(2, 2);
+        const page3 = await couponKpiLinkedRateFacet.getCouponsOrderedList(2, 2);
         expect(page3).to.be.an("array").with.lengthOf(1);
         expect(page3[0]).to.equal(5);
 
         // Get page beyond available data
-        const page4 = await bondReadFacet.getCouponsOrderedList(3, 2);
+        const page4 = await couponKpiLinkedRateFacet.getCouponsOrderedList(3, 2);
         expect(page4).to.be.an("array").that.is.empty;
       });
 
@@ -823,24 +818,24 @@ describe("Bond KpiLinked Rate Tests", () => {
             rateStatus: 0,
           };
 
-          await bondKpiLinkedRateFacet.setCoupon(coupon);
+          await couponKpiLinkedRateFacet.setCoupon(coupon);
         }
 
         // Move time forward past all fixing dates
         await timeTravelFacet.changeSystemTimestamp(currentBlockTimestamp + TIME_PERIODS_S.DAY * 7);
 
         // Get page 0 (first item)
-        const page0 = await bondReadFacet.getCouponsOrderedList(0, 1);
+        const page0 = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 1);
         expect(page0).to.be.an("array").with.lengthOf(1);
         expect(page0[0]).to.equal(1);
 
         // Get page 1 (second item)
-        const page1 = await bondReadFacet.getCouponsOrderedList(1, 1);
+        const page1 = await couponKpiLinkedRateFacet.getCouponsOrderedList(1, 1);
         expect(page1).to.be.an("array").with.lengthOf(1);
         expect(page1[0]).to.equal(2);
 
         // Get page 2 (third item)
-        const page2 = await bondReadFacet.getCouponsOrderedList(2, 1);
+        const page2 = await couponKpiLinkedRateFacet.getCouponsOrderedList(2, 1);
         expect(page2).to.be.an("array").with.lengthOf(1);
         expect(page2[0]).to.equal(3);
       });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/sustainabilityPerformanceTargetRate/bondSustainabilityPerformanceTargetRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/sustainabilityPerformanceTargetRate/bondSustainabilityPerformanceTargetRate.test.ts
@@ -5,14 +5,13 @@ import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import {
   ResolverProxy,
-  BondUSASustainabilityPerformanceTargetRateFacetTimeTravel,
   SustainabilityPerformanceTargetRateFacetTimeTravel,
-  BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel,
   TimeTravelFacet,
-  ERC1594FacetTimeTravel,
+  ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel,
   ProceedRecipientsSustainabilityPerformanceTargetRateFacetTimeTravel,
   KpisSustainabilityPerformanceTargetRateFacetTimeTravel,
   ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacetTimeTravel,
+  CouponFacetTimeTravel,
 } from "@contract-types";
 import { dateToUnixTimestamp, ATS_ROLES, TIME_PERIODS_S } from "@scripts";
 import { SecurityType } from "@scripts/domain";
@@ -44,11 +43,10 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
   let project1: string;
   let project2: string;
 
-  let bondSPTRateFacet: BondUSASustainabilityPerformanceTargetRateFacetTimeTravel;
-  let bondReadFacet: BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel;
+  let couponSPTRateFacet: CouponFacetTimeTravel;
   let sptRateFacet: SustainabilityPerformanceTargetRateFacetTimeTravel;
   let timeTravelFacet: TimeTravelFacet;
-  let erc1594Facet: ERC1594FacetTimeTravel;
+  let erc1594Facet: ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel;
   let proceedRecipientsFacet: ProceedRecipientsSustainabilityPerformanceTargetRateFacetTimeTravel;
   let kpisFacet: KpisSustainabilityPerformanceTargetRateFacetTimeTravel;
   let scheduledTasksFacet: ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacetTimeTravel;
@@ -97,22 +95,16 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       },
     ]);
 
-    bondSPTRateFacet = await ethers.getContractAt(
-      "BondUSASustainabilityPerformanceTargetRateFacetTimeTravel",
-      diamond.target,
-      signer_A,
-    );
-    bondReadFacet = await ethers.getContractAt(
-      "BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel",
-      diamond.target,
-      signer_A,
-    );
     sptRateFacet = await ethers.getContractAt(
       "SustainabilityPerformanceTargetRateFacetTimeTravel",
       diamond.target,
       signer_A,
     );
-    erc1594Facet = await ethers.getContractAt("ERC1594FacetTimeTravel", diamond.target, signer_A);
+    erc1594Facet = await ethers.getContractAt(
+      "ERC1594SustainabilityPerformanceTargetRateFacetTimeTravel",
+      diamond.target,
+      signer_A,
+    );
     timeTravelFacet = await ethers.getContractAt("TimeTravelFacet", diamond.target);
     proceedRecipientsFacet = await ethers.getContractAt(
       "ProceedRecipientsSustainabilityPerformanceTargetRateFacetTimeTravel",
@@ -126,6 +118,11 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
     );
     scheduledTasksFacet = await ethers.getContractAt(
       "ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacetTimeTravel",
+      diamond.target,
+      signer_A,
+    );
+    couponSPTRateFacet = await ethers.getContractAt(
+      "CouponSustainabilityPerformanceTargetRateFacetTimeTravel",
       diamond.target,
       signer_A,
     );
@@ -153,9 +150,9 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
     nominalValue: number = 100,
     nominalValueDecimals: number = 2,
   ) {
-    const [registeredCouponPostFixingDate] = await bondReadFacet.getCoupon(couponID);
-    const couponForPostFixingDate = await bondReadFacet.getCouponFor(couponID, accountAddress);
-    const couponAmountForPostFixingDate = await bondReadFacet.getCouponAmountFor(couponID, accountAddress);
+    const registeredCouponPostFixingDate = (await couponSPTRateFacet.getCoupon(couponID)).registeredCoupon_;
+    const couponForPostFixingDate = await couponSPTRateFacet.getCouponFor(couponID, accountAddress);
+    const couponAmountForPostFixingDate = await couponSPTRateFacet.getCouponAmountFor(couponID, accountAddress);
 
     const numerator =
       BigInt(amount) *
@@ -239,7 +236,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
 
       const originalFixingDate = couponData.fixingDate;
 
-      await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
       const tasks_count_Before = await scheduledTasksFacet.scheduledCrossOrderedTaskCount();
 
       await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) + 1);
@@ -288,7 +285,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const deltaRateProject1 = 300;
         const deltaRateProject2 = 400;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) + 1);
 
@@ -303,7 +300,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const kpiValue = 800;
         const deltaRateProject1 = 300;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project1);
@@ -320,7 +317,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       it("GIVEN KPI value at or above baseline with PENALTY MINIMUM mode WHEN rate is calculated THEN no deltaRate is added for that project", async () => {
         const kpiValue = 1000;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project1);
@@ -338,7 +335,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const kpiValue = 2200;
         const deltaRateProject2 = 400;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project2);
@@ -355,7 +352,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       it("GIVEN KPI value at or below baseline with PENALTY MAXIMUM mode WHEN rate is calculated THEN no deltaRate is added for that project", async () => {
         const kpiValue = 2000;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project2);
@@ -370,7 +367,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       });
 
       it("GIVEN multiple projects with all targets met WHEN rate is calculated THEN base rate is maintained", async () => {
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, 1200, project1); // Above baseline (MINIMUM) -> no penalty
@@ -413,7 +410,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       });
 
       it("GIVEN no KPI data for any project WHEN rate is calculated with BONUS mode THEN no deltaRate is subtracted", async () => {
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) + 1);
 
@@ -432,7 +429,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const kpiValue = 1200;
         const deltaRateProject1 = 250;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project1);
@@ -448,7 +445,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       it("GIVEN KPI value at or below baseline with BONUS MINIMUM mode WHEN rate is calculated THEN no deltaRate is subtracted", async () => {
         const kpiValue = 1000;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project1);
@@ -470,7 +467,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const kpiValue = 1800;
         const deltaRateProject2 = 350;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project2);
@@ -486,7 +483,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       it("GIVEN KPI value at or above baseline with BONUS MAXIMUM mode WHEN rate is calculated THEN no deltaRate is subtracted", async () => {
         const kpiValue = 2000;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue, project2);
@@ -533,7 +530,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
         const deltaRateProject1 = 200;
         const deltaRateProject2 = 150;
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, kpiValue1, project1);
@@ -548,7 +545,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
       });
 
       it("GIVEN one project with KPI data and one without WHEN rate is calculated THEN only applicable adjustments are made", async () => {
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, 1500, project1); // Above baseline -> no penalty
@@ -592,7 +589,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
           [project1, project2],
         );
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, 2000, project1); // Above baseline -> bonus applies
@@ -623,7 +620,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
           [project1, project2],
         );
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData);
 
         await timeTravelFacet.changeSystemTimestamp(parseInt(couponData.fixingDate) - 1);
         await kpisFacet.addKpiData(parseInt(couponData.fixingDate) - 1, 800, project1); // Below baseline -> penalty
@@ -646,7 +643,7 @@ describe("Bond Sustainability Performance Target Rate Tests", () => {
           executionDate: newExecutionDate.toString(),
         };
 
-        await bondSPTRateFacet.connect(signer_A).setCoupon(couponData2);
+        await couponSPTRateFacet.connect(signer_A).setCoupon(couponData2);
 
         await timeTravelFacet.changeSystemTimestamp(newFixingDate - 1);
         await kpisFacet.addKpiData(newFixingDate - 1, 1500, project1); // Above baseline -> no penalty

--- a/packages/ats/contracts/test/contracts/integration/layer_1/corporateActions/corporateActions.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/corporateActions/corporateActions.test.ts
@@ -51,7 +51,7 @@ describe("Corporate Actions Tests", () => {
     const currentTimestamp = await timeTravelFacet.blockTimestamp();
     const ONE_DAY = 86400n; // 24 hours in seconds
 
-    let dividendData = {
+    const dividendData = {
       recordDate: Number(currentTimestamp + ONE_DAY),
       executionDate: Number(currentTimestamp + ONE_DAY + 1000n),
       amount: 10,

--- a/packages/ats/contracts/test/contracts/integration/layer_1/corporateActions/corporateActions.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/corporateActions/corporateActions.test.ts
@@ -46,7 +46,6 @@ describe("Corporate Actions Tests", () => {
   beforeEach(async () => {
     await loadFixture(deploySecurityFixtureSinglePartition);
   });
-
   it("GIVEN a token with a corporate action the functions returns the data", async () => {
     const currentTimestamp = await timeTravelFacet.blockTimestamp();
     const ONE_DAY = 86400n; // 24 hours in seconds

--- a/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
@@ -1,0 +1,1122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import {
+  ResolverProxy,
+  BondUSAFacet,
+  AccessControl,
+  Pause,
+  Lock,
+  type IERC1410,
+  Kyc,
+  SsiManagement,
+  IHold,
+  ClearingActionsFacet,
+  FreezeFacet,
+  ClearingTransferFacet,
+  BondUSAReadFacet,
+  TimeTravelFacet as TimeTravel,
+  CouponFacetTimeTravel,
+  NominalValueFacet,
+} from "@contract-types";
+import {
+  DEFAULT_PARTITION,
+  ATS_ROLES,
+  TIME_PERIODS_S,
+  ADDRESS_ZERO,
+  ZERO,
+  EMPTY_HEX_BYTES,
+  EMPTY_STRING,
+} from "@scripts";
+import { getDltTimestamp, grantRoleAndPauseToken } from "@test";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { deployBondTokenFixture, deployBondKpiLinkedRateTokenFixture } from "@test";
+import { executeRbac, MAX_UINT256 } from "@test";
+
+const numberOfUnits = 1000;
+let startingDate = 0;
+const numberOfCoupons = 50;
+const frequency = TIME_PERIODS_S.DAY;
+let maturityDate = 0;
+
+let couponRecordDateInSeconds = 0;
+let couponExecutionDateInSeconds = 0;
+const couponRate = 50;
+const couponRateDecimals = 1;
+const couponPeriod = TIME_PERIODS_S.WEEK;
+let couponFixingDateInSeconds = 0;
+let couponEndDateInSeconds = 0;
+let couponStartDateInSeconds = 0;
+const EMPTY_VC_ID = EMPTY_STRING;
+const YEAR_SECONDS = 365 * 24 * 60 * 60;
+const couponRateStatus = 1;
+
+let couponData = {
+  recordDate: couponRecordDateInSeconds.toString(),
+  executionDate: couponExecutionDateInSeconds.toString(),
+  rate: couponRate,
+  rateDecimals: couponRateDecimals,
+  startDate: couponStartDateInSeconds.toString(),
+  endDate: couponEndDateInSeconds.toString(),
+  fixingDate: couponFixingDateInSeconds.toString(),
+  rateStatus: couponRateStatus,
+};
+
+describe("Coupon Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+  let signer_D: HardhatEthersSigner;
+
+  let bondFacet: BondUSAFacet;
+  let bondReadFacet: BondUSAReadFacet;
+  let couponFacet: CouponFacetTimeTravel;
+  let accessControlFacet: AccessControl;
+  let pauseFacet: Pause;
+  let lockFacet: Lock;
+  let holdFacet: IHold;
+  let erc1410Facet: IERC1410;
+  let timeTravelFacet: TimeTravel;
+  let kycFacet: Kyc;
+  let ssiManagementFacet: SsiManagement;
+
+  let clearingActionsFacet: ClearingActionsFacet;
+  let freezeFacet: FreezeFacet;
+  let clearingTransferFacet: ClearingTransferFacet;
+  let nominalValueFacet: NominalValueFacet;
+
+  async function deploySecurityFixture(isMultiPartition = false) {
+    const base = await deployBondTokenFixture({
+      bondDataParams: {
+        securityData: {
+          isMultiPartition,
+        },
+        bondDetails: {
+          startingDate: startingDate,
+          maturityDate: maturityDate,
+        },
+      },
+    });
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+    signer_D = base.user3;
+
+    await executeRbac(base.accessControlFacet, [
+      {
+        role: ATS_ROLES._FREEZE_MANAGER_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES._PAUSER_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES._KYC_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES._MATURITY_REDEEMER_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES._SSI_MANAGER_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES._CONTROL_LIST_ROLE,
+        members: [signer_D.address],
+      },
+      {
+        role: ATS_ROLES._CLEARING_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES._PROTECTED_PARTITIONS_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES._AGENT_ROLE,
+        members: [signer_A.address],
+      },
+    ]);
+
+    bondFacet = await ethers.getContractAt("BondUSAFacetTimeTravel", diamond.target, signer_A);
+    bondReadFacet = await ethers.getContractAt("BondUSAReadFacetTimeTravel", diamond.target, signer_A);
+    couponFacet = await ethers.getContractAt("CouponFacetTimeTravel", diamond.target, signer_A);
+
+    accessControlFacet = await ethers.getContractAt("AccessControl", diamond.target, signer_A);
+    pauseFacet = await ethers.getContractAt("Pause", diamond.target, signer_A);
+    lockFacet = await ethers.getContractAt("Lock", diamond.target, signer_A);
+    holdFacet = await ethers.getContractAt("IHold", diamond.target, signer_A);
+    erc1410Facet = await ethers.getContractAt("IERC1410", diamond.target, signer_A);
+    timeTravelFacet = await ethers.getContractAt("TimeTravelFacet", diamond.target, signer_A);
+    kycFacet = await ethers.getContractAt("Kyc", diamond.target, signer_B);
+    ssiManagementFacet = await ethers.getContractAt("SsiManagement", diamond.target, signer_A);
+    nominalValueFacet = await ethers.getContractAt("NominalValueFacet", diamond.target, signer_A);
+
+    await ssiManagementFacet.connect(signer_A).addIssuer(signer_A.address);
+
+    clearingActionsFacet = await ethers.getContractAt("ClearingActionsFacet", diamond.target, signer_A);
+
+    freezeFacet = await ethers.getContractAt("FreezeFacet", diamond.target, signer_A);
+    clearingTransferFacet = await ethers.getContractAt("ClearingTransferFacet", diamond.target, signer_A);
+
+    await kycFacet.grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+  }
+
+  before(async () => {
+    const currentTimestamp = await getDltTimestamp();
+    startingDate = currentTimestamp + TIME_PERIODS_S.DAY;
+    maturityDate = startingDate + numberOfCoupons * frequency;
+  });
+
+  beforeEach(async () => {
+    const currentTimestamp = await getDltTimestamp();
+    couponRecordDateInSeconds = currentTimestamp + 400;
+    couponExecutionDateInSeconds = currentTimestamp + 1200;
+    couponFixingDateInSeconds = currentTimestamp + 1200;
+    couponEndDateInSeconds = couponFixingDateInSeconds - 1;
+    couponStartDateInSeconds = couponEndDateInSeconds - couponPeriod;
+    couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: 1,
+    };
+    await loadFixture(deploySecurityFixture);
+  });
+
+  it("GIVEN an account without corporateActions role WHEN setCoupon THEN transaction fails with AccountHasNoRole", async () => {
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData)).to.be.rejectedWith("AccountHasNoRole");
+  });
+
+  it("GIVEN a paused Token WHEN setCoupon THEN transaction fails with TokenIsPaused", async () => {
+    // Granting Role to account C and Pause
+    await grantRoleAndPauseToken(
+      accessControlFacet,
+      pauseFacet,
+      ATS_ROLES._CORPORATE_ACTION_ROLE,
+      signer_A,
+      signer_B,
+      signer_C.address,
+    );
+
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData)).to.be.rejectedWith("TokenIsPaused");
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon with wrong dates THEN transaction fails", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    const wrongcouponData_1 = {
+      recordDate: couponExecutionDateInSeconds.toString(),
+      executionDate: couponRecordDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(wrongcouponData_1)).to.be.revertedWithCustomError(
+      bondFacet,
+      "WrongDates",
+    );
+
+    const wrongcouponData_2 = {
+      recordDate: (await getDltTimestamp()) - 1,
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(wrongcouponData_2)).to.be.revertedWithCustomError(
+      bondFacet,
+      "WrongTimestamp",
+    );
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon with period THEN period is stored correctly", async () => {
+    await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+    const customPeriod = 3 * 24 * 60 * 60; // 3 days in seconds
+    const customStartDate = couponEndDateInSeconds - customPeriod;
+    const customCouponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: customStartDate.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(customCouponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        customStartDate,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+
+    const registeredCoupon = await couponFacet.getCoupon(1);
+    expect(registeredCoupon.registeredCoupon_.coupon.endDate).to.equal(couponEndDateInSeconds);
+    expect(registeredCoupon.registeredCoupon_.coupon.startDate).to.equal(customStartDate);
+
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    expect(couponFor.coupon.endDate).to.equal(couponEndDateInSeconds);
+    expect(couponFor.coupon.startDate).to.equal(customStartDate);
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon with period 0 THEN transaction succeeds", async () => {
+    accessControlFacet = accessControlFacet.connect(signer_A);
+    await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    const minValidPeriodCouponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponEndDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(minValidPeriodCouponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        couponEndDateInSeconds,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        couponStartDateInSeconds,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+
+    const listCount = await couponFacet.getCouponCount();
+    const [coupon, isDisabled] = await couponFacet.getCoupon(1);
+
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    const couponAmountFor = await couponFacet.getCouponAmountFor(1, signer_A.address);
+    const couponTotalHolders = await couponFacet.getTotalCouponHolders(1);
+    const couponHolders = await couponFacet.getCouponHolders(1, 0, couponTotalHolders);
+
+    const [couponsFor, accounts] = await couponFacet.getCouponsFor(1, 0, 10);
+
+    const couponsOrderedListTotal = await couponFacet.getCouponsOrderedListTotal();
+
+    expect(listCount).to.equal(1);
+    expect(isDisabled).to.be.false;
+    expect(coupon.snapshotId).to.equal(0);
+    expect(coupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
+    expect(coupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
+    expect(coupon.coupon.rate).to.equal(couponRate);
+    expect(coupon.coupon.rateDecimals).to.equal(couponRateDecimals);
+    expect(coupon.coupon.startDate).to.equal(couponStartDateInSeconds);
+    expect(coupon.coupon.endDate).to.equal(couponEndDateInSeconds);
+    expect(coupon.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
+    expect(coupon.coupon.rateStatus).to.equal(couponRateStatus);
+
+    expect(couponFor.coupon.recordDate).to.equal(couponRecordDateInSeconds);
+    expect(couponFor.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
+    expect(couponFor.coupon.rate).to.equal(couponRate);
+    expect(couponFor.coupon.rateDecimals).to.equal(couponRateDecimals);
+    expect(couponFor.coupon.startDate).to.equal(couponStartDateInSeconds);
+    expect(couponFor.coupon.endDate).to.equal(couponEndDateInSeconds);
+    expect(couponFor.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
+    expect(couponFor.coupon.rateStatus).to.equal(couponRateStatus);
+    expect(couponFor.tokenBalance).to.equal(0);
+    expect(couponFor.recordDateReached).to.equal(false);
+    expect(couponFor.isDisabled).to.equal(false);
+    expect(couponFor.nominalValue).to.be.equal(0);
+    expect(couponFor.decimals).to.be.equal(0);
+
+    expect(couponFor.couponAmount.recordDateReached).to.equal(false);
+    expect(couponFor.couponAmount.numerator).to.equal(0);
+    expect(couponFor.couponAmount.denominator).to.equal(0);
+
+    expect(couponTotalHolders).to.equal(0);
+    expect(couponHolders.length).to.equal(couponTotalHolders);
+    expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
+    expect(couponAmountFor.numerator).to.equal(0);
+    expect(couponAmountFor.denominator).to.equal(0);
+
+    expect(couponsFor.length).to.equal(0); // No holders yet, so no entries
+    expect(accounts.length).to.equal(0);
+
+    expect(couponsOrderedListTotal).to.equal(0);
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon and lock THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._LOCKER_ROLE, signer_C.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    // issue and lock
+    const TotalAmount = numberOfUnits;
+    const LockedAmount = TotalAmount - 5;
+
+    await erc1410Facet.connect(signer_C).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: TotalAmount,
+      data: "0x",
+    });
+
+    await lockFacet.connect(signer_C).lock(LockedAmount, signer_A.address, MAX_UINT256);
+
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        couponStartDateInSeconds,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+    await accessControlFacet.connect(signer_A).revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    const couponAmountFor = await couponFacet.getCouponAmountFor(1, signer_A.address);
+    const couponTotalHolders = await couponFacet.getTotalCouponHolders(1);
+    const couponHolders = await couponFacet.getCouponHolders(1, 0, couponTotalHolders);
+    const nominalValue = await nominalValueFacet.getNominalValue();
+    const nominalValueDecimals = await nominalValueFacet.getNominalValueDecimals();
+    const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
+
+    const [couponsForList, accountsList] = await couponFacet.getCouponsFor(1, 0, 10);
+    expect(couponsForList.length).to.equal(1);
+    expect(accountsList.length).to.equal(1);
+    expect(accountsList[0]).to.equal(signer_A.address);
+
+    const couponForFromList = couponsForList[0];
+    expect(couponForFromList.tokenBalance).to.equal(TotalAmount);
+    expect(couponForFromList.recordDateReached).to.equal(true);
+    expect(couponForFromList.isDisabled).to.equal(false);
+    expect(couponForFromList.nominalValue).to.be.greaterThan(0);
+    expect(couponForFromList.decimals).to.be.greaterThan(0);
+
+    expect(couponFor.tokenBalance).to.equal(TotalAmount);
+    expect(couponFor.recordDateReached).to.equal(true);
+    expect(couponTotalHolders).to.equal(1);
+    expect(couponHolders.length).to.equal(couponTotalHolders);
+    expect([...couponHolders]).to.have.members([signer_A.address]);
+    expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
+    expect(couponAmountFor.numerator).to.equal(couponFor.tokenBalance * nominalValue * couponFor.coupon.rate * period);
+    expect(couponAmountFor.denominator).to.equal(
+      10n ** (couponFor.decimals + nominalValueDecimals + couponFor.coupon.rateDecimals) * BigInt(YEAR_SECONDS),
+    );
+  });
+
+  it("GIVEN an account with corporateActions role WHEN setCoupon and hold THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    const TotalAmount = numberOfUnits;
+    const HeldAmount = TotalAmount - 5;
+
+    await erc1410Facet.connect(signer_C).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: TotalAmount,
+      data: "0x",
+    });
+
+    const hold = {
+      amount: HeldAmount,
+      expirationTimestamp: MAX_UINT256,
+      escrow: signer_B.address,
+      to: ADDRESS_ZERO,
+      data: "0x",
+    };
+
+    await holdFacet.createHoldByPartition(DEFAULT_PARTITION, hold);
+
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        couponStartDateInSeconds,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+    await accessControlFacet.connect(signer_A).revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    const couponAmountFor = await couponFacet.getCouponAmountFor(1, signer_A.address);
+    const couponTotalHolders = await couponFacet.getTotalCouponHolders(1);
+    const couponHolders = await couponFacet.getCouponHolders(1, 0, couponTotalHolders);
+    const nominalValue = await nominalValueFacet.getNominalValue();
+    const nominalValueDecimals = await nominalValueFacet.getNominalValueDecimals();
+    const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
+
+    const [couponsForList, accountsList] = await couponFacet.getCouponsFor(1, 0, 10);
+    expect(couponsForList.length).to.equal(1);
+    expect(accountsList.length).to.equal(1);
+    expect(accountsList[0]).to.equal(signer_A.address);
+
+    const couponForFromList = couponsForList[0];
+    expect(couponForFromList.tokenBalance).to.equal(TotalAmount);
+    expect(couponForFromList.recordDateReached).to.equal(true);
+    expect(couponForFromList.isDisabled).to.equal(false);
+    expect(couponForFromList.nominalValue).to.be.greaterThan(0);
+    expect(couponForFromList.decimals).to.be.greaterThan(0);
+
+    expect(couponFor.tokenBalance).to.equal(TotalAmount);
+    expect(couponFor.recordDateReached).to.equal(true);
+    expect(couponTotalHolders).to.equal(1);
+    expect(couponHolders.length).to.equal(couponTotalHolders);
+    expect([...couponHolders]).to.have.members([signer_A.address]);
+    expect(couponAmountFor.recordDateReached).to.equal(couponFor.recordDateReached);
+    expect(couponAmountFor.numerator).to.equal(couponFor.tokenBalance * nominalValue * couponFor.coupon.rate * period);
+    expect(couponAmountFor.denominator).to.equal(
+      10n ** (couponFor.decimals + nominalValueDecimals + couponFor.coupon.rateDecimals) * BigInt(YEAR_SECONDS),
+    );
+  });
+
+  it("GIVEN an account with bondManager role WHEN setMaturityDate THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._BOND_MANAGER_ROLE, signer_C.address);
+    const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
+    const newMaturityDate = maturityDateBefore + 86400n;
+
+    await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate))
+      .to.emit(bondFacet, "MaturityDateUpdated")
+      .withArgs(bondFacet.target, newMaturityDate, maturityDateBefore);
+    const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
+    expect(maturityDateAfter).not.to.be.equal(maturityDateBefore);
+    expect(maturityDateAfter).to.be.equal(newMaturityDate);
+  });
+
+  it("GIVEN an account with bondManager role WHEN setMaturityDate to earlier date THEN transaction fails", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._BOND_MANAGER_ROLE, signer_C.address);
+    const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
+    const dayBeforeCurrentMaturity = maturityDateBefore - 86400n;
+
+    await expect(
+      bondFacet.connect(signer_C).updateMaturityDate(dayBeforeCurrentMaturity),
+    ).to.be.revertedWithCustomError(bondFacet, "BondMaturityDateWrong");
+    const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
+    expect(maturityDateAfter).to.be.equal(maturityDateBefore);
+  });
+
+  it("GIVEN an account without bondManager role WHEN setMaturityDate THEN transaction fails with AccountHasNoRole", async () => {
+    const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
+    const newMaturityDate = maturityDateBefore + 86400n;
+
+    await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate)).to.be.rejectedWith(
+      "AccountHasNoRole",
+    );
+    const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
+    expect(maturityDateAfter).to.be.equal(maturityDateBefore);
+  });
+
+  it("GIVEN a paused Token WHEN setMaturityDate THEN transaction fails with TokenIsPaused", async () => {
+    await grantRoleAndPauseToken(
+      accessControlFacet,
+      pauseFacet,
+      ATS_ROLES._BOND_MANAGER_ROLE,
+      signer_A,
+      signer_B,
+      signer_C.address,
+    );
+
+    const maturityDateBefore = (await bondReadFacet.getBondDetails()).maturityDate;
+    const newMaturityDate = maturityDateBefore + 86400n;
+
+    await expect(bondFacet.connect(signer_C).updateMaturityDate(newMaturityDate)).to.be.rejectedWith("TokenIsPaused");
+    const maturityDateAfter = (await bondReadFacet.getBondDetails()).maturityDate;
+    expect(maturityDateAfter).to.be.equal(maturityDateBefore);
+  });
+
+  it("Given a coupon and account with normal, cleared, held, locked and frozen balance WHEN  getCouponFor THEN sum of balances is correct", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._LOCKER_ROLE, signer_C.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    const totalAmount = numberOfUnits;
+    const lockedAmount = totalAmount / 5;
+    const heldAmount = totalAmount / 5;
+    const frozenAmount = totalAmount / 5;
+    const clearedAmount = totalAmount / 5;
+
+    await erc1410Facet.connect(signer_C).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: totalAmount,
+      data: "0x",
+    });
+
+    const hold = {
+      amount: heldAmount,
+      expirationTimestamp: MAX_UINT256,
+      escrow: signer_B.address,
+      to: ADDRESS_ZERO,
+      data: "0x",
+    };
+
+    await holdFacet.createHoldByPartition(DEFAULT_PARTITION, hold);
+    await lockFacet.connect(signer_C).lock(lockedAmount, signer_A.address, MAX_UINT256);
+    await freezeFacet.freezePartialTokens(signer_A.address, frozenAmount);
+    await clearingActionsFacet.activateClearing();
+
+    const clearingOperation = {
+      partition: DEFAULT_PARTITION,
+      expirationTimestamp: (await getDltTimestamp()) + 500,
+      data: EMPTY_HEX_BYTES,
+    };
+
+    await clearingTransferFacet.clearingTransferByPartition(clearingOperation, clearedAmount, signer_D.address);
+
+    await expect(couponFacet.connect(signer_C).setCoupon(couponData))
+      .to.emit(couponFacet, "CouponSet")
+      .withArgs("0x0000000000000000000000000000000000000000000000000000000000000001", 1, signer_C.address, [
+        couponRecordDateInSeconds,
+        couponExecutionDateInSeconds,
+        couponStartDateInSeconds,
+        couponEndDateInSeconds,
+        couponFixingDateInSeconds,
+        couponRate,
+        couponRateDecimals,
+        couponRateStatus,
+      ]);
+
+    const before = await couponFacet.getCouponFor(1, signer_A.address);
+    const couponAmountForBefore = await couponFacet.getCouponAmountFor(1, signer_A.address);
+    expect(before.recordDateReached).to.equal(false);
+    expect(before.tokenBalance).to.equal(0);
+    expect(couponAmountForBefore.recordDateReached).to.equal(before.recordDateReached);
+    expect(couponAmountForBefore.numerator).to.equal(0);
+    expect(couponAmountForBefore.denominator).to.equal(0);
+
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+    await accessControlFacet.revokeRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    const couponAmountForAfter = await couponFacet.getCouponAmountFor(1, signer_A.address);
+    const bondDetails = await bondReadFacet.getBondDetails();
+    const period = couponFor.coupon.endDate - couponFor.coupon.startDate;
+
+    const [couponsForList, accountsList] = await couponFacet.getCouponsFor(1, 0, 10);
+    expect(couponsForList.length).to.equal(1);
+    expect(accountsList.length).to.equal(1);
+    expect(accountsList[0]).to.equal(signer_A.address);
+
+    const couponForFromList = couponsForList[0];
+    expect(couponForFromList.tokenBalance).to.equal(couponFor.tokenBalance);
+    expect(couponForFromList.recordDateReached).to.equal(couponFor.recordDateReached);
+    expect(couponForFromList.isDisabled).to.equal(couponFor.isDisabled);
+    expect(couponForFromList.nominalValue).to.equal(couponFor.nominalValue);
+    expect(couponForFromList.decimals).to.equal(couponFor.decimals);
+    expect(couponForFromList.coupon.recordDate).to.equal(couponFor.coupon.recordDate);
+    expect(couponForFromList.coupon.executionDate).to.equal(couponFor.coupon.executionDate);
+    expect(couponForFromList.coupon.rate).to.equal(couponFor.coupon.rate);
+    expect(couponForFromList.coupon.rateDecimals).to.equal(couponFor.coupon.rateDecimals);
+    expect(couponForFromList.coupon.startDate).to.equal(couponFor.coupon.startDate);
+    expect(couponForFromList.coupon.endDate).to.equal(couponFor.coupon.endDate);
+    expect(couponForFromList.coupon.fixingDate).to.equal(couponFor.coupon.fixingDate);
+    expect(couponForFromList.coupon.rateStatus).to.equal(couponFor.coupon.rateStatus);
+    expect(couponForFromList.couponAmount.numerator).to.equal(couponFor.couponAmount.numerator);
+    expect(couponForFromList.couponAmount.denominator).to.equal(couponFor.couponAmount.denominator);
+    expect(couponForFromList.couponAmount.recordDateReached).to.equal(couponFor.couponAmount.recordDateReached);
+
+    expect(couponFor.recordDateReached).to.equal(true);
+    expect(couponFor.tokenBalance).to.equal(totalAmount); // normal+cleared+held+locked+frozen
+    expect(couponAmountForAfter.recordDateReached).to.equal(couponFor.recordDateReached);
+    expect(couponAmountForAfter.numerator).to.equal(
+      couponFor.tokenBalance * bondDetails.nominalValue * couponFor.coupon.rate * period,
+    );
+    expect(couponAmountForAfter.denominator).to.equal(
+      10n ** (couponFor.decimals + bondDetails.nominalValueDecimals + couponFor.coupon.rateDecimals) *
+        BigInt(YEAR_SECONDS),
+    );
+  });
+
+  it("GIVEN an account with corporateActions role WHEN cancelling a coupon THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await couponFacet.connect(signer_C).setCoupon(couponData);
+
+    await expect(couponFacet.connect(signer_C).cancelCoupon(1))
+      .to.emit(couponFacet, "CouponCancelled")
+      .withArgs(1, signer_C.address);
+    const isDisabled = (await couponFacet.getCoupon(1)).isDisabled_;
+    expect(isDisabled).to.equal(true);
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    expect(couponFor.isDisabled).to.equal(true);
+  });
+
+  it("GIVEN a coupon after execution date WHEN cancelCoupon THEN transaction fails with CorporateActionAlreadyExecuted", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await couponFacet.connect(signer_C).setCoupon(couponData);
+
+    await timeTravelFacet.changeSystemTimestamp(couponExecutionDateInSeconds + 1);
+
+    await expect(couponFacet.connect(signer_C).cancelCoupon(1)).to.be.revertedWithCustomError(
+      bondFacet,
+      "CouponAlreadyExecuted",
+    );
+  });
+
+  it("GIVEN a coupon after record date but before execution date WHEN cancelCoupon THEN transaction succeeds", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await couponFacet.connect(signer_C).setCoupon(couponData);
+
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+
+    await expect(couponFacet.connect(signer_C).cancelCoupon(1))
+      .to.emit(couponFacet, "CouponCancelled")
+      .withArgs(1, signer_C.address);
+  });
+
+  it("GIVEN an account without corporateActions role WHEN cancelCoupon THEN transaction fails with AccountHasNoRole", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await couponFacet.connect(signer_C).setCoupon(couponData);
+
+    await expect(couponFacet.connect(signer_D).cancelCoupon(1)).to.be.rejectedWith("AccountHasNoRole");
+  });
+
+  it("GIVEN a paused Token WHEN cancelCoupon THEN transaction fails with TokenIsPaused", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await couponFacet.connect(signer_C).setCoupon(couponData);
+
+    await pauseFacet.connect(signer_B).pause();
+
+    await expect(couponFacet.connect(signer_C).cancelCoupon(1)).to.be.rejectedWith("TokenIsPaused");
+  });
+
+  it("GIVEN no existing coupon WHEN cancelCoupon with invalid ID THEN transaction fails", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C);
+
+    await expect(couponFacet.connect(signer_C).cancelCoupon(999)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+  });
+
+  it("GIVEN a coupon with snapshot WHEN getCouponHolders is called THEN returns token holders from snapshot", async () => {
+    const TotalAmount = 1000;
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_A.address);
+    await kycFacet.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+
+    await erc1410Facet.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: TotalAmount,
+      data: "0x",
+    });
+
+    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
+    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await couponFacet.connect(signer_A).setCoupon(couponData);
+
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+
+    // Trigger scheduled tasks by performing an action
+    await erc1410Facet.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_B.address,
+      value: 500,
+      data: "0x",
+    });
+
+    const coupon = (await couponFacet.getCoupon(1)).registeredCoupon_;
+    const couponTotalHolders = await couponFacet.getTotalCouponHolders(1);
+    const couponHolders = await couponFacet.getCouponHolders(1, 0, couponTotalHolders);
+
+    expect(coupon.snapshotId).to.be.greaterThan(0); // Snapshot should have been taken
+    expect(couponTotalHolders).to.equal(1);
+    expect([...couponHolders]).to.have.members([signer_A.address]);
+  });
+
+  it("GIVEN a coupon without snapshot WHEN getCouponFor is called after record date THEN uses current balance", async () => {
+    const TotalAmount = 1000;
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_A.address);
+
+    await erc1410Facet.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: TotalAmount,
+      data: "0x",
+    });
+
+    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
+    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await couponFacet.connect(signer_A).setCoupon(couponData);
+
+    // Time travel past record date but DON'T trigger snapshot
+    await timeTravelFacet.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+
+    // Query couponFor without triggering snapshot - should use current balance path
+    const couponFor = await couponFacet.getCouponFor(1, signer_A.address);
+    const coupon = (await couponFacet.getCoupon(1)).registeredCoupon_;
+
+    expect(coupon.snapshotId).to.equal(0); // No snapshot taken
+    expect(couponFor.recordDateReached).to.be.true;
+    expect(couponFor.tokenBalance).to.equal(TotalAmount);
+    expect(couponFor.isDisabled).to.be.false;
+  });
+
+  it("GIVEN a coupon WHEN getCoupon is called THEN decodes coupon data", async () => {
+    await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
+    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
+    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await couponFacet.connect(signer_A).setCoupon(couponData);
+
+    const coupon = (await couponFacet.getCoupon(1)).registeredCoupon_;
+
+    expect(coupon.coupon.recordDate).to.equal(couponRecordDateInSeconds);
+    expect(coupon.coupon.executionDate).to.equal(couponExecutionDateInSeconds);
+    expect(coupon.coupon.rate).to.equal(couponRate);
+    expect(coupon.coupon.rateDecimals).to.equal(couponRateDecimals);
+    expect(coupon.coupon.startDate).to.equal(couponStartDateInSeconds);
+    expect(coupon.coupon.endDate).to.equal(couponEndDateInSeconds);
+    expect(coupon.coupon.fixingDate).to.equal(couponFixingDateInSeconds);
+    expect(coupon.coupon.rateStatus).to.equal(couponRateStatus);
+  });
+
+  it("GIVEN a non-coupon corporate action WHEN call with invalid index view methods THEN transaction fails with WrongActionType", async () => {
+    await expect(couponFacet.getCoupon(999)).to.be.revertedWithCustomError(couponFacet, "WrongIndexForAction");
+    await expect(couponFacet.getCouponFor(999, signer_A.address)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+    await expect(couponFacet.getCouponAmountFor(999, signer_A.address)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+    await expect(couponFacet.getTotalCouponHolders(999)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+    await expect(couponFacet.getCouponHolders(999, 0, 10)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+
+    await expect(couponFacet.getCouponsFor(999, 0, 10)).to.be.revertedWithCustomError(
+      couponFacet,
+      "WrongIndexForAction",
+    );
+  });
+
+  it("GIVEN invalid startDate > endDate WHEN setCoupon THEN transaction fails with WrongDates", async () => {
+    await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+    const currentTimestamp = await getDltTimestamp();
+    const invalidCoupon = {
+      recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
+      executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: currentTimestamp + TIME_PERIODS_S.DAY * 3, // startDate > endDate
+      endDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
+      fixingDate: currentTimestamp + TIME_PERIODS_S.DAY,
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
+      bondFacet,
+      "WrongDates",
+    );
+  });
+
+  it("GIVEN invalid fixingDate > executionDate WHEN setCoupon THEN transaction fails with WrongDates", async () => {
+    await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    const currentTimestamp = await getDltTimestamp();
+    const invalidCoupon = {
+      recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
+      executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: currentTimestamp,
+      endDate: currentTimestamp + TIME_PERIODS_S.DAY * 3,
+      fixingDate: currentTimestamp + TIME_PERIODS_S.DAY * 3, // fixingDate > executionDate
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
+      bondFacet,
+      "WrongDates",
+    );
+  });
+
+  it("GIVEN fixingDate in the past WHEN setCoupon THEN transaction fails with WrongTimestamp", async () => {
+    await accessControlFacet.grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+    const currentTimestamp = await getDltTimestamp();
+    const invalidCoupon = {
+      recordDate: currentTimestamp + TIME_PERIODS_S.DAY,
+      executionDate: currentTimestamp + TIME_PERIODS_S.DAY * 2,
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: currentTimestamp - TIME_PERIODS_S.DAY * 3,
+      endDate: currentTimestamp + TIME_PERIODS_S.DAY * 3,
+      fixingDate: currentTimestamp - TIME_PERIODS_S.DAY, // fixingDate in the past
+      rateStatus: couponRateStatus,
+    };
+
+    await expect(couponFacet.connect(signer_C).setCoupon(invalidCoupon)).to.be.revertedWithCustomError(
+      bondFacet,
+      "WrongTimestamp",
+    );
+  });
+
+  it("GIVEN multiple coupons WHEN triggerScheduledCrossOrderedTasks is called after fixingDate THEN coupons are added to ordered list", async () => {
+    const kpiLinkedRateBase = await deployBondKpiLinkedRateTokenFixture({
+      bondDataParams: {
+        securityData: {
+          isMultiPartition: false,
+        },
+        bondDetails: {
+          startingDate: startingDate,
+          maturityDate: maturityDate,
+        },
+      },
+    });
+
+    const kpiDiamond = kpiLinkedRateBase.diamond;
+    const couponKpiLinkedRateFacet = await ethers.getContractAt(
+      "CouponKpiLinkedRateFacetTimeTravel",
+      kpiDiamond.target,
+      signer_A,
+    );
+    const accessControlKpi = await ethers.getContractAt("AccessControl", kpiDiamond.target, signer_A);
+    const scheduledTasksKpi = await ethers.getContractAt("ScheduledCrossOrderedTasks", kpiDiamond.target, signer_A);
+    const timeTravelKpi = await ethers.getContractAt("TimeTravelFacet", kpiDiamond.target, signer_A);
+
+    await accessControlKpi.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
+
+    const timestamp = await getDltTimestamp();
+
+    const coupon1 = {
+      recordDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      executionDate: (timestamp + TIME_PERIODS_S.DAY * 2).toString(),
+      rate: 0,
+      rateDecimals: 0,
+      startDate: timestamp.toString(),
+      endDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      fixingDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      rateStatus: 0,
+    };
+
+    const coupon2 = {
+      recordDate: (timestamp + TIME_PERIODS_S.DAY * 2).toString(),
+      executionDate: (timestamp + TIME_PERIODS_S.DAY * 3).toString(),
+      rate: 0,
+      rateDecimals: 0,
+      startDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      endDate: (timestamp + TIME_PERIODS_S.DAY * 2).toString(),
+      fixingDate: (timestamp + TIME_PERIODS_S.DAY * 2).toString(),
+      rateStatus: 0,
+    };
+
+    await expect(couponKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon1)).to.emit(
+      couponKpiLinkedRateFacet,
+      "CouponSet",
+    );
+
+    await expect(await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon2)).to.emit(
+      couponKpiLinkedRateFacet,
+      "CouponSet",
+    );
+
+    let orderedList = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
+    expect(orderedList).to.be.an("array").with.lengthOf(0);
+
+    await timeTravelKpi.changeSystemTimestamp(timestamp + TIME_PERIODS_S.DAY + 1);
+
+    await scheduledTasksKpi.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+
+    orderedList = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
+    expect(orderedList).to.be.an("array").with.lengthOf(1);
+    expect(orderedList[0]).to.equal(1); // couponId 1
+
+    await timeTravelKpi.changeSystemTimestamp(timestamp + TIME_PERIODS_S.DAY * 2 + 1);
+
+    await scheduledTasksKpi.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+
+    orderedList = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
+    expect(orderedList).to.be.an("array").with.lengthOf(2);
+    expect(orderedList[0]).to.equal(1); // couponId 1
+    expect(orderedList[1]).to.equal(2); // couponId 2
+
+    // Verify getCouponFromOrderedListAt works correctly
+    const couponIdAtPos0 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(0);
+    const couponIdAtPos1 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(1);
+    expect(couponIdAtPos0).to.equal(1);
+    expect(couponIdAtPos1).to.equal(2);
+
+    // Verify getCouponsOrderedListTotal
+    const totalCouponsInOrderedList = await couponKpiLinkedRateFacet.getCouponsOrderedListTotal();
+    expect(totalCouponsInOrderedList).to.equal(2);
+  });
+
+  it("GIVEN deprecated coupons in bond storage AND new coupons in coupon storage WHEN getCouponFromOrderedListAt is called THEN it correctly routes to both storages with offset", async () => {
+    const kpiLinkedRateBase = await deployBondKpiLinkedRateTokenFixture({
+      bondDataParams: {
+        securityData: {
+          isMultiPartition: false,
+        },
+        bondDetails: {
+          startingDate: startingDate,
+          maturityDate: maturityDate,
+        },
+      },
+    });
+
+    const kpiDiamond = kpiLinkedRateBase.diamond;
+    const couponKpiLinkedRateFacet = await ethers.getContractAt(
+      "CouponKpiLinkedRateFacetTimeTravel",
+      kpiDiamond.target,
+      signer_A,
+    );
+    const accessControlKpi = await ethers.getContractAt("AccessControl", kpiDiamond.target, signer_A);
+    const scheduledTasksKpi = await ethers.getContractAt("ScheduledCrossOrderedTasks", kpiDiamond.target, signer_A);
+    const timeTravelKpi = await ethers.getContractAt("TimeTravelFacet", kpiDiamond.target, signer_A);
+
+    await accessControlKpi.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_A.address);
+
+    const timestamp = await getDltTimestamp();
+
+    const coupon1 = {
+      recordDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      executionDate: (timestamp + TIME_PERIODS_S.DAY * 2).toString(),
+      rate: 0,
+      rateDecimals: 0,
+      startDate: timestamp.toString(),
+      endDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      fixingDate: (timestamp + TIME_PERIODS_S.DAY).toString(),
+      rateStatus: 0,
+    };
+
+    await expect(couponKpiLinkedRateFacet.connect(signer_A).setCoupon(coupon1)).to.emit(
+      couponKpiLinkedRateFacet,
+      "CouponSet",
+    );
+
+    // Trigger scheduled tasks to move coupon1 to ordered list
+    await timeTravelKpi.changeSystemTimestamp(timestamp + TIME_PERIODS_S.DAY + 1);
+    await scheduledTasksKpi.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+
+    // Add deprecated coupons to bond storage (simulating legacy data from before refactor)
+    // This must be done AFTER triggers complete to avoid errors when triggers try to process fake IDs
+    await timeTravelKpi.testOnlyAddDeprecatedCoupon(100);
+
+    // 1 deprecated (in bond storage) + 1 new (in coupon storage)
+    const totalCoupons = await couponKpiLinkedRateFacet.getCouponsOrderedListTotal();
+    expect(totalCoupons).to.equal(2);
+
+    const pos0 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(0);
+    expect(pos0).to.equal(100); // from deprecated bond storage
+
+    const pos3 = await couponKpiLinkedRateFacet.getCouponFromOrderedListAt(1);
+    expect(pos3).to.equal(1); // first new coupon
+
+    const fullList = await couponKpiLinkedRateFacet.getCouponsOrderedList(0, 10);
+    expect(fullList).to.have.lengthOf(2);
+    expect(fullList[0]).to.equal(100); // deprecated
+    expect(fullList[1]).to.equal(1); // new storage
+  });
+
+  it("GIVEN empty ordered list WHEN getCouponFromOrderedListAt with _pos >= getCouponsOrderedListTotalAdjustedAt THEN returns 0", async () => {
+    const couponIdAtPos0 = await couponFacet.getCouponFromOrderedListAt(0);
+    expect(couponIdAtPos0).to.equal(0);
+
+    // Test position 1 - should return 0 because list is empty
+    const couponIdAtPos1 = await couponFacet.getCouponFromOrderedListAt(1);
+    expect(couponIdAtPos1).to.equal(0);
+
+    // Test position 100 - should return 0 because list is empty
+    const couponIdAtPos100 = await couponFacet.getCouponFromOrderedListAt(100);
+    expect(couponIdAtPos100).to.equal(0);
+  });
+});

--- a/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
@@ -701,7 +701,7 @@ describe("Coupon Tests", () => {
     await timeTravelFacet.changeSystemTimestamp(couponExecutionDateInSeconds + 1);
 
     await expect(couponFacet.connect(signer_C).cancelCoupon(1)).to.be.revertedWithCustomError(
-      bondFacet,
+      couponFacet,
       "CouponAlreadyExecuted",
     );
   });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/proceedRecipients/fixingDateInterestRate/proceedRecipients.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/proceedRecipients/fixingDateInterestRate/proceedRecipients.test.ts
@@ -7,9 +7,9 @@ import {
   ProceedRecipientsKpiLinkedRateFacetTimeTravel,
   ResolverProxy,
   AccessControl,
-  BondUSAKpiLinkedRateFacetTimeTravel,
   ScheduledCrossOrderedTasksKpiLinkedRateFacetTimeTravel,
   TimeTravelFacet,
+  CouponFacetTimeTravel,
 } from "@contract-types";
 import { dateToUnixTimestamp, ATS_ROLES } from "@scripts";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
@@ -25,7 +25,7 @@ describe("Proceed Recipients fixing Date Interest RateTests", () => {
   let diamond: ResolverProxy;
   let proceedRecipientsFacet: ProceedRecipientsKpiLinkedRateFacetTimeTravel;
   let accessControlFacet: AccessControl;
-  let bondKpiLinkedRateFacet: BondUSAKpiLinkedRateFacetTimeTravel;
+  let couponKpiLinkedRateFacet: CouponFacetTimeTravel;
   let scheduledTasksFacet: ScheduledCrossOrderedTasksKpiLinkedRateFacetTimeTravel;
   let timeTravelFacet: TimeTravelFacet;
 
@@ -52,8 +52,8 @@ describe("Proceed Recipients fixing Date Interest RateTests", () => {
       signer_A,
     );
     accessControlFacet = await ethers.getContractAt("AccessControlFacet", diamond.target, signer_A);
-    bondKpiLinkedRateFacet = await ethers.getContractAt(
-      "BondUSAKpiLinkedRateFacetTimeTravel",
+    couponKpiLinkedRateFacet = await ethers.getContractAt(
+      "CouponKpiLinkedRateFacetTimeTravel",
       diamond.target,
       signer_A,
     );
@@ -74,7 +74,7 @@ describe("Proceed Recipients fixing Date Interest RateTests", () => {
 
   describe("Add Tests", () => {
     it("GIVEN a unlisted proceed recipient WHEN authorized user adds it THEN it is listed and pending tasks triggered", async () => {
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
       const tasks_count_Before = await scheduledTasksFacet.scheduledCrossOrderedTaskCount();
 
       await timeTravelFacet.changeSystemTimestamp(couponData.fixingDate + 1);
@@ -92,7 +92,7 @@ describe("Proceed Recipients fixing Date Interest RateTests", () => {
     it("GIVEN a unlisted proceed recipient WHEN authorized user adds it THEN it is listed and pending tasks triggered", async () => {
       await proceedRecipientsFacet.addProceedRecipient(PROCEED_RECIPIENT_1, PROCEED_RECIPIENT_1_DATA);
 
-      await bondKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
+      await couponKpiLinkedRateFacet.connect(signer_A).setCoupon(couponData);
       const tasks_count_Before = await scheduledTasksFacet.scheduledCrossOrderedTaskCount();
 
       await timeTravelFacet.changeSystemTimestamp(couponData.fixingDate + 1);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/scheduledTasks/scheduledCouponListing/scheduledCouponListing.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/scheduledTasks/scheduledCouponListing/scheduledCouponListing.test.ts
@@ -3,12 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import {
-  type ResolverProxy,
-  ScheduledCouponListingFacet,
-  BondUSAKpiLinkedRateFacet,
-  AccessControl,
-} from "@contract-types";
+import { type ResolverProxy, ScheduledCouponListingFacet, CouponFacetTimeTravel, AccessControl } from "@contract-types";
 import { deployBondKpiLinkedRateTokenFixture, getDltTimestamp } from "@test";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { ATS_ROLES, TIME_PERIODS_S } from "@scripts";
@@ -18,7 +13,7 @@ describe("ScheduledCouponListing Tests", () => {
   let signer_A: HardhatEthersSigner;
 
   let scheduledCouponListingFacet: ScheduledCouponListingFacet;
-  let bondFacet: BondUSAKpiLinkedRateFacet;
+  let couponFacet: CouponFacetTimeTravel;
   let accessControlFacet: AccessControl;
 
   let startingDate = 0;
@@ -46,7 +41,7 @@ describe("ScheduledCouponListing Tests", () => {
     signer_A = base.deployer;
 
     scheduledCouponListingFacet = await ethers.getContractAt("ScheduledCouponListingFacet", diamond.target);
-    bondFacet = await ethers.getContractAt("BondUSAKpiLinkedRateFacetTimeTravel", diamond.target);
+    couponFacet = await ethers.getContractAt("CouponKpiLinkedRateFacetTimeTravel", diamond.target);
     accessControlFacet = await ethers.getContractAt("AccessControl", diamond.target);
 
     // Grant corporate action role to signer_A
@@ -69,7 +64,7 @@ describe("ScheduledCouponListing Tests", () => {
         const fixingDate = startingDate + TIME_PERIODS_S.MONTH * (i + 1);
         const executionDate = fixingDate + TIME_PERIODS_S.WEEK;
 
-        await bondFacet.setCoupon({
+        await couponFacet.setCoupon({
           recordDate: fixingDate.toString(),
           executionDate: executionDate.toString(),
           rate: 0,
@@ -93,7 +88,7 @@ describe("ScheduledCouponListing Tests", () => {
         const fixingDate = startingDate + TIME_PERIODS_S.MONTH * (i + 1);
         const executionDate = fixingDate + TIME_PERIODS_S.WEEK;
 
-        await bondFacet.setCoupon({
+        await couponFacet.setCoupon({
           recordDate: fixingDate.toString(),
           executionDate: executionDate.toString(),
           rate: 0,

--- a/packages/ats/contracts/test/contracts/integration/layer_2/nominalValue/nominalValueMigration.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/nominalValue/nominalValueMigration.test.ts
@@ -5,13 +5,8 @@ import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import { type ResolverProxy, type INominalValue, type NominalValueMigrationFacetTest } from "@contract-types";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { ATS_ROLES, BOND_CONFIG_ID, EQUITY_CONFIG_ID } from "@scripts";
+import { BOND_CONFIG_ID, EQUITY_CONFIG_ID } from "@scripts";
 import { deployBondTokenFixture, deployEquityTokenFixture } from "@test";
-
-async function grantNominalValueRole(diamond: ResolverProxy, admin: HardhatEthersSigner, account: string) {
-  const accessControl = await ethers.getContractAt("AccessControl", diamond.target, admin);
-  await accessControl.grantRole(ATS_ROLES._NOMINAL_VALUE_ROLE, account);
-}
 
 async function addMigrationFacetToDiamond(base: Awaited<ReturnType<typeof deployBondTokenFixture>>, configId: string) {
   const { blr, deployer, diamond: baseDiamond } = base;
@@ -47,9 +42,6 @@ async function addMigrationFacetToDiamond(base: Awaited<ReturnType<typeof deploy
 
   const newConfigVersion = Number(await blr.getLatestVersionByConfiguration(configId));
   await diamondFacet.connect(deployer).updateConfigVersion(newConfigVersion);
-
-  // Grant NOMINAL_VALUE_ROLE to deployer for testing
-  await grantNominalValueRole(baseDiamond, deployer, deployer.address);
 
   return base;
 }
@@ -293,7 +285,7 @@ describe("NominalValue Migration Tests", () => {
       // Reset initialized flag to simulate a legacy token
       await migrationFacet.resetNominalValueInitialized();
 
-      // setNominalValue should trigger _initializeNominalValue internally
+      // setNominalValue should trigger _initialize_NominalValue internally
       await nominalValueFacet.connect(signer_A).setNominalValue(600, 5);
 
       expect(await nominalValueFacet.getNominalValue()).to.equal(600);
@@ -345,8 +337,6 @@ describe("NominalValue Migration Tests", () => {
       signer_B = base.user1;
 
       nominalValueFacet = await ethers.getContractAt("INominalValue", diamond.target, signer_A);
-
-      await grantNominalValueRole(diamond, signer_A, signer_A.address);
     }
 
     beforeEach(async () => {

--- a/packages/ats/contracts/test/fixtures/tokens/bond.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/bond.fixture.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { deployAtsInfrastructureFixture } from "../infrastructure.fixture";
-import { CURRENCIES, DeepPartial, TIME_PERIODS_S, BOND_CONFIG_ID } from "../../../scripts";
+import { ATS_ROLES, CURRENCIES, DeepPartial, TIME_PERIODS_S, BOND_CONFIG_ID } from "../../../scripts";
 import {
   AccessControlFacet__factory,
   PauseFacet__factory,
@@ -97,6 +97,8 @@ export async function deployBondTokenFixture({
   const pauseFacet = PauseFacet__factory.connect(diamond.target as string, deployer);
   const kycFacet = KycFacet__factory.connect(diamond.target as string, deployer);
   const controlListFacet = ControlListFacet__factory.connect(diamond.target as string, deployer);
+
+  await accessControlFacet.grantRole(ATS_ROLES._NOMINAL_VALUE_ROLE, deployer.address);
 
   return {
     ...infrastructure,

--- a/packages/ats/contracts/test/fixtures/tokens/equity.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/equity.fixture.ts
@@ -10,7 +10,13 @@
  */
 
 import { deployAtsInfrastructureFixture } from "../infrastructure.fixture";
-import { deployEquityFromFactory, CURRENCIES, DeployEquityFromFactoryParams, DeepPartial } from "../../../scripts";
+import {
+  ATS_ROLES,
+  deployEquityFromFactory,
+  CURRENCIES,
+  DeployEquityFromFactoryParams,
+  DeepPartial,
+} from "../../../scripts";
 import {
   AccessControlFacet__factory,
   PauseFacet__factory,
@@ -95,6 +101,8 @@ export async function deployEquityTokenFixture({
   const pauseFacet = PauseFacet__factory.connect(diamond.target as string, deployer);
   const kycFacet = KycFacet__factory.connect(diamond.target as string, deployer);
   const controlListFacet = ControlListFacet__factory.connect(diamond.target as string, deployer);
+
+  await accessControlFacet.grantRole(ATS_ROLES._NOMINAL_VALUE_ROLE, deployer.address);
 
   return {
     ...infrastructure,

--- a/packages/ats/sdk/__tests__/fixtures/bond/BondFixture.ts
+++ b/packages/ats/sdk/__tests__/fixtures/bond/BondFixture.ts
@@ -26,6 +26,7 @@ import FullRedeemAtMaturityRequest from "@port/in/request/bond/FullRedeemAtMatur
 import GetAllCouponsRequest from "@port/in/request/bond/GetAllCouponsRequest";
 import GetBondDetailsRequest from "@port/in/request/bond/GetBondDetailsRequest";
 import GetCouponForRequest from "@port/in/request/bond/GetCouponForRequest";
+import GetCouponsForRequest from "@port/in/request/bond/GetCouponsForRequest";
 import GetCouponHoldersRequest from "@port/in/request/bond/GetCouponHoldersRequest";
 import GetCouponRequest from "@port/in/request/bond/GetCouponRequest";
 import GetCouponsOrderedListRequest from "@port/in/request/bond/GetCouponsOrderedListRequest";
@@ -42,6 +43,7 @@ import { GetCouponQuery } from "@query/bond/coupons/getCoupon/GetCouponQuery";
 import { GetCouponAmountForQuery } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQuery";
 import { GetCouponCountQuery } from "@query/bond/coupons/getCouponCount/GetCouponCountQuery";
 import { GetCouponForQuery } from "@query/bond/coupons/getCouponFor/GetCouponForQuery";
+import { GetCouponsForQuery } from "@query/bond/coupons/getCouponsFor/GetCouponsForQuery";
 import { GetCouponFromOrderedListAtQuery } from "@query/bond/coupons/getCouponFromOrderedListAt/GetCouponFromOrderedListAtQuery";
 import { GetCouponHoldersQuery } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQuery";
 import { GetTotalCouponHoldersQuery } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQuery";
@@ -165,6 +167,13 @@ export const GetCouponForQueryFixture = createFixture<GetCouponForQuery>((query)
   query.securityId.as(() => HederaIdPropsFixture.create().value);
   query.targetId.as(() => HederaIdPropsFixture.create().value);
   query.couponId.faker((faker) => faker.number.int({ min: 1, max: 999 }));
+});
+
+export const GetCouponsForQueryFixture = createFixture<GetCouponsForQuery>((query) => {
+  query.securityId.as(() => HederaIdPropsFixture.create().value);
+  query.couponId.faker((faker) => faker.number.int({ min: 1, max: 999 }));
+  query.pageIndex.faker((faker) => faker.number.int({ min: 0, max: 10 }));
+  query.pageLength.faker((faker) => faker.number.int({ min: 1, max: 50 }));
 });
 
 export const GetCouponAmountForQueryFixture = createFixture<GetCouponAmountForQuery>((query) => {
@@ -311,6 +320,13 @@ export const GetCouponForRequestFixture = createFixture<GetCouponForRequest>((re
   request.securityId.as(() => HederaIdPropsFixture.create().value);
   request.targetId.as(() => HederaIdPropsFixture.create().value);
   request.couponId.faker((faker) => faker.number.int({ min: 1, max: 10 }));
+});
+
+export const GetCouponsForRequestFixture = createFixture<GetCouponsForRequest>((request) => {
+  request.securityId.as(() => HederaIdPropsFixture.create().value);
+  request.couponId.faker((faker) => faker.number.int({ min: 1, max: 10 }));
+  request.pageIndex.faker((faker) => faker.number.int({ min: 0, max: 10 }));
+  request.pageLength.faker((faker) => faker.number.int({ min: 1, max: 50 }));
 });
 
 export const GetPrincipalForRequestFixture = createFixture<GetPrincipalForRequest>((request) => {

--- a/packages/ats/sdk/__tests__/port/environmentMock.ts
+++ b/packages/ats/sdk/__tests__/port/environmentMock.ts
@@ -39,6 +39,8 @@ import {
 } from "@domain/context/security/Clearing";
 import { HoldDetails } from "@domain/context/security/Hold";
 import { RateStatus } from "@domain/context/bond/RateStatus";
+import { CouponFor } from "@domain/context/bond/CouponFor";
+import { CouponAmountFor } from "@domain/context/bond/CouponAmountFor";
 
 //* Mock console.log() method
 global.console.log = jest.fn();
@@ -610,12 +612,19 @@ jest.mock("@port/out/rpc/RPCQueryAdapter", () => {
 
   singletonInstance.getCouponFor = jest.fn(async (address: EvmAddress, target: EvmAddress, coupon: number) => {
     const couponsBalances = couponsFor.get(coupon);
+    const balanceStr = couponsBalances
+      ? (couponsBalances.get("0x" + target.toString().toUpperCase().substring(2)) ?? "0")
+      : "0";
 
-    if (!couponsBalances) return BigDecimal.fromString("0", securityInfo.decimals);
-
-    const balance = couponsBalances.get("0x" + target.toString().toUpperCase().substring(2));
-    if (balance) return BigDecimal.fromString(balance, securityInfo.decimals);
-    return BigDecimal.fromString("0", securityInfo.decimals);
+    return new CouponFor(
+      BigDecimal.fromString(balanceStr, securityInfo.decimals),
+      BigDecimal.fromString("0", 0),
+      securityInfo.decimals,
+      false,
+      coupons[coupon - 1],
+      new CouponAmountFor("5", "3", true),
+      false,
+    );
   });
 
   singletonInstance.getCouponAmountFor = jest.fn(async (address: EvmAddress, target: EvmAddress, coupon: number) => {
@@ -666,6 +675,12 @@ jest.mock("@port/out/rpc/RPCQueryAdapter", () => {
     }
     return pos + 1;
   });
+
+  singletonInstance.getCouponsFor = jest.fn(
+    async (address: EvmAddress, couponId: number, pageIndex: number, pageLength: number) => {
+      return { coupons: [], accounts: [] };
+    },
+  );
 
   singletonInstance.getAccountSecurityRelationship = jest.fn(async (address: EvmAddress, target: EvmAddress) => {});
 

--- a/packages/ats/sdk/__tests__/port/in/Bond.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Bond.test.ts
@@ -6,23 +6,15 @@ import {
   LoggerTransports,
   CreateBondRequest,
   GetBondDetailsRequest,
-  GetCouponRequest,
-  GetAllCouponsRequest,
-  GetCouponsOrderedListRequest,
-  GetCouponsOrderedListTotalRequest,
-  GetCouponFromOrderedListAtRequest,
   SupportedWallets,
   Network,
   Bond,
-  GetCouponForRequest,
   Role,
   RoleRequest,
-  SetCouponRequest,
   UpdateMaturityDateRequest,
   AddKpiDataRequest,
 } from "@port/in";
 import { CLIENT_ACCOUNT_ECDSA, FACTORY_ADDRESS, RESOLVER_ADDRESS } from "@test/config";
-import { TIME_PERIODS_S } from "@core/Constants";
 import ConnectRequest from "@port/in/request/network/ConnectRequest";
 import { MirrorNode } from "@domain/context/network/MirrorNode";
 import { JsonRpcRelay } from "@domain/context/network/JsonRpcRelay";
@@ -41,7 +33,6 @@ import { MirrorNodeAdapter } from "@port/out/mirror/MirrorNodeAdapter";
 import { RPCTransactionAdapter } from "@port/out/rpc/RPCTransactionAdapter";
 import { Wallet, ethers } from "ethers";
 import BaseError from "@core/error/BaseError";
-import { CastRateStatus, RateStatus } from "@domain/context/bond/RateStatus";
 
 SDK.log = { level: "ERROR", transports: new LoggerTransports.Console() };
 
@@ -169,107 +160,6 @@ describe("🧪 Bond test", () => {
     expect(bondDetails.maturityDate.getTime() / 1000).toEqual(maturityDate);
   }, 60_000);
 
-  it("Coupons Fixed", async () => {
-    // Manually create a coupon since automatic creation was removed
-    const couponRate = "3";
-    const couponRecordDate = startingDate + 30;
-    const couponExecutionDate = startingDate + 35;
-    const couponFixingDate = startingDate + 25;
-
-    await Bond.setCoupon(
-      new SetCouponRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        rate: couponRate,
-        recordTimestamp: couponRecordDate.toString(),
-        executionTimestamp: couponExecutionDate.toString(),
-        startTimestamp: "0",
-        endTimestamp: TIME_PERIODS_S.DAY.toString(),
-        fixingTimestamp: couponFixingDate.toString(),
-        rateStatus: CastRateStatus.toNumber(RateStatus.SET),
-      }),
-    );
-
-    const coupon = await Bond.getCoupon(
-      new GetCouponRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        couponId: 1,
-      }),
-    );
-
-    const allCoupon = await Bond.getAllCoupons(
-      new GetAllCouponsRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-      }),
-    );
-
-    const couponFor = await Bond.getCouponFor(
-      new GetCouponForRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
-        couponId: 1,
-      }),
-    );
-
-    const couponAmountFor = await Bond.getCouponAmountFor(
-      new GetCouponForRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
-        couponId: 1,
-      }),
-    );
-
-    expect(coupon.rate).toEqual(couponRate);
-    expect(coupon.rateDecimals).toEqual(0);
-    expect(coupon.couponId).toEqual(1);
-    expect(coupon.recordDate.getTime() / 1000).toEqual(couponRecordDate);
-    expect(coupon.executionDate.getTime() / 1000).toEqual(couponExecutionDate);
-    expect(couponFor.tokenBalance).toEqual("0");
-    expect(couponFor.decimals).toEqual("0");
-    expect(allCoupon.length).toEqual(1); // Now only 1 manually created coupon
-    expect(couponAmountFor.numerator).toEqual("5");
-    expect(couponAmountFor.denominator).toEqual("3");
-    expect(couponAmountFor.recordDateReached).toEqual(true);
-  }, 600_000);
-
-  it("Coupons Custom", async () => {
-    await Role.grantRole(
-      new RoleRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
-        role: SecurityRole._CORPORATEACTIONS_ROLE,
-      }),
-    );
-
-    const rate = "1";
-    const recordTimestamp = Math.ceil(new Date().getTime() / 1000) + 1000;
-    const executionTimestamp = recordTimestamp + 1000;
-    const couponFixingDate = recordTimestamp - 1000;
-
-    await Bond.setCoupon(
-      new SetCouponRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        rate: rate,
-        recordTimestamp: recordTimestamp.toString(),
-        executionTimestamp: executionTimestamp.toString(),
-        startTimestamp: "0",
-        endTimestamp: TIME_PERIODS_S.DAY.toString(),
-        fixingTimestamp: couponFixingDate.toString(),
-        rateStatus: CastRateStatus.toNumber(RateStatus.PENDING),
-      }),
-    );
-
-    const coupon = await Bond.getCoupon(
-      new GetCouponRequest({
-        securityId: bond.evmDiamondAddress!.toString(),
-        couponId: 2, // Second coupon (first one was created in 'Coupons Fixed' test)
-      }),
-    );
-
-    expect(coupon.couponId).toEqual(2);
-    expect(coupon.recordDate.getTime() / 1000).toEqual(recordTimestamp);
-    expect(coupon.executionDate.getTime() / 1000).toEqual(executionTimestamp);
-  }, 600_000);
-
   it("Update bond maturity date correctly", async () => {
     const newMaturityDate = maturityDate + 10;
     const request = new UpdateMaturityDateRequest({
@@ -302,76 +192,6 @@ describe("🧪 Bond test", () => {
       thrownError = error;
     }
     expect(thrownError).toBeInstanceOf(BaseError);
-  }, 600_000);
-
-  it("Get coupons ordered list correctly", async () => {
-    const request = new GetCouponsOrderedListRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-      pageIndex: 0,
-      pageLength: 10,
-    });
-
-    const result = await Bond.getCouponsOrderedList(request);
-
-    expect(Array.isArray(result)).toBe(true);
-    result.forEach((couponId) => {
-      expect(typeof couponId).toBe("number");
-      expect(couponId).toBeGreaterThan(0);
-    });
-  }, 600_000);
-
-  it("Get coupons ordered list with pagination", async () => {
-    const request1 = new GetCouponsOrderedListRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-      pageIndex: 0,
-      pageLength: 5,
-    });
-
-    const result1 = await Bond.getCouponsOrderedList(request1);
-    expect(Array.isArray(result1)).toBe(true);
-
-    const request2 = new GetCouponsOrderedListRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-      pageIndex: 1,
-      pageLength: 5,
-    });
-
-    const result2 = await Bond.getCouponsOrderedList(request2);
-    expect(Array.isArray(result2)).toBe(true);
-  }, 600_000);
-
-  it("Get coupons ordered list with empty page", async () => {
-    const request = new GetCouponsOrderedListRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-      pageIndex: 100,
-      pageLength: 10,
-    });
-
-    const result = await Bond.getCouponsOrderedList(request);
-    expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBe(0);
-  }, 600_000);
-
-  it("Get coupon from ordered list at", async () => {
-    const request = new GetCouponFromOrderedListAtRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-      pos: 0,
-    });
-
-    const result = await Bond.getCouponFromOrderedListAt(request);
-    expect(typeof result).toBe("number");
-    expect(result).toBe(1);
-  }, 600_000);
-
-  it("Get coupons ordered list total", async () => {
-    const request = new GetCouponsOrderedListTotalRequest({
-      securityId: bond.evmDiamondAddress!.toString(),
-    });
-
-    const result = await Bond.getCouponsOrderedListTotal(request);
-
-    expect(typeof result).toBe("number");
-    expect(result).toBeGreaterThanOrEqual(0);
   }, 600_000);
 
   it("addKpiData", async () => {

--- a/packages/ats/sdk/__tests__/port/in/Coupon.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Coupon.test.ts
@@ -1,0 +1,339 @@
+//SPDX-License-Identifier: Apache-2.0
+
+import "../environmentMock";
+import {
+  SDK,
+  LoggerTransports,
+  CreateBondRequest,
+  GetCouponRequest,
+  GetAllCouponsRequest,
+  GetCouponsOrderedListRequest,
+  GetCouponsOrderedListTotalRequest,
+  GetCouponFromOrderedListAtRequest,
+  SupportedWallets,
+  Network,
+  Bond,
+  Coupon,
+  GetCouponForRequest,
+  GetCouponsForRequest,
+  Role,
+  RoleRequest,
+  SetCouponRequest,
+} from "@port/in";
+import { CLIENT_ACCOUNT_ECDSA, FACTORY_ADDRESS, RESOLVER_ADDRESS } from "@test/config";
+import { TIME_PERIODS_S } from "@core/Constants";
+import ConnectRequest from "@port/in/request/network/ConnectRequest";
+import { MirrorNode } from "@domain/context/network/MirrorNode";
+import { JsonRpcRelay } from "@domain/context/network/JsonRpcRelay";
+import NetworkService from "@service/network/NetworkService";
+import SecurityViewModel from "@port/in/response/SecurityViewModel";
+import Injectable from "@core/injectable/Injectable";
+import { SecurityRole } from "@domain/context/security/SecurityRole";
+import {
+  CastRegulationSubType,
+  CastRegulationType,
+  RegulationSubType,
+  RegulationType,
+} from "@domain/context/factory/RegulationType";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import { MirrorNodeAdapter } from "@port/out/mirror/MirrorNodeAdapter";
+import { RPCTransactionAdapter } from "@port/out/rpc/RPCTransactionAdapter";
+import { Wallet, ethers } from "ethers";
+import { CastRateStatus, RateStatus } from "@domain/context/bond/RateStatus";
+
+SDK.log = { level: "ERROR", transports: new LoggerTransports.Console() };
+
+const decimals = 0;
+const name = "TEST_SECURITY_TOKEN";
+const symbol = "TEST";
+const isin = "ABCDE123456Z";
+const currency = "0x455552";
+const TIME = 30;
+const numberOfUnits = "1000";
+const nominalValue = "100";
+const nominalValueDecimals = 3;
+const currentTimeInSeconds = Math.floor(new Date().getTime() / 1000) + 1000;
+const startingDate = currentTimeInSeconds + TIME;
+const maturityDate = startingDate + 365; // 1 year maturity
+const regulationType = RegulationType.REG_S;
+const regulationSubType = RegulationSubType.NONE;
+const countries = "AF,HG,BN";
+const info = "Anything";
+const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
+const configVersion = 0;
+
+const mirrorNode: MirrorNode = {
+  name: "testmirrorNode",
+  baseUrl: "https://testnet.mirrornode.hedera.com/api/v1/",
+};
+
+const rpcNode: JsonRpcRelay = {
+  name: "testrpcNode",
+  baseUrl: "http://127.0.0.1:7546/api",
+};
+
+describe("🧪 Coupon test", () => {
+  let th: RPCTransactionAdapter;
+  let ns: NetworkService;
+  let mirrorNodeAdapter: MirrorNodeAdapter;
+  let rpcQueryAdapter: RPCQueryAdapter;
+  let bond: SecurityViewModel;
+
+  beforeAll(async () => {
+    mirrorNodeAdapter = Injectable.resolve(MirrorNodeAdapter);
+    mirrorNodeAdapter.set(mirrorNode);
+
+    th = Injectable.resolve(RPCTransactionAdapter);
+    ns = Injectable.resolve(NetworkService);
+    rpcQueryAdapter = Injectable.resolve(RPCQueryAdapter);
+
+    rpcQueryAdapter.init();
+    ns.environment = "testnet";
+    ns.configuration = {
+      factoryAddress: FACTORY_ADDRESS,
+      resolverAddress: RESOLVER_ADDRESS,
+    };
+    ns.mirrorNode = mirrorNode;
+    ns.rpcNode = rpcNode;
+
+    await th.init(true);
+
+    const url = "http://127.0.0.1:7546";
+    const customHttpProvider = new ethers.JsonRpcProvider(url);
+
+    th.setSignerOrProvider(new Wallet(CLIENT_ACCOUNT_ECDSA.privateKey?.key ?? "", customHttpProvider));
+
+    await Network.connect(
+      new ConnectRequest({
+        account: {
+          accountId: CLIENT_ACCOUNT_ECDSA.id.toString(),
+          privateKey: CLIENT_ACCOUNT_ECDSA.privateKey,
+        },
+        network: "testnet",
+        wallet: SupportedWallets.METAMASK,
+        mirrorNode: mirrorNode,
+        rpcNode: rpcNode,
+        debug: true,
+      }),
+    );
+
+    const requestST = new CreateBondRequest({
+      name: name,
+      symbol: symbol,
+      isin: isin,
+      decimals: decimals,
+      isWhiteList: false,
+      erc20VotesActivated: false,
+      isControllable: true,
+      arePartitionsProtected: false,
+      clearingActive: false,
+      internalKycActivated: true,
+      isMultiPartition: false,
+      diamondOwnerAccount: CLIENT_ACCOUNT_ECDSA.id.toString(),
+      currency: currency,
+      numberOfUnits: numberOfUnits.toString(),
+      nominalValue: nominalValue,
+      nominalValueDecimals: nominalValueDecimals,
+      startingDate: startingDate.toString(),
+      maturityDate: maturityDate.toString(),
+      regulationType: CastRegulationType.toNumber(regulationType),
+      regulationSubType: CastRegulationSubType.toNumber(regulationSubType),
+      isCountryControlListWhiteList: true,
+      countries: countries,
+      info: info,
+      configId: configId,
+      configVersion: configVersion,
+    });
+
+    Injectable.resolveTransactionHandler();
+
+    bond = (await Bond.create(requestST)).security;
+
+    console.log("bond: " + JSON.stringify(bond));
+  }, 600_000);
+
+  it("Coupons Fixed", async () => {
+    // Manually create a coupon since automatic creation was removed
+    const couponRate = "3";
+    const couponRecordDate = startingDate + 30;
+    const couponExecutionDate = startingDate + 35;
+    const couponFixingDate = startingDate + 25;
+
+    await Coupon.setCoupon(
+      new SetCouponRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        rate: couponRate,
+        recordTimestamp: couponRecordDate.toString(),
+        executionTimestamp: couponExecutionDate.toString(),
+        startTimestamp: "0",
+        endTimestamp: TIME_PERIODS_S.DAY.toString(),
+        fixingTimestamp: couponFixingDate.toString(),
+        rateStatus: CastRateStatus.toNumber(RateStatus.SET),
+      }),
+    );
+
+    const coupon = await Coupon.getCoupon(
+      new GetCouponRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        couponId: 1,
+      }),
+    );
+
+    const allCoupon = await Coupon.getAllCoupons(
+      new GetAllCouponsRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+      }),
+    );
+
+    const couponFor = await Coupon.getCouponFor(
+      new GetCouponForRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        couponId: 1,
+      }),
+    );
+
+    const couponAmountFor = await Coupon.getCouponAmountFor(
+      new GetCouponForRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        couponId: 1,
+      }),
+    );
+
+    expect(coupon.rate).toEqual(couponRate);
+    expect(coupon.rateDecimals).toEqual(0);
+    expect(coupon.couponId).toEqual(1);
+    expect(coupon.recordDate.getTime() / 1000).toEqual(couponRecordDate);
+    expect(coupon.executionDate.getTime() / 1000).toEqual(couponExecutionDate);
+    expect(couponFor.tokenBalance).toEqual("0");
+    expect(couponFor.decimals).toEqual("0");
+    expect(allCoupon.length).toEqual(1); // Now only 1 manually created coupon
+    expect(couponAmountFor.numerator).toEqual("5");
+    expect(couponAmountFor.denominator).toEqual("3");
+    expect(couponAmountFor.recordDateReached).toEqual(true);
+  }, 600_000);
+
+  it("Coupons Custom", async () => {
+    await Role.grantRole(
+      new RoleRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        targetId: CLIENT_ACCOUNT_ECDSA.evmAddress!.toString(),
+        role: SecurityRole._CORPORATEACTIONS_ROLE,
+      }),
+    );
+
+    const rate = "1";
+    const recordTimestamp = Math.ceil(new Date().getTime() / 1000) + 1000;
+    const executionTimestamp = recordTimestamp + 1000;
+    const couponFixingDate = recordTimestamp - 1000;
+
+    await Coupon.setCoupon(
+      new SetCouponRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        rate: rate,
+        recordTimestamp: recordTimestamp.toString(),
+        executionTimestamp: executionTimestamp.toString(),
+        startTimestamp: "0",
+        endTimestamp: TIME_PERIODS_S.DAY.toString(),
+        fixingTimestamp: couponFixingDate.toString(),
+        rateStatus: CastRateStatus.toNumber(RateStatus.PENDING),
+      }),
+    );
+
+    const coupon = await Coupon.getCoupon(
+      new GetCouponRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        couponId: 2, // Second coupon (first one was created in 'Coupons Fixed' test)
+      }),
+    );
+
+    expect(coupon.couponId).toEqual(2);
+    expect(coupon.recordDate.getTime() / 1000).toEqual(recordTimestamp);
+    expect(coupon.executionDate.getTime() / 1000).toEqual(executionTimestamp);
+  }, 600_000);
+
+  it("Get coupons ordered list correctly", async () => {
+    const request = new GetCouponsOrderedListRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+      pageIndex: 0,
+      pageLength: 10,
+    });
+
+    const result = await Coupon.getCouponsOrderedList(request);
+
+    expect(Array.isArray(result)).toBe(true);
+    result.forEach((couponId) => {
+      expect(typeof couponId).toBe("number");
+      expect(couponId).toBeGreaterThan(0);
+    });
+  }, 600_000);
+
+  it("Get coupons ordered list with pagination", async () => {
+    const request1 = new GetCouponsOrderedListRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+      pageIndex: 0,
+      pageLength: 5,
+    });
+
+    const result1 = await Coupon.getCouponsOrderedList(request1);
+    expect(Array.isArray(result1)).toBe(true);
+
+    const request2 = new GetCouponsOrderedListRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+      pageIndex: 1,
+      pageLength: 5,
+    });
+
+    const result2 = await Coupon.getCouponsOrderedList(request2);
+    expect(Array.isArray(result2)).toBe(true);
+  }, 600_000);
+
+  it("Get coupons ordered list with empty page", async () => {
+    const request = new GetCouponsOrderedListRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+      pageIndex: 100,
+      pageLength: 10,
+    });
+
+    const result = await Coupon.getCouponsOrderedList(request);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
+  }, 600_000);
+
+  it("Get coupon from ordered list at", async () => {
+    const request = new GetCouponFromOrderedListAtRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+      pos: 0,
+    });
+
+    const result = await Coupon.getCouponFromOrderedListAt(request);
+    expect(typeof result).toBe("number");
+    expect(result).toBe(1);
+  }, 600_000);
+
+  it("Get coupons ordered list total", async () => {
+    const request = new GetCouponsOrderedListTotalRequest({
+      securityId: bond.evmDiamondAddress!.toString(),
+    });
+
+    const result = await Coupon.getCouponsOrderedListTotal(request);
+
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThanOrEqual(0);
+  }, 600_000);
+
+  it("Get coupons for account with pagination", async () => {
+    const result = await Coupon.getCouponsFor(
+      new GetCouponsForRequest({
+        securityId: bond.evmDiamondAddress!.toString(),
+        couponId: 1,
+        pageIndex: 0,
+        pageLength: 10,
+      }),
+    );
+
+    expect(Array.isArray(result.coupons)).toBe(true);
+    expect(Array.isArray(result.accounts)).toBe(true);
+  }, 600_000);
+});

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQuery.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQuery.ts
@@ -2,14 +2,10 @@
 
 import { Query } from "@core/query/Query";
 import { QueryResponse } from "@core/query/QueryResponse";
-import BigDecimal from "@domain/context/shared/BigDecimal";
+import { CouponFor } from "@domain/context/bond/CouponFor";
 
 export class GetCouponForQueryResponse implements QueryResponse {
-  constructor(
-    public readonly tokenBalance: BigDecimal,
-    public readonly decimals: number,
-    public readonly isDisabled: boolean,
-  ) {}
+  constructor(public readonly couponFor: CouponFor) {}
 }
 
 export class GetCouponForQuery extends Query<GetCouponForQueryResponse> {

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQueryHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQueryHandler.ts
@@ -30,7 +30,7 @@ export class GetCouponForQueryHandler implements IQueryHandler<GetCouponForQuery
 
       const res = await this.queryAdapter.getCouponFor(securityEvmAddress, targetEvmAddress, couponId);
 
-      return new GetCouponForQueryResponse(res.tokenBalance || "0", res.decimals, res.isDisabled);
+      return new GetCouponForQueryResponse(res);
     } catch (error) {
       throw new GetCouponForQueryError(error as Error);
     }

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQueryHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponFor/GetCouponForQueryHandler.unit.test.ts
@@ -6,11 +6,12 @@ import { ErrorCode } from "@core/error/BaseError";
 import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
 import ContractService from "@service/contract/ContractService";
 import EvmAddress from "@domain/context/contract/EvmAddress";
-import { GetCouponForQueryFixture } from "@test/fixtures/bond/BondFixture";
+import { CouponFixture, GetCouponForQueryFixture } from "@test/fixtures/bond/BondFixture";
 import { GetCouponForQueryError } from "./error/GetCouponForQueryError";
 import { GetCouponForQueryHandler } from "./GetCouponForQueryHandler";
 import AccountService from "@service/account/AccountService";
 import BigDecimal from "@domain/context/shared/BigDecimal";
+import { CouponAmountFor } from "@domain/context/bond/CouponAmountFor";
 import { GetCouponForQuery, GetCouponForQueryResponse } from "./GetCouponForQuery";
 
 describe("GetCouponForQueryHandler", () => {
@@ -26,7 +27,10 @@ describe("GetCouponForQueryHandler", () => {
 
   const errorMsg = ErrorMsgFixture.create().msg;
   const amount = new BigDecimal("1000000");
+  const nominalValue = new BigDecimal("500");
   const decimals = 6;
+  const coupon = CouponFixture.create();
+  const couponAmount = new CouponAmountFor("10", "4", true);
 
   beforeEach(() => {
     handler = new GetCouponForQueryHandler(queryAdapterServiceMock, accountServiceMock, contractServiceMock);
@@ -57,16 +61,24 @@ describe("GetCouponForQueryHandler", () => {
       accountServiceMock.getAccountEvmAddress.mockResolvedValueOnce(targetEvmAddress);
       queryAdapterServiceMock.getCouponFor.mockResolvedValue({
         tokenBalance: amount,
+        nominalValue: nominalValue,
         decimals: decimals,
+        recordDateReached: false,
+        coupon: coupon,
+        couponAmount: couponAmount,
         isDisabled: false,
       });
 
       const result = await handler.execute(query);
 
       expect(result).toBeInstanceOf(GetCouponForQueryResponse);
-      expect(result.tokenBalance).toStrictEqual(amount);
-      expect(result.decimals).toStrictEqual(decimals);
-      expect(result.isDisabled).toBe(false);
+      expect(result.couponFor.tokenBalance).toStrictEqual(amount);
+      expect(result.couponFor.nominalValue).toStrictEqual(nominalValue);
+      expect(result.couponFor.decimals).toStrictEqual(decimals);
+      expect(result.couponFor.recordDateReached).toBe(false);
+      expect(result.couponFor.coupon).toStrictEqual(coupon);
+      expect(result.couponFor.couponAmount).toStrictEqual(couponAmount);
+      expect(result.couponFor.isDisabled).toBe(false);
       expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledTimes(1);
       expect(accountServiceMock.getAccountEvmAddress).toHaveBeenCalledTimes(1);
       expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(query.securityId);

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQuery.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQuery.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Query } from "@core/query/Query";
+import { QueryResponse } from "@core/query/QueryResponse";
+import { CouponFor } from "@domain/context/bond/CouponFor";
+
+export class GetCouponsForQueryResponse implements QueryResponse {
+  constructor(
+    public readonly coupons: CouponFor[],
+    public readonly accounts: string[],
+  ) {}
+}
+
+export class GetCouponsForQuery extends Query<GetCouponsForQueryResponse> {
+  constructor(
+    public readonly securityId: string,
+    public readonly couponId: number,
+    public readonly pageIndex: number,
+    public readonly pageLength: number,
+  ) {
+    super();
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQueryHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQueryHandler.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { IQueryHandler } from "@core/query/QueryHandler";
+import { QueryHandler } from "@core/decorator/QueryHandlerDecorator";
+import { lazyInject } from "@core/decorator/LazyInjectDecorator";
+import { GetCouponsForQuery, GetCouponsForQueryResponse } from "./GetCouponsForQuery";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import ContractService from "@service/contract/ContractService";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import { GetCouponsForQueryError } from "./error/GetCouponsForQueryError";
+
+@QueryHandler(GetCouponsForQuery)
+export class GetCouponsForQueryHandler implements IQueryHandler<GetCouponsForQuery> {
+  constructor(
+    @lazyInject(RPCQueryAdapter)
+    private readonly queryAdapter: RPCQueryAdapter,
+    @lazyInject(ContractService)
+    private readonly contractService: ContractService,
+  ) {}
+
+  async execute(query: GetCouponsForQuery): Promise<GetCouponsForQueryResponse> {
+    try {
+      const { securityId, couponId, pageIndex, pageLength } = query;
+
+      const securityEvmAddress: EvmAddress = await this.contractService.getContractEvmAddress(securityId);
+
+      const res = await this.queryAdapter.getCouponsFor(securityEvmAddress, couponId, pageIndex, pageLength);
+
+      return new GetCouponsForQueryResponse(res.coupons, res.accounts);
+    } catch (error) {
+      throw new GetCouponsForQueryError(error as Error);
+    }
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQueryHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/GetCouponsForQueryHandler.unit.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMock } from "@golevelup/ts-jest";
+import { ErrorMsgFixture, EvmAddressPropsFixture } from "@test/fixtures/shared/DataFixture";
+import { ErrorCode } from "@core/error/BaseError";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import ContractService from "@service/contract/ContractService";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import { CouponFixture, GetCouponsForQueryFixture } from "@test/fixtures/bond/BondFixture";
+import { GetCouponsForQueryError } from "./error/GetCouponsForQueryError";
+import { GetCouponsForQueryHandler } from "./GetCouponsForQueryHandler";
+import BigDecimal from "@domain/context/shared/BigDecimal";
+import { CouponAmountFor } from "@domain/context/bond/CouponAmountFor";
+import { CouponFor } from "@domain/context/bond/CouponFor";
+import { GetCouponsForQuery, GetCouponsForQueryResponse } from "./GetCouponsForQuery";
+
+describe("GetCouponsForQueryHandler", () => {
+  let handler: GetCouponsForQueryHandler;
+  let query: GetCouponsForQuery;
+
+  const queryAdapterServiceMock = createMock<RPCQueryAdapter>();
+  const contractServiceMock = createMock<ContractService>();
+
+  const evmAddress = new EvmAddress(EvmAddressPropsFixture.create().value);
+  const errorMsg = ErrorMsgFixture.create().msg;
+  const amount = new BigDecimal("1000000");
+  const nominalValue = new BigDecimal("500");
+  const decimals = 6;
+  const coupon = CouponFixture.create();
+  const couponAmount = new CouponAmountFor("10", "4", true);
+  const accounts = ["0x1234567890abcdef1234567890abcdef12345678"];
+
+  beforeEach(() => {
+    handler = new GetCouponsForQueryHandler(queryAdapterServiceMock, contractServiceMock);
+    query = GetCouponsForQueryFixture.create();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("execute", () => {
+    it("throws GetCouponsForQueryError when query fails with uncaught error", async () => {
+      const fakeError = new Error(errorMsg);
+      contractServiceMock.getContractEvmAddress.mockRejectedValue(fakeError);
+
+      const resultPromise = handler.execute(query);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(GetCouponsForQueryError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(`An error occurred while querying coupons for: ${errorMsg}`),
+        errorCode: ErrorCode.UncaughtQueryError,
+      });
+    });
+
+    it("should successfully get coupons for", async () => {
+      const couponForDomain = new CouponFor(amount, nominalValue, decimals, true, coupon, couponAmount, false);
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(evmAddress);
+      queryAdapterServiceMock.getCouponsFor.mockResolvedValue({
+        coupons: [couponForDomain],
+        accounts,
+      });
+
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(GetCouponsForQueryResponse);
+      expect(result.coupons).toHaveLength(1);
+      expect(result.coupons[0]).toStrictEqual(couponForDomain);
+      expect(result.accounts).toStrictEqual(accounts);
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledTimes(1);
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(query.securityId);
+      expect(queryAdapterServiceMock.getCouponsFor).toHaveBeenCalledWith(
+        evmAddress,
+        query.couponId,
+        query.pageIndex,
+        query.pageLength,
+      );
+    });
+  });
+});

--- a/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/error/GetCouponsForQueryError.ts
+++ b/packages/ats/sdk/src/app/usecase/query/bond/coupons/getCouponsFor/error/GetCouponsForQueryError.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { QueryError } from "@query/error/QueryError";
+import BaseError from "@core/error/BaseError";
+
+export class GetCouponsForQueryError extends QueryError {
+  constructor(error: Error) {
+    const msg = `An error occurred while querying coupons for: ${error.message}`;
+    super(msg, error instanceof BaseError ? error.errorCode : undefined);
+  }
+}

--- a/packages/ats/sdk/src/core/injectable/bond/InjectableBond.ts
+++ b/packages/ats/sdk/src/core/injectable/bond/InjectableBond.ts
@@ -15,6 +15,7 @@ import { GetCouponQueryHandler } from "@query/bond/coupons/getCoupon/GetCouponQu
 import { GetCouponAmountForQueryHandler } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQueryHandler";
 import { GetCouponCountQueryHandler } from "@query/bond/coupons/getCouponCount/GetCouponCountQueryHandler";
 import { GetCouponForQueryHandler } from "@query/bond/coupons/getCouponFor/GetCouponForQueryHandler";
+import { GetCouponsForQueryHandler } from "@query/bond/coupons/getCouponsFor/GetCouponsForQueryHandler";
 import { GetCouponHoldersQueryHandler } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQueryHandler";
 import { GetTotalCouponHoldersQueryHandler } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQueryHandler";
 import { GetCouponsOrderedListQueryHandler } from "@query/bond/coupons/getCouponsOrderedList/GetCouponsOrderedListQueryHandler";
@@ -83,6 +84,10 @@ export const QUERY_HANDLERS_BOND = [
   {
     token: TOKENS.QUERY_HANDLER,
     useClass: GetCouponForQueryHandler,
+  },
+  {
+    token: TOKENS.QUERY_HANDLER,
+    useClass: GetCouponsForQueryHandler,
   },
   {
     token: TOKENS.QUERY_HANDLER,

--- a/packages/ats/sdk/src/domain/context/bond/CouponFor.ts
+++ b/packages/ats/sdk/src/domain/context/bond/CouponFor.ts
@@ -1,14 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BigDecimal from "../shared/BigDecimal";
+import { Coupon } from "./Coupon";
+import { CouponAmountFor } from "./CouponAmountFor";
 
 export class CouponFor {
   tokenBalance: BigDecimal;
+  nominalValue: BigDecimal;
   decimals: number;
+  recordDateReached: boolean;
+  coupon: Coupon;
+  couponAmount: CouponAmountFor;
   isDisabled: boolean;
-  constructor(tokenBalance: BigDecimal, decimals: number, isDisabled: boolean = false) {
+
+  constructor(
+    tokenBalance: BigDecimal,
+    nominalValue: BigDecimal,
+    decimals: number,
+    recordDateReached: boolean,
+    coupon: Coupon,
+    couponAmount: CouponAmountFor,
+    isDisabled: boolean = false,
+  ) {
     this.tokenBalance = tokenBalance;
+    this.nominalValue = nominalValue;
     this.decimals = decimals;
+    this.recordDateReached = recordDateReached;
+    this.coupon = coupon;
+    this.couponAmount = couponAmount;
     this.isDisabled = isDisabled;
   }
 }

--- a/packages/ats/sdk/src/port/in/bond/Bond.ts
+++ b/packages/ats/sdk/src/port/in/bond/Bond.ts
@@ -6,8 +6,6 @@ import { QueryBus } from "@core/query/QueryBus";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import { GetBondDetailsQuery } from "@query/bond/get/getBondDetails/GetBondDetailsQuery";
 
-import { CancelCouponCommand } from "@command/bond/coupon/cancel/CancelCouponCommand";
-import { SetCouponCommand } from "@command/bond/coupon/set/SetCouponCommand";
 import { CreateBondCommand } from "@command/bond/create/CreateBondCommand";
 import { CreateBondFixedRateCommand } from "@command/bond/createfixedrate/CreateBondFixedRateCommand";
 import { CreateBondKpiLinkedRateCommand } from "@command/bond/createkpilinkedrate/CreateBondKpiLinkedRateCommand";
@@ -20,21 +18,11 @@ import { AddProceedRecipientCommand } from "@command/security/proceedRecipients/
 import { RemoveProceedRecipientCommand } from "@command/security/proceedRecipients/removeProceedRecipient/RemoveProceedRecipientCommand";
 import { UpdateProceedRecipientDataCommand } from "@command/security/proceedRecipients/updateProceedRecipientData/UpdateProceedRecipientDataCommand";
 import { CommandBus } from "@core/command/CommandBus";
-import { CastRateStatus } from "@domain/context/bond/RateStatus";
 import ContractId from "@domain/context/contract/ContractId";
 import { CastRegulationSubType, CastRegulationType } from "@domain/context/factory/RegulationType";
 import { SecurityProps } from "@domain/context/security/Security";
 import BigDecimal from "@domain/context/shared/BigDecimal";
 import { ONE_THOUSAND } from "@domain/context/shared/SecurityDate";
-import { GetCouponQuery } from "@query/bond/coupons/getCoupon/GetCouponQuery";
-import { GetCouponAmountForQuery } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQuery";
-import { GetCouponCountQuery } from "@query/bond/coupons/getCouponCount/GetCouponCountQuery";
-import { GetCouponForQuery } from "@query/bond/coupons/getCouponFor/GetCouponForQuery";
-import { GetCouponFromOrderedListAtQuery } from "@query/bond/coupons/getCouponFromOrderedListAt/GetCouponFromOrderedListAtQuery";
-import { GetCouponHoldersQuery } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQuery";
-import { GetCouponsOrderedListQuery } from "@query/bond/coupons/getCouponsOrderedList/GetCouponsOrderedListQuery";
-import { GetCouponsOrderedListTotalQuery } from "@query/bond/coupons/getCouponsOrderedListTotal/GetCouponsOrderedListTotalQuery";
-import { GetTotalCouponHoldersQuery } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQuery";
 import { GetPrincipalForQuery } from "@query/bond/get/getPrincipalFor/GetPrincipalForQuery";
 import { GetSecurityQuery } from "@query/security/get/GetSecurityQuery";
 import { GetProceedRecipientDataQuery } from "@query/security/proceedRecipient/getProceedRecipientData/GetProceedRecipientDataQuery";
@@ -43,11 +31,9 @@ import { GetProceedRecipientsCountQuery } from "@query/security/proceedRecipient
 import { IsProceedRecipientQuery } from "@query/security/proceedRecipient/isProceedRecipient/IsProceedRecipientQuery";
 import NetworkService from "@service/network/NetworkService";
 import {
-  GetCouponHoldersRequest,
   GetProceedRecipientDataRequest,
   GetProceedRecipientsCountRequest,
   GetProceedRecipientsRequest,
-  GetTotalCouponHoldersRequest,
 } from "../request";
 import AddProceedRecipientRequest from "../request/bond/AddProceedRecipientRequest";
 import CreateBondFixedRateRequest from "../request/bond/CreateBondFixedRateRequest";
@@ -55,26 +41,15 @@ import CreateBondKpiLinkedRateRequest from "../request/bond/CreateBondKpiLinkedR
 import CreateBondRequest from "../request/bond/CreateBondRequest";
 import CreateTrexSuiteBondRequest from "../request/bond/CreateTrexSuiteBondRequest";
 import FullRedeemAtMaturityRequest from "../request/bond/FullRedeemAtMaturityRequest";
-import GetCouponsOrderedListRequest from "../request/bond/GetCouponsOrderedListRequest";
-import GetCouponsOrderedListTotalRequest from "../request/bond/GetCouponsOrderedListTotalRequest";
-import GetAllCouponsRequest from "../request/bond/GetAllCouponsRequest";
 import GetBondDetailsRequest from "../request/bond/GetBondDetailsRequest";
-import GetCouponForRequest from "../request/bond/GetCouponForRequest";
-import GetCouponFromOrderedListAtRequest from "../request/bond/GetCouponFromOrderedListAtRequest";
-import GetCouponRequest from "../request/bond/GetCouponRequest";
 import GetPrincipalForRequest from "../request/bond/GetPrincipalForRequest";
 import IsProceedRecipientRequest from "../request/bond/IsProceedRecipientRequest";
 import RedeemAtMaturityByPartitionRequest from "../request/bond/RedeemAtMaturityByPartitionRequest";
 import RemoveProceedRecipientRequest from "../request/bond/RemoveProceedRecipientRequest";
-import CancelCouponRequest from "../request/bond/CancelCouponRequest";
-import SetCouponRequest from "../request/bond/SetCouponRequest";
 import UpdateMaturityDateRequest from "../request/bond/UpdateMaturityDateRequest";
 import UpdateProceedRecipientDataRequest from "../request/bond/UpdateProceedRecipientDataRequest";
 import { AddKpiDataRequest } from "../request/kpis/AddKpiDataRequest";
 import BondDetailsViewModel from "../response/BondDetailsViewModel";
-import CouponAmountForViewModel from "../response/CouponAmountForViewModel";
-import CouponForViewModel from "../response/CouponForViewModel";
-import CouponViewModel from "../response/CouponViewModel";
 import PrincipalForViewModel from "../response/PrincipalForViewModel";
 import { SecurityViewModel } from "../security/Security";
 
@@ -82,26 +57,14 @@ interface IBondInPort {
   create(request: CreateBondRequest): Promise<{ security: SecurityViewModel; transactionId: string }>;
   createFixedRate(request: CreateBondFixedRateRequest): Promise<{ security: SecurityViewModel; transactionId: string }>;
   getBondDetails(request: GetBondDetailsRequest): Promise<BondDetailsViewModel>;
-  setCoupon(request: SetCouponRequest): Promise<{ payload: number; transactionId: string }>;
-  cancelCoupon(request: CancelCouponRequest): Promise<{ payload: boolean; transactionId: string }>;
-  getCouponFor(request: GetCouponForRequest): Promise<CouponForViewModel>;
-  getCouponAmountFor(request: GetCouponForRequest): Promise<CouponAmountForViewModel>;
   getPrincipalFor(request: GetPrincipalForRequest): Promise<PrincipalForViewModel>;
-  getCoupon(request: GetCouponRequest): Promise<CouponViewModel>;
-  getAllCoupons(request: GetAllCouponsRequest): Promise<CouponViewModel[]>;
-  getCouponsOrderedList(request: GetCouponsOrderedListRequest): Promise<number[]>;
-  getCouponsOrderedListTotal(request: GetCouponsOrderedListTotalRequest): Promise<number>;
   updateMaturityDate(request: UpdateMaturityDateRequest): Promise<{ payload: boolean; transactionId: string }>;
   redeemAtMaturityByPartition(
     request: RedeemAtMaturityByPartitionRequest,
   ): Promise<{ payload: boolean; transactionId: string }>;
   fullRedeemAtMaturity(request: FullRedeemAtMaturityRequest): Promise<{ payload: boolean; transactionId: string }>;
-  getCouponHolders(request: GetCouponHoldersRequest): Promise<string[]>;
-  getTotalCouponHolders(request: GetTotalCouponHoldersRequest): Promise<number>;
-  getCouponFromOrderedListAt(request: GetCouponFromOrderedListAtRequest): Promise<number>;
   createTrexSuite(request: CreateTrexSuiteBondRequest): Promise<{ security: SecurityViewModel; transactionId: string }>;
   addKpiData(request: AddKpiDataRequest): Promise<{ transactionId: string }>;
-
   addProceedRecipient(request: AddProceedRecipientRequest): Promise<{ payload: boolean; transactionId: string }>;
   removeProceedRecipient(request: RemoveProceedRecipientRequest): Promise<{ payload: boolean; transactionId: string }>;
   updateProceedRecipientData(
@@ -361,76 +324,6 @@ class BondInPort implements IBondInPort {
   }
 
   @LogError
-  async setCoupon(request: SetCouponRequest): Promise<{ payload: number; transactionId: string }> {
-    const {
-      rate,
-      recordTimestamp,
-      executionTimestamp,
-      securityId,
-      startTimestamp,
-      endTimestamp,
-      fixingTimestamp,
-      rateStatus,
-    } = request;
-    ValidatedRequest.handleValidation("SetCouponRequest", request);
-
-    return await this.commandBus.execute(
-      new SetCouponCommand(
-        securityId,
-        recordTimestamp,
-        executionTimestamp,
-        rate,
-        startTimestamp,
-        endTimestamp,
-        fixingTimestamp,
-        CastRateStatus.fromNumber(rateStatus),
-      ),
-    );
-  }
-
-  @LogError
-  async cancelCoupon(request: CancelCouponRequest): Promise<{ payload: boolean; transactionId: string }> {
-    const { securityId, couponId } = request;
-    ValidatedRequest.handleValidation("CancelCouponRequest", request);
-
-    return await this.commandBus.execute(new CancelCouponCommand(securityId, couponId));
-  }
-
-  @LogError
-  async getCouponFor(request: GetCouponForRequest): Promise<CouponForViewModel> {
-    ValidatedRequest.handleValidation("GetCouponForRequest", request);
-
-    const res = await this.queryBus.execute(
-      new GetCouponForQuery(request.targetId, request.securityId, request.couponId),
-    );
-
-    const couponFor: CouponForViewModel = {
-      tokenBalance: res.tokenBalance.toString(),
-      decimals: res.decimals.toString(),
-      isDisabled: res.isDisabled,
-    };
-
-    return couponFor;
-  }
-
-  @LogError
-  async getCouponAmountFor(request: GetCouponForRequest): Promise<CouponAmountForViewModel> {
-    ValidatedRequest.handleValidation("GetCouponForRequest", request);
-
-    const res = await this.queryBus.execute(
-      new GetCouponAmountForQuery(request.targetId, request.securityId, request.couponId),
-    );
-
-    const couponAmountFor: CouponAmountForViewModel = {
-      numerator: res.numerator,
-      denominator: res.denominator,
-      recordDateReached: res.recordDateReached,
-    };
-
-    return couponAmountFor;
-  }
-
-  @LogError
   async getPrincipalFor(request: GetPrincipalForRequest): Promise<PrincipalForViewModel> {
     ValidatedRequest.handleValidation("GetPrincipalForRequest", request);
 
@@ -442,74 +335,6 @@ class BondInPort implements IBondInPort {
     };
 
     return principalFor;
-  }
-
-  @LogError
-  async getCoupon(request: GetCouponRequest): Promise<CouponViewModel> {
-    ValidatedRequest.handleValidation("GetCouponRequest", request);
-
-    const res = await this.queryBus.execute(new GetCouponQuery(request.securityId, request.couponId));
-
-    const coupon: CouponViewModel = {
-      couponId: request.couponId,
-      recordDate: new Date(res.coupon.recordTimeStamp * ONE_THOUSAND),
-      executionDate: new Date(res.coupon.executionTimeStamp * ONE_THOUSAND),
-      rate: res.coupon.rate.toString(),
-      rateDecimals: res.coupon.rateDecimals,
-      startDate: new Date(res.coupon.startTimeStamp * ONE_THOUSAND),
-      endDate: new Date(res.coupon.endTimeStamp * ONE_THOUSAND),
-      fixingDate: new Date(res.coupon.fixingTimeStamp * ONE_THOUSAND),
-      rateStatus: CastRateStatus.toNumber(res.coupon.rateStatus),
-      isDisabled: res.coupon.isDisabled,
-    };
-
-    return coupon;
-  }
-
-  @LogError
-  async getAllCoupons(request: GetAllCouponsRequest): Promise<CouponViewModel[]> {
-    ValidatedRequest.handleValidation("GetAllCouponsRequest", request);
-
-    const count = await this.queryBus.execute(new GetCouponCountQuery(request.securityId));
-
-    if (count.payload == 0) return [];
-
-    const coupons: CouponViewModel[] = [];
-
-    for (let i = 1; i <= count.payload; i++) {
-      const couponRequest = new GetCouponRequest({
-        securityId: request.securityId,
-        couponId: i,
-      });
-
-      const coupon = await this.getCoupon(couponRequest);
-
-      coupons.push(coupon);
-    }
-
-    return coupons;
-  }
-
-  @LogError
-  async getCouponsOrderedList(request: GetCouponsOrderedListRequest): Promise<number[]> {
-    ValidatedRequest.handleValidation("GetCouponsOrderedListRequest", request);
-
-    const { securityId, pageIndex, pageLength } = request;
-
-    const result = await this.queryBus.execute(new GetCouponsOrderedListQuery(securityId, pageIndex, pageLength));
-
-    return result.payload;
-  }
-
-  @LogError
-  async getCouponsOrderedListTotal(request: GetCouponsOrderedListTotalRequest): Promise<number> {
-    ValidatedRequest.handleValidation("GetCouponsOrderedListTotalRequest", request);
-
-    const { securityId } = request;
-
-    const result = await this.queryBus.execute(new GetCouponsOrderedListTotalQuery(securityId));
-
-    return result.payload;
   }
 
   @LogError
@@ -540,30 +365,6 @@ class BondInPort implements IBondInPort {
     ValidatedRequest.handleValidation(FullRedeemAtMaturityRequest.name, request);
 
     return await this.commandBus.execute(new FullRedeemAtMaturityCommand(securityId, sourceId));
-  }
-
-  @LogError
-  async getCouponHolders(request: GetCouponHoldersRequest): Promise<string[]> {
-    const { securityId, couponId, start, end } = request;
-    ValidatedRequest.handleValidation(GetCouponHoldersRequest.name, request);
-
-    return (await this.queryBus.execute(new GetCouponHoldersQuery(securityId, couponId, start, end))).payload;
-  }
-
-  @LogError
-  async getTotalCouponHolders(request: GetTotalCouponHoldersRequest): Promise<number> {
-    const { securityId, couponId } = request;
-    ValidatedRequest.handleValidation(GetTotalCouponHoldersRequest.name, request);
-
-    return (await this.queryBus.execute(new GetTotalCouponHoldersQuery(securityId, couponId))).payload;
-  }
-
-  @LogError
-  async getCouponFromOrderedListAt(request: GetCouponFromOrderedListAtRequest): Promise<number> {
-    const { securityId, pos } = request;
-    ValidatedRequest.handleValidation(GetCouponFromOrderedListAtRequest.name, request);
-
-    return (await this.queryBus.execute(new GetCouponFromOrderedListAtQuery(securityId, pos))).couponId;
   }
 
   @LogError
@@ -681,11 +482,13 @@ class BondInPort implements IBondInPort {
       new GetProceedRecipientsQuery(request.securityId, request.pageIndex, request.pageSize),
     );
   }
+
   @LogError
   async getProceedRecipientsCount(request: GetProceedRecipientsCountRequest): Promise<{ payload: number }> {
     ValidatedRequest.handleValidation(GetProceedRecipientsCountRequest.name, request);
     return await this.queryBus.execute(new GetProceedRecipientsCountQuery(request.securityId));
   }
+
   @LogError
   async getProceedRecipientData(request: GetProceedRecipientDataRequest): Promise<{ payload: string }> {
     ValidatedRequest.handleValidation(GetProceedRecipientDataRequest.name, request);
@@ -693,6 +496,7 @@ class BondInPort implements IBondInPort {
       new GetProceedRecipientDataQuery(request.securityId, request.proceedRecipientId),
     );
   }
+
   @LogError
   async isProceedRecipient(request: IsProceedRecipientRequest): Promise<{ payload: boolean }> {
     ValidatedRequest.handleValidation(IsProceedRecipientRequest.name, request);

--- a/packages/ats/sdk/src/port/in/bond/Bond.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/bond/Bond.unit.test.ts
@@ -2,20 +2,12 @@
 
 import { createMock } from "@golevelup/ts-jest";
 import { CommandBus } from "@core/command/CommandBus";
-import CancelCouponRequest from "../request/bond/CancelCouponRequest";
 import {
   CreateBondRequest,
   GetBondDetailsRequest,
-  SetCouponRequest,
-  GetCouponForRequest,
-  GetCouponRequest,
-  GetAllCouponsRequest,
-  GetCouponsOrderedListRequest,
   UpdateMaturityDateRequest,
   RedeemAtMaturityByPartitionRequest,
   FullRedeemAtMaturityRequest,
-  GetCouponHoldersRequest,
-  GetTotalCouponHoldersRequest,
   CreateTrexSuiteBondRequest,
   RemoveProceedRecipientRequest,
   UpdateProceedRecipientDataRequest,
@@ -34,19 +26,10 @@ import NetworkService from "@service/network/NetworkService";
 import BondToken from "./Bond";
 import {
   BondDetailsFixture,
-  CouponFixture,
   CreateBondRequestFixture,
-  GetAllCouponsRequestFixture,
-  GetCouponsOrderedListRequestFixture,
   GetBondDetailsRequestFixture,
-  GetCouponForRequestFixture,
-  GetCouponHoldersQueryFixture,
-  GetCouponRequestFixture,
   RedeemAtMaturityByPartitionRequestFixture,
   FullRedeemAtMaturityRequestFixture,
-  GetTotalCouponHoldersRequestFixture,
-  CancelCouponRequestFixture,
-  SetCouponRequestFixture,
   UpdateMaturityDateRequestFixture,
   CreateTrexSuiteBondRequestFixture,
   AddProceedRecipientRequestFixture,
@@ -67,20 +50,10 @@ import BigDecimal from "@domain/context/shared/BigDecimal";
 import { faker } from "@faker-js/faker/.";
 import { GetBondDetailsQuery } from "@query/bond/get/getBondDetails/GetBondDetailsQuery";
 import { ONE_THOUSAND } from "@domain/context/shared/SecurityDate";
-import { CancelCouponCommand } from "@command/bond/coupon/cancel/CancelCouponCommand";
-import { SetCouponCommand } from "@command/bond/coupon/set/SetCouponCommand";
-
-import { GetCouponForQuery } from "@query/bond/coupons/getCouponFor/GetCouponForQuery";
 import { GetPrincipalForQuery } from "@query/bond/get/getPrincipalFor/GetPrincipalForQuery";
-import { GetCouponAmountForQuery } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQuery";
-import { GetCouponQuery } from "@query/bond/coupons/getCoupon/GetCouponQuery";
-import { GetCouponsOrderedListQuery } from "@query/bond/coupons/getCouponsOrderedList/GetCouponsOrderedListQuery";
-import { GetCouponCountQuery } from "@query/bond/coupons/getCouponCount/GetCouponCountQuery";
 import { UpdateMaturityDateCommand } from "@command/bond/updateMaturityDate/UpdateMaturityDateCommand";
 import { RedeemAtMaturityByPartitionCommand } from "@command/bond/redeemAtMaturityByPartition/RedeemAtMaturityByPartitionCommand";
 import { FullRedeemAtMaturityCommand } from "@command/bond/fullRedeemAtMaturity/FullRedeemAtMaturityCommand";
-import { GetCouponHoldersQuery } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQuery";
-import { GetTotalCouponHoldersQuery } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQuery";
 import { CreateTrexSuiteBondCommand } from "@command/bond/createTrexSuite/CreateTrexSuiteBondCommand";
 import AddProceedRecipientRequest from "../request/bond/AddProceedRecipientRequest";
 import { AddProceedRecipientCommand } from "@command/security/proceedRecipients/addProceedRecipient/AddProceedRecipientCommand";
@@ -90,7 +63,6 @@ import { IsProceedRecipientQuery } from "@query/security/proceedRecipient/isProc
 import { GetProceedRecipientsCountQuery } from "@query/security/proceedRecipient/getProceedRecipientsCount/GetProceedRecipientsCountQuery";
 import { GetProceedRecipientDataQuery } from "@query/security/proceedRecipient/getProceedRecipientData/GetProceedRecipientDataQuery";
 import { GetProceedRecipientsQuery } from "@query/security/proceedRecipient/getProceedRecipients/GetProceedRecipientsQuery";
-import { CastRateStatus } from "@domain/context/bond/RateStatus";
 
 describe("Bond", () => {
   let commandBusMock: jest.Mocked<CommandBus>;
@@ -99,17 +71,9 @@ describe("Bond", () => {
 
   let createBondRequest: CreateBondRequest;
   let getBondDetailsRequest: GetBondDetailsRequest;
-  let setCouponRequest: SetCouponRequest;
-  let cancelCouponRequest: CancelCouponRequest;
-  let getCouponForRequest: GetCouponForRequest;
-  let getCouponRequest: GetCouponRequest;
-  let getAllCouponsRequest: GetAllCouponsRequest;
-  let getCouponsOrderedListRequest: GetCouponsOrderedListRequest;
   let updateMaturityDateRequest: UpdateMaturityDateRequest;
   let redeemAtMaturityByPartitionRequest: RedeemAtMaturityByPartitionRequest;
   let fullRedeemAtMaturityRequest: FullRedeemAtMaturityRequest;
-  let getCouponHoldersRequest: GetCouponHoldersRequest;
-  let getTotalCouponHoldersRequest: GetTotalCouponHoldersRequest;
   let createTrexSuiteBondRequest: CreateTrexSuiteBondRequest;
   let getPrincipalForRequest: GetPrincipalForRequest;
 
@@ -124,8 +88,6 @@ describe("Bond", () => {
     commandBusMock = createMock<CommandBus>();
     queryBusMock = createMock<QueryBus>();
     handleValidationSpy = jest.spyOn(ValidatedRequest, "handleValidation");
-    getAllCouponsRequest = new GetAllCouponsRequest(GetAllCouponsRequestFixture.create());
-    getCouponsOrderedListRequest = new GetCouponsOrderedListRequest(GetCouponsOrderedListRequestFixture.create());
     networkServiceMock = createMock<NetworkService>({
       configuration: {
         factoryAddress: factoryAddress,
@@ -468,309 +430,6 @@ describe("Bond", () => {
       await expect(BondToken.getBondDetails(getBondDetailsRequest)).rejects.toThrow(ValidationError);
     });
   });
-
-  describe("setCoupon", () => {
-    setCouponRequest = new SetCouponRequest(SetCouponRequestFixture.create());
-    it("should set coupon successfully", async () => {
-      const expectedResponse = {
-        payload: 1,
-        transactionId: transactionId,
-      };
-
-      commandBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.setCoupon(setCouponRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("SetCouponRequest", setCouponRequest);
-
-      expect(commandBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(commandBusMock.execute).toHaveBeenCalledWith(
-        new SetCouponCommand(
-          setCouponRequest.securityId,
-          setCouponRequest.recordTimestamp,
-          setCouponRequest.executionTimestamp,
-          setCouponRequest.rate,
-          setCouponRequest.startTimestamp,
-          setCouponRequest.endTimestamp,
-          setCouponRequest.fixingTimestamp,
-          CastRateStatus.fromNumber(setCouponRequest.rateStatus),
-        ),
-      );
-
-      expect(result).toEqual(expectedResponse);
-    });
-
-    it("should throw an error if command execution fails", async () => {
-      const error = new Error("Command execution failed");
-      commandBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.setCoupon(setCouponRequest)).rejects.toThrow("Command execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("SetCouponRequest", setCouponRequest);
-
-      expect(commandBusMock.execute).toHaveBeenCalledWith(
-        new SetCouponCommand(
-          setCouponRequest.securityId,
-          setCouponRequest.recordTimestamp,
-          setCouponRequest.executionTimestamp,
-          setCouponRequest.rate,
-          setCouponRequest.startTimestamp,
-          setCouponRequest.endTimestamp,
-          setCouponRequest.fixingTimestamp,
-          CastRateStatus.fromNumber(setCouponRequest.rateStatus),
-        ),
-      );
-    });
-
-    it("should throw error if recordTimestamp is invalid", async () => {
-      setCouponRequest = new SetCouponRequest({
-        ...SetCouponRequestFixture.create(),
-        recordTimestamp: (Math.ceil(new Date().getTime() / 1000) - 100).toString(),
-      });
-
-      await expect(BondToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if executionTimestamp is invalid", async () => {
-      const time = faker.date.past().getTime();
-      setCouponRequest = new SetCouponRequest({
-        ...SetCouponRequestFixture.create(),
-        recordTimestamp: time.toString(),
-        executionTimestamp: (time - 10).toString(),
-      });
-
-      await expect(BondToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      setCouponRequest = new SetCouponRequest({
-        ...SetCouponRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
-    });
-    it("should throw error if rate is invalid", async () => {
-      setCouponRequest = new SetCouponRequest({
-        ...SetCouponRequestFixture.create(),
-        rate: "invalid",
-      });
-
-      await expect(BondToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
-  describe("cancelCoupon", () => {
-    beforeEach(() => {
-      cancelCouponRequest = new CancelCouponRequest(CancelCouponRequestFixture.create());
-    });
-    it("should cancel coupon successfully", async () => {
-      const expectedResponse = {
-        payload: true,
-        transactionId: transactionId,
-      };
-
-      commandBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.cancelCoupon(cancelCouponRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("CancelCouponRequest", cancelCouponRequest);
-
-      expect(commandBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(commandBusMock.execute).toHaveBeenCalledWith(
-        new CancelCouponCommand(cancelCouponRequest.securityId, cancelCouponRequest.couponId),
-      );
-
-      expect(result).toEqual(expectedResponse);
-    });
-
-    it("should throw an error if command execution fails", async () => {
-      const error = new Error("Command execution failed");
-      commandBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.cancelCoupon(cancelCouponRequest)).rejects.toThrow("Command execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("CancelCouponRequest", cancelCouponRequest);
-
-      expect(commandBusMock.execute).toHaveBeenCalledWith(
-        new CancelCouponCommand(cancelCouponRequest.securityId, cancelCouponRequest.couponId),
-      );
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      cancelCouponRequest = new CancelCouponRequest({
-        ...CancelCouponRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.cancelCoupon(cancelCouponRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
-  describe("getCouponFor", () => {
-    beforeEach(() => {
-      getCouponForRequest = new GetCouponForRequest(GetCouponForRequestFixture.create());
-    });
-    it("should get coupon for successfully", async () => {
-      const expectedResponse = {
-        tokenBalance: BigInt(1000),
-        decimals: 2,
-        isDisabled: false,
-      };
-
-      queryBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.getCouponFor(getCouponForRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponForQuery(
-          getCouponForRequest.targetId,
-          getCouponForRequest.securityId,
-          getCouponForRequest.couponId,
-        ),
-      );
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          tokenBalance: expectedResponse.tokenBalance.toString(),
-          decimals: expectedResponse.decimals.toString(),
-          isDisabled: false,
-        }),
-      );
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getCouponFor(getCouponForRequest)).rejects.toThrow("Query execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponForQuery(
-          getCouponForRequest.targetId,
-          getCouponForRequest.securityId,
-          getCouponForRequest.couponId,
-        ),
-      );
-    });
-
-    it("should throw error if targetId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        targetId: "invalid",
-      });
-
-      await expect(BondToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if couponId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        couponId: 0,
-      });
-
-      await expect(BondToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
-  describe("getCouponAmountFor", () => {
-    beforeEach(() => {
-      getCouponForRequest = new GetCouponForRequest(GetCouponForRequestFixture.create());
-    });
-    it("should get coupon for successfully", async () => {
-      const expectedResponse = {
-        numerator: "10",
-        denominator: "4",
-        recordDateReached: true,
-      };
-
-      queryBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.getCouponAmountFor(getCouponForRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponAmountForQuery(
-          getCouponForRequest.targetId,
-          getCouponForRequest.securityId,
-          getCouponForRequest.couponId,
-        ),
-      );
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          numerator: expectedResponse.numerator,
-          denominator: expectedResponse.denominator,
-          recordDateReached: expectedResponse.recordDateReached,
-        }),
-      );
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow("Query execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponAmountForQuery(
-          getCouponForRequest.targetId,
-          getCouponForRequest.securityId,
-          getCouponForRequest.couponId,
-        ),
-      );
-    });
-
-    it("should throw error if targetId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        targetId: "invalid",
-      });
-
-      await expect(BondToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if couponId is invalid", async () => {
-      getCouponForRequest = new GetCouponForRequest({
-        ...GetCouponForRequestFixture.create(),
-        couponId: 0,
-      });
-
-      await expect(BondToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
   describe("getPrincipalFor", () => {
     beforeEach(() => {
       getPrincipalForRequest = new GetPrincipalForRequest(GetPrincipalForRequestFixture.create());
@@ -832,220 +491,6 @@ describe("Bond", () => {
       await expect(BondToken.getPrincipalFor(getPrincipalForRequest)).rejects.toThrow(ValidationError);
     });
   });
-
-  describe("getCoupon", () => {
-    getCouponRequest = new GetCouponRequest(GetCouponRequestFixture.create());
-    it("should get coupon successfully", async () => {
-      const expectedResponse = {
-        coupon: CouponFixture.create(),
-      };
-
-      queryBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.getCoupon(getCouponRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponRequest", getCouponRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponQuery(getCouponRequest.securityId, getCouponRequest.couponId),
-      );
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          couponId: getCouponRequest.couponId,
-          recordDate: new Date(expectedResponse.coupon.recordTimeStamp * ONE_THOUSAND),
-          executionDate: new Date(expectedResponse.coupon.executionTimeStamp * ONE_THOUSAND),
-          rate: expectedResponse.coupon.rate.toString(),
-        }),
-      );
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getCoupon(getCouponRequest)).rejects.toThrow("Query execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponRequest", getCouponRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponQuery(getCouponRequest.securityId, getCouponRequest.couponId),
-      );
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      getCouponRequest = new GetCouponRequest({
-        ...GetCouponRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.getCoupon(getCouponRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if couponId is invalid", async () => {
-      getCouponRequest = new GetCouponRequest({
-        ...GetCouponRequestFixture.create(),
-        couponId: 0,
-      });
-
-      await expect(BondToken.getCoupon(getCouponRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
-  describe("getAllCoupons", () => {
-    getAllCouponsRequest = new GetAllCouponsRequest(GetAllCouponsRequestFixture.create());
-    it("should get all coupon successfully", async () => {
-      const expectedResponse = {
-        payload: 1,
-      };
-
-      const expectedResponse2 = {
-        coupon: CouponFixture.create(),
-      };
-
-      queryBusMock.execute.mockResolvedValueOnce(expectedResponse).mockResolvedValueOnce(expectedResponse2);
-
-      const result = await BondToken.getAllCoupons(getAllCouponsRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(2);
-
-      expect(queryBusMock.execute).toHaveBeenNthCalledWith(1, new GetCouponCountQuery(getAllCouponsRequest.securityId));
-
-      expect(queryBusMock.execute).toHaveBeenNthCalledWith(2, new GetCouponQuery(getAllCouponsRequest.securityId, 1));
-
-      expect(result).toEqual(
-        expect.arrayContaining([
-          {
-            couponId: 1,
-            recordDate: new Date(expectedResponse2.coupon.recordTimeStamp * ONE_THOUSAND),
-            executionDate: new Date(expectedResponse2.coupon.executionTimeStamp * ONE_THOUSAND),
-            rate: expectedResponse2.coupon.rate.toString(),
-            rateDecimals: expectedResponse2.coupon.rateDecimals,
-            startDate: new Date(expectedResponse2.coupon.startTimeStamp * ONE_THOUSAND),
-            endDate: new Date(expectedResponse2.coupon.endTimeStamp * ONE_THOUSAND),
-            fixingDate: new Date(expectedResponse2.coupon.fixingTimeStamp * ONE_THOUSAND),
-            rateStatus: CastRateStatus.toNumber(expectedResponse2.coupon.rateStatus),
-            isDisabled: expectedResponse2.coupon.isDisabled,
-          },
-        ]),
-      );
-    });
-
-    it("should return empty array if count is 0", async () => {
-      const expectedResponse = {
-        payload: 0,
-      };
-      queryBusMock.execute.mockResolvedValueOnce(expectedResponse);
-
-      const result = await BondToken.getAllCoupons(getAllCouponsRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponCountQuery(getAllCouponsRequest.securityId));
-
-      expect(result).toStrictEqual([]);
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getAllCoupons(getAllCouponsRequest)).rejects.toThrow("Query execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponCountQuery(getAllCouponsRequest.securityId));
-    });
-  });
-
-  describe("getCouponsOrderedList", () => {
-    it("should get coupons ordered list successfully", async () => {
-      const expectedResponse = [1, 2, 3, 4, 5];
-
-      queryBusMock.execute.mockResolvedValue({ payload: expectedResponse });
-
-      const result = await BondToken.getCouponsOrderedList(getCouponsOrderedListRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponsOrderedListQuery(
-          getCouponsOrderedListRequest.securityId,
-          getCouponsOrderedListRequest.pageIndex,
-          getCouponsOrderedListRequest.pageLength,
-        ),
-      );
-
-      expect(result).toEqual(expectedResponse);
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getCouponsOrderedList(getCouponsOrderedListRequest)).rejects.toThrow(
-        "Query execution failed",
-      );
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponsOrderedListQuery(
-          getCouponsOrderedListRequest.securityId,
-          getCouponsOrderedListRequest.pageIndex,
-          getCouponsOrderedListRequest.pageLength,
-        ),
-      );
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      const invalidRequest = new GetCouponsOrderedListRequest({
-        securityId: "invalid",
-        pageIndex: 0,
-        pageLength: 10,
-      });
-
-      await expect(BondToken.getCouponsOrderedList(invalidRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should work with mocked query handler", async () => {
-      const expectedResponse = [10, 20, 30];
-
-      // Mock the query handler directly
-      const mockHandler = {
-        execute: jest.fn().mockResolvedValue({ payload: expectedResponse }),
-      };
-
-      // Replace the query bus execute for this specific query
-      queryBusMock.execute.mockImplementation((query) => {
-        if (query instanceof GetCouponsOrderedListQuery) {
-          return mockHandler.execute(query);
-        }
-        return Promise.resolve({});
-      });
-
-      const result = await BondToken.getCouponsOrderedList(getCouponsOrderedListRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
-      expect(mockHandler.execute).toHaveBeenCalledWith(
-        new GetCouponsOrderedListQuery(
-          getCouponsOrderedListRequest.securityId,
-          getCouponsOrderedListRequest.pageIndex,
-          getCouponsOrderedListRequest.pageLength,
-        ),
-      );
-      expect(result).toEqual(expectedResponse);
-    });
-  });
-
   describe("updateMaturityDate", () => {
     updateMaturityDateRequest = new UpdateMaturityDateRequest(UpdateMaturityDateRequestFixture.create());
     it("should update maturity date successfully", async () => {
@@ -1257,148 +702,6 @@ describe("Bond", () => {
       await expect(BondToken.fullRedeemAtMaturity(fullRedeemAtMaturityRequest)).rejects.toThrow(ValidationError);
     });
   });
-
-  describe("getCouponHolders", () => {
-    getCouponHoldersRequest = new GetCouponHoldersRequest(GetCouponHoldersQueryFixture.create());
-    it("should get coupon holders successfully", async () => {
-      const expectedResponse = {
-        payload: [transactionId],
-      };
-
-      queryBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.getCouponHolders(getCouponHoldersRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith(GetCouponHoldersRequest.name, getCouponHoldersRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponHoldersQuery(
-          getCouponHoldersRequest.securityId,
-          getCouponHoldersRequest.couponId,
-          getCouponHoldersRequest.start,
-          getCouponHoldersRequest.end,
-        ),
-      );
-
-      expect(result).toStrictEqual(expectedResponse.payload);
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow("Query execution failed");
-
-      expect(handleValidationSpy).toHaveBeenCalledWith(GetCouponHoldersRequest.name, getCouponHoldersRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetCouponHoldersQuery(
-          getCouponHoldersRequest.securityId,
-          getCouponHoldersRequest.couponId,
-          getCouponHoldersRequest.start,
-          getCouponHoldersRequest.end,
-        ),
-      );
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      getCouponHoldersRequest = new GetCouponHoldersRequest({
-        ...GetCouponHoldersQueryFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if couponId is invalid", async () => {
-      getCouponHoldersRequest = new GetCouponHoldersRequest({
-        ...GetCouponHoldersQueryFixture.create(),
-        couponId: -1,
-      });
-
-      await expect(BondToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if start is invalid", async () => {
-      getCouponHoldersRequest = new GetCouponHoldersRequest({
-        ...GetCouponHoldersQueryFixture.create(),
-        start: -1,
-      });
-
-      await expect(BondToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-    it("should throw error if end is invalid", async () => {
-      getCouponHoldersRequest = new GetCouponHoldersRequest({
-        ...GetCouponHoldersQueryFixture.create(),
-        end: -1,
-      });
-
-      await expect(BondToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
-  describe("getTotalCouponHolders", () => {
-    getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest(GetTotalCouponHoldersRequestFixture.create());
-    it("should get total coupon holders successfully", async () => {
-      const expectedResponse = {
-        payload: 1,
-      };
-
-      queryBusMock.execute.mockResolvedValue(expectedResponse);
-
-      const result = await BondToken.getTotalCouponHolders(getTotalCouponHoldersRequest);
-
-      expect(handleValidationSpy).toHaveBeenCalledWith(GetTotalCouponHoldersRequest.name, getTotalCouponHoldersRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetTotalCouponHoldersQuery(getTotalCouponHoldersRequest.securityId, getTotalCouponHoldersRequest.couponId),
-      );
-
-      expect(result).toEqual(expectedResponse.payload);
-    });
-
-    it("should throw an error if query execution fails", async () => {
-      const error = new Error("Query execution failed");
-      queryBusMock.execute.mockRejectedValue(error);
-
-      await expect(BondToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(
-        "Query execution failed",
-      );
-
-      expect(handleValidationSpy).toHaveBeenCalledWith(GetTotalCouponHoldersRequest.name, getTotalCouponHoldersRequest);
-
-      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
-
-      expect(queryBusMock.execute).toHaveBeenCalledWith(
-        new GetTotalCouponHoldersQuery(getTotalCouponHoldersRequest.securityId, getTotalCouponHoldersRequest.couponId),
-      );
-    });
-
-    it("should throw error if securityId is invalid", async () => {
-      getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest({
-        ...GetTotalCouponHoldersRequestFixture.create(),
-        securityId: "invalid",
-      });
-
-      await expect(BondToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-
-    it("should throw error if couponId is invalid", async () => {
-      getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest({
-        ...GetTotalCouponHoldersRequestFixture.create(),
-        couponId: -1,
-      });
-
-      await expect(BondToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(ValidationError);
-    });
-  });
-
   describe("createTrexSuite", () => {
     createTrexSuiteBondRequest = new CreateTrexSuiteBondRequest(CreateTrexSuiteBondRequestFixture.create());
     it("should create successfully", async () => {

--- a/packages/ats/sdk/src/port/in/coupon/Coupon.ts
+++ b/packages/ats/sdk/src/port/in/coupon/Coupon.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { LogError } from "@core/decorator/LogErrorDecorator";
+import Injectable from "@core/injectable/Injectable";
+import { QueryBus } from "@core/query/QueryBus";
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import { CommandBus } from "@core/command/CommandBus";
+import { CastRateStatus } from "@domain/context/bond/RateStatus";
+import { ONE_THOUSAND } from "@domain/context/shared/SecurityDate";
+import { CancelCouponCommand } from "@command/bond/coupon/cancel/CancelCouponCommand";
+import { SetCouponCommand } from "@command/bond/coupon/set/SetCouponCommand";
+import { GetCouponQuery } from "@query/bond/coupons/getCoupon/GetCouponQuery";
+import { GetCouponAmountForQuery } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQuery";
+import { GetCouponCountQuery } from "@query/bond/coupons/getCouponCount/GetCouponCountQuery";
+import { GetCouponForQuery } from "@query/bond/coupons/getCouponFor/GetCouponForQuery";
+import { GetCouponsForQuery } from "@query/bond/coupons/getCouponsFor/GetCouponsForQuery";
+import { GetCouponFromOrderedListAtQuery } from "@query/bond/coupons/getCouponFromOrderedListAt/GetCouponFromOrderedListAtQuery";
+import { GetCouponHoldersQuery } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQuery";
+import { GetCouponsOrderedListQuery } from "@query/bond/coupons/getCouponsOrderedList/GetCouponsOrderedListQuery";
+import { GetCouponsOrderedListTotalQuery } from "@query/bond/coupons/getCouponsOrderedListTotal/GetCouponsOrderedListTotalQuery";
+import { GetTotalCouponHoldersQuery } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQuery";
+import { GetCouponHoldersRequest, GetTotalCouponHoldersRequest } from "../request";
+import CancelCouponRequest from "../request/bond/CancelCouponRequest";
+import GetAllCouponsRequest from "../request/bond/GetAllCouponsRequest";
+import GetCouponForRequest from "../request/bond/GetCouponForRequest";
+import GetCouponsForRequest from "../request/bond/GetCouponsForRequest";
+import GetCouponFromOrderedListAtRequest from "../request/bond/GetCouponFromOrderedListAtRequest";
+import GetCouponRequest from "../request/bond/GetCouponRequest";
+import GetCouponsOrderedListRequest from "../request/bond/GetCouponsOrderedListRequest";
+import GetCouponsOrderedListTotalRequest from "../request/bond/GetCouponsOrderedListTotalRequest";
+import SetCouponRequest from "../request/bond/SetCouponRequest";
+import CouponAmountForViewModel from "../response/CouponAmountForViewModel";
+import CouponForViewModel from "../response/CouponForViewModel";
+import CouponViewModel from "../response/CouponViewModel";
+
+interface ICouponInPort {
+  setCoupon(request: SetCouponRequest): Promise<{ payload: number; transactionId: string }>;
+  cancelCoupon(request: CancelCouponRequest): Promise<{ payload: boolean; transactionId: string }>;
+  getCouponFor(request: GetCouponForRequest): Promise<CouponForViewModel>;
+  getCouponsFor(request: GetCouponsForRequest): Promise<{ coupons: CouponForViewModel[]; accounts: string[] }>;
+  getCouponAmountFor(request: GetCouponForRequest): Promise<CouponAmountForViewModel>;
+  getCoupon(request: GetCouponRequest): Promise<CouponViewModel>;
+  getAllCoupons(request: GetAllCouponsRequest): Promise<CouponViewModel[]>;
+  getCouponsOrderedList(request: GetCouponsOrderedListRequest): Promise<number[]>;
+  getCouponsOrderedListTotal(request: GetCouponsOrderedListTotalRequest): Promise<number>;
+  getCouponHolders(request: GetCouponHoldersRequest): Promise<string[]>;
+  getTotalCouponHolders(request: GetTotalCouponHoldersRequest): Promise<number>;
+  getCouponFromOrderedListAt(request: GetCouponFromOrderedListAtRequest): Promise<number>;
+}
+
+class CouponInPort implements ICouponInPort {
+  constructor(
+    private readonly queryBus: QueryBus = Injectable.resolve(QueryBus),
+    private readonly commandBus: CommandBus = Injectable.resolve(CommandBus),
+  ) {}
+
+  @LogError
+  async setCoupon(request: SetCouponRequest): Promise<{ payload: number; transactionId: string }> {
+    const {
+      rate,
+      recordTimestamp,
+      executionTimestamp,
+      securityId,
+      startTimestamp,
+      endTimestamp,
+      fixingTimestamp,
+      rateStatus,
+    } = request;
+    ValidatedRequest.handleValidation("SetCouponRequest", request);
+
+    return await this.commandBus.execute(
+      new SetCouponCommand(
+        securityId,
+        recordTimestamp,
+        executionTimestamp,
+        rate,
+        startTimestamp,
+        endTimestamp,
+        fixingTimestamp,
+        CastRateStatus.fromNumber(rateStatus),
+      ),
+    );
+  }
+
+  @LogError
+  async cancelCoupon(request: CancelCouponRequest): Promise<{ payload: boolean; transactionId: string }> {
+    const { securityId, couponId } = request;
+    ValidatedRequest.handleValidation("CancelCouponRequest", request);
+
+    return await this.commandBus.execute(new CancelCouponCommand(securityId, couponId));
+  }
+
+  @LogError
+  async getCouponFor(request: GetCouponForRequest): Promise<CouponForViewModel> {
+    ValidatedRequest.handleValidation("GetCouponForRequest", request);
+
+    const res = await this.queryBus.execute(
+      new GetCouponForQuery(request.targetId, request.securityId, request.couponId),
+    );
+
+    const couponFor: CouponForViewModel = {
+      tokenBalance: res.couponFor.tokenBalance.toString(),
+      nominalValue: res.couponFor.nominalValue.toString(),
+      decimals: res.couponFor.decimals.toString(),
+      recordDateReached: res.couponFor.recordDateReached,
+      coupon: {
+        recordDate: new Date(res.couponFor.coupon.recordTimeStamp * ONE_THOUSAND),
+        executionDate: new Date(res.couponFor.coupon.executionTimeStamp * ONE_THOUSAND),
+        rate: res.couponFor.coupon.rate.toString(),
+        rateDecimals: res.couponFor.coupon.rateDecimals,
+        startDate: new Date(res.couponFor.coupon.startTimeStamp * ONE_THOUSAND),
+        endDate: new Date(res.couponFor.coupon.endTimeStamp * ONE_THOUSAND),
+        fixingDate: new Date(res.couponFor.coupon.fixingTimeStamp * ONE_THOUSAND),
+        rateStatus: CastRateStatus.toNumber(res.couponFor.coupon.rateStatus),
+      },
+      couponAmount: {
+        numerator: res.couponFor.couponAmount.numerator,
+        denominator: res.couponFor.couponAmount.denominator,
+        recordDateReached: res.couponFor.couponAmount.recordDateReached,
+      },
+      isDisabled: res.couponFor.isDisabled,
+    };
+
+    return couponFor;
+  }
+
+  @LogError
+  async getCouponsFor(request: GetCouponsForRequest): Promise<{ coupons: CouponForViewModel[]; accounts: string[] }> {
+    ValidatedRequest.handleValidation("GetCouponsForRequest", request);
+
+    const res = await this.queryBus.execute(
+      new GetCouponsForQuery(request.securityId, request.couponId, request.pageIndex, request.pageLength),
+    );
+
+    const coupons: CouponForViewModel[] = res.coupons.map((couponFor) => ({
+      tokenBalance: couponFor.tokenBalance.toString(),
+      nominalValue: couponFor.nominalValue.toString(),
+      decimals: couponFor.decimals.toString(),
+      recordDateReached: couponFor.recordDateReached,
+      coupon: {
+        recordDate: new Date(couponFor.coupon.recordTimeStamp * ONE_THOUSAND),
+        executionDate: new Date(couponFor.coupon.executionTimeStamp * ONE_THOUSAND),
+        rate: couponFor.coupon.rate.toString(),
+        rateDecimals: couponFor.coupon.rateDecimals,
+        startDate: new Date(couponFor.coupon.startTimeStamp * ONE_THOUSAND),
+        endDate: new Date(couponFor.coupon.endTimeStamp * ONE_THOUSAND),
+        fixingDate: new Date(couponFor.coupon.fixingTimeStamp * ONE_THOUSAND),
+        rateStatus: CastRateStatus.toNumber(couponFor.coupon.rateStatus),
+      },
+      couponAmount: {
+        numerator: couponFor.couponAmount.numerator,
+        denominator: couponFor.couponAmount.denominator,
+        recordDateReached: couponFor.couponAmount.recordDateReached,
+      },
+      isDisabled: couponFor.isDisabled,
+    }));
+
+    return { coupons, accounts: res.accounts };
+  }
+
+  @LogError
+  async getCouponAmountFor(request: GetCouponForRequest): Promise<CouponAmountForViewModel> {
+    ValidatedRequest.handleValidation("GetCouponForRequest", request);
+
+    const res = await this.queryBus.execute(
+      new GetCouponAmountForQuery(request.targetId, request.securityId, request.couponId),
+    );
+
+    const couponAmountFor: CouponAmountForViewModel = {
+      numerator: res.numerator,
+      denominator: res.denominator,
+      recordDateReached: res.recordDateReached,
+    };
+
+    return couponAmountFor;
+  }
+
+  @LogError
+  async getCoupon(request: GetCouponRequest): Promise<CouponViewModel> {
+    ValidatedRequest.handleValidation("GetCouponRequest", request);
+
+    const res = await this.queryBus.execute(new GetCouponQuery(request.securityId, request.couponId));
+
+    const coupon: CouponViewModel = {
+      couponId: request.couponId,
+      recordDate: new Date(res.coupon.recordTimeStamp * ONE_THOUSAND),
+      executionDate: new Date(res.coupon.executionTimeStamp * ONE_THOUSAND),
+      rate: res.coupon.rate.toString(),
+      rateDecimals: res.coupon.rateDecimals,
+      startDate: new Date(res.coupon.startTimeStamp * ONE_THOUSAND),
+      endDate: new Date(res.coupon.endTimeStamp * ONE_THOUSAND),
+      fixingDate: new Date(res.coupon.fixingTimeStamp * ONE_THOUSAND),
+      rateStatus: CastRateStatus.toNumber(res.coupon.rateStatus),
+      isDisabled: res.coupon.isDisabled,
+    };
+
+    return coupon;
+  }
+
+  @LogError
+  async getAllCoupons(request: GetAllCouponsRequest): Promise<CouponViewModel[]> {
+    ValidatedRequest.handleValidation("GetAllCouponsRequest", request);
+
+    const count = await this.queryBus.execute(new GetCouponCountQuery(request.securityId));
+
+    if (count.payload == 0) return [];
+
+    const coupons: CouponViewModel[] = [];
+
+    for (let i = 1; i <= count.payload; i++) {
+      const couponRequest = new GetCouponRequest({
+        securityId: request.securityId,
+        couponId: i,
+      });
+
+      const coupon = await this.getCoupon(couponRequest);
+
+      coupons.push(coupon);
+    }
+
+    return coupons;
+  }
+
+  @LogError
+  async getCouponsOrderedList(request: GetCouponsOrderedListRequest): Promise<number[]> {
+    ValidatedRequest.handleValidation("GetCouponsOrderedListRequest", request);
+
+    const { securityId, pageIndex, pageLength } = request;
+
+    const result = await this.queryBus.execute(new GetCouponsOrderedListQuery(securityId, pageIndex, pageLength));
+
+    return result.payload;
+  }
+
+  @LogError
+  async getCouponsOrderedListTotal(request: GetCouponsOrderedListTotalRequest): Promise<number> {
+    ValidatedRequest.handleValidation("GetCouponsOrderedListTotalRequest", request);
+
+    const { securityId } = request;
+
+    const result = await this.queryBus.execute(new GetCouponsOrderedListTotalQuery(securityId));
+
+    return result.payload;
+  }
+
+  @LogError
+  async getCouponHolders(request: GetCouponHoldersRequest): Promise<string[]> {
+    const { securityId, couponId, start, end } = request;
+    ValidatedRequest.handleValidation(GetCouponHoldersRequest.name, request);
+
+    return (await this.queryBus.execute(new GetCouponHoldersQuery(securityId, couponId, start, end))).payload;
+  }
+
+  @LogError
+  async getTotalCouponHolders(request: GetTotalCouponHoldersRequest): Promise<number> {
+    const { securityId, couponId } = request;
+    ValidatedRequest.handleValidation(GetTotalCouponHoldersRequest.name, request);
+
+    return (await this.queryBus.execute(new GetTotalCouponHoldersQuery(securityId, couponId))).payload;
+  }
+
+  @LogError
+  async getCouponFromOrderedListAt(request: GetCouponFromOrderedListAtRequest): Promise<number> {
+    const { securityId, pos } = request;
+    ValidatedRequest.handleValidation(GetCouponFromOrderedListAtRequest.name, request);
+
+    return (await this.queryBus.execute(new GetCouponFromOrderedListAtQuery(securityId, pos))).couponId;
+  }
+}
+
+const CouponToken = new CouponInPort();
+export default CouponToken;

--- a/packages/ats/sdk/src/port/in/coupon/Coupon.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/coupon/Coupon.unit.test.ts
@@ -1,0 +1,833 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMock } from "@golevelup/ts-jest";
+import { CommandBus } from "@core/command/CommandBus";
+import { QueryBus } from "@core/query/QueryBus";
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import { ValidationError } from "@core/validation/ValidationError";
+import LogService from "@service/log/LogService";
+import { CancelCouponCommand } from "@command/bond/coupon/cancel/CancelCouponCommand";
+import { SetCouponCommand } from "@command/bond/coupon/set/SetCouponCommand";
+import { GetCouponForQuery } from "@query/bond/coupons/getCouponFor/GetCouponForQuery";
+import { GetCouponAmountForQuery } from "@query/bond/coupons/getCouponAmountFor/GetCouponAmountForQuery";
+import { GetCouponQuery } from "@query/bond/coupons/getCoupon/GetCouponQuery";
+import { GetCouponCountQuery } from "@query/bond/coupons/getCouponCount/GetCouponCountQuery";
+import { GetCouponsOrderedListQuery } from "@query/bond/coupons/getCouponsOrderedList/GetCouponsOrderedListQuery";
+import { GetCouponsOrderedListTotalQuery } from "@query/bond/coupons/getCouponsOrderedListTotal/GetCouponsOrderedListTotalQuery";
+import { GetCouponHoldersQuery } from "@query/bond/coupons/getCouponHolders/GetCouponHoldersQuery";
+import { GetTotalCouponHoldersQuery } from "@query/bond/coupons/getTotalCouponHolders/GetTotalCouponHoldersQuery";
+import { GetCouponFromOrderedListAtQuery } from "@query/bond/coupons/getCouponFromOrderedListAt/GetCouponFromOrderedListAtQuery";
+import CancelCouponRequest from "../request/bond/CancelCouponRequest";
+import SetCouponRequest from "../request/bond/SetCouponRequest";
+import GetCouponForRequest from "../request/bond/GetCouponForRequest";
+import GetCouponRequest from "../request/bond/GetCouponRequest";
+import GetAllCouponsRequest from "../request/bond/GetAllCouponsRequest";
+import GetCouponsOrderedListRequest from "../request/bond/GetCouponsOrderedListRequest";
+import GetCouponsOrderedListTotalRequest from "../request/bond/GetCouponsOrderedListTotalRequest";
+import GetCouponFromOrderedListAtRequest from "../request/bond/GetCouponFromOrderedListAtRequest";
+import { GetCouponHoldersRequest, GetTotalCouponHoldersRequest } from "../request";
+import { HederaIdPropsFixture, TransactionIdFixture } from "@test/fixtures/shared/DataFixture";
+import {
+  CancelCouponRequestFixture,
+  CouponFixture,
+  GetAllCouponsRequestFixture,
+  GetCouponForRequestFixture,
+  GetCouponHoldersQueryFixture,
+  GetCouponRequestFixture,
+  GetCouponsOrderedListRequestFixture,
+  GetTotalCouponHoldersRequestFixture,
+  SetCouponRequestFixture,
+} from "@test/fixtures/bond/BondFixture";
+import { ONE_THOUSAND } from "@domain/context/shared/SecurityDate";
+import { CastRateStatus } from "@domain/context/bond/RateStatus";
+import { faker } from "@faker-js/faker/.";
+import CouponToken from "./Coupon";
+
+describe("Coupon", () => {
+  let commandBusMock: jest.Mocked<CommandBus>;
+  let queryBusMock: jest.Mocked<QueryBus>;
+
+  let setCouponRequest: SetCouponRequest;
+  let cancelCouponRequest: CancelCouponRequest;
+  let getCouponForRequest: GetCouponForRequest;
+  let getCouponRequest: GetCouponRequest;
+  let getAllCouponsRequest: GetAllCouponsRequest;
+  let getCouponsOrderedListRequest: GetCouponsOrderedListRequest;
+  let getCouponHoldersRequest: GetCouponHoldersRequest;
+  let getTotalCouponHoldersRequest: GetTotalCouponHoldersRequest;
+
+  let handleValidationSpy: jest.SpyInstance;
+
+  const transactionId = TransactionIdFixture.create().id;
+
+  beforeEach(() => {
+    commandBusMock = createMock<CommandBus>();
+    queryBusMock = createMock<QueryBus>();
+    handleValidationSpy = jest.spyOn(ValidatedRequest, "handleValidation");
+    getAllCouponsRequest = new GetAllCouponsRequest(GetAllCouponsRequestFixture.create());
+    getCouponsOrderedListRequest = new GetCouponsOrderedListRequest(GetCouponsOrderedListRequestFixture.create());
+    jest.spyOn(LogService, "logError").mockImplementation(() => {});
+    (CouponToken as any).commandBus = commandBusMock;
+    (CouponToken as any).queryBus = queryBusMock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe("setCoupon", () => {
+    setCouponRequest = new SetCouponRequest(SetCouponRequestFixture.create());
+    it("should set coupon successfully", async () => {
+      const expectedResponse = {
+        payload: 1,
+        transactionId: transactionId,
+      };
+
+      commandBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.setCoupon(setCouponRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("SetCouponRequest", setCouponRequest);
+
+      expect(commandBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new SetCouponCommand(
+          setCouponRequest.securityId,
+          setCouponRequest.recordTimestamp,
+          setCouponRequest.executionTimestamp,
+          setCouponRequest.rate,
+          setCouponRequest.startTimestamp,
+          setCouponRequest.endTimestamp,
+          setCouponRequest.fixingTimestamp,
+          CastRateStatus.fromNumber(setCouponRequest.rateStatus),
+        ),
+      );
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it("should throw an error if command execution fails", async () => {
+      const error = new Error("Command execution failed");
+      commandBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.setCoupon(setCouponRequest)).rejects.toThrow("Command execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("SetCouponRequest", setCouponRequest);
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new SetCouponCommand(
+          setCouponRequest.securityId,
+          setCouponRequest.recordTimestamp,
+          setCouponRequest.executionTimestamp,
+          setCouponRequest.rate,
+          setCouponRequest.startTimestamp,
+          setCouponRequest.endTimestamp,
+          setCouponRequest.fixingTimestamp,
+          CastRateStatus.fromNumber(setCouponRequest.rateStatus),
+        ),
+      );
+    });
+
+    it("should throw error if recordTimestamp is invalid", async () => {
+      setCouponRequest = new SetCouponRequest({
+        ...SetCouponRequestFixture.create(),
+        recordTimestamp: (Math.ceil(new Date().getTime() / 1000) - 100).toString(),
+      });
+
+      await expect(CouponToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if executionTimestamp is invalid", async () => {
+      const time = faker.date.past().getTime();
+      setCouponRequest = new SetCouponRequest({
+        ...SetCouponRequestFixture.create(),
+        recordTimestamp: time.toString(),
+        executionTimestamp: (time - 10).toString(),
+      });
+
+      await expect(CouponToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      setCouponRequest = new SetCouponRequest({
+        ...SetCouponRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if rate is invalid", async () => {
+      setCouponRequest = new SetCouponRequest({
+        ...SetCouponRequestFixture.create(),
+        rate: "invalid",
+      });
+
+      await expect(CouponToken.setCoupon(setCouponRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("cancelCoupon", () => {
+    beforeEach(() => {
+      cancelCouponRequest = new CancelCouponRequest(CancelCouponRequestFixture.create());
+    });
+
+    it("should cancel coupon successfully", async () => {
+      const expectedResponse = {
+        payload: true,
+        transactionId: transactionId,
+      };
+
+      commandBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.cancelCoupon(cancelCouponRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("CancelCouponRequest", cancelCouponRequest);
+
+      expect(commandBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new CancelCouponCommand(cancelCouponRequest.securityId, cancelCouponRequest.couponId),
+      );
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it("should throw an error if command execution fails", async () => {
+      const error = new Error("Command execution failed");
+      commandBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.cancelCoupon(cancelCouponRequest)).rejects.toThrow("Command execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("CancelCouponRequest", cancelCouponRequest);
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new CancelCouponCommand(cancelCouponRequest.securityId, cancelCouponRequest.couponId),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      cancelCouponRequest = new CancelCouponRequest({
+        ...CancelCouponRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.cancelCoupon(cancelCouponRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getCouponFor", () => {
+    beforeEach(() => {
+      getCouponForRequest = new GetCouponForRequest(GetCouponForRequestFixture.create());
+    });
+
+    it("should get coupon for successfully", async () => {
+      const coupon = CouponFixture.create();
+      const expectedResponse = {
+        tokenBalance: BigInt(1000),
+        nominalValue: BigInt(500),
+        decimals: 2,
+        recordDateReached: false,
+        coupon: coupon,
+        couponAmount: {
+          numerator: "10",
+          denominator: "4",
+          recordDateReached: true,
+        },
+        isDisabled: false,
+      };
+
+      queryBusMock.execute.mockResolvedValue({ couponFor: expectedResponse });
+
+      const result = await CouponToken.getCouponFor(getCouponForRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponForQuery(
+          getCouponForRequest.targetId,
+          getCouponForRequest.securityId,
+          getCouponForRequest.couponId,
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          tokenBalance: expectedResponse.tokenBalance.toString(),
+          nominalValue: expectedResponse.nominalValue.toString(),
+          decimals: expectedResponse.decimals.toString(),
+          recordDateReached: expectedResponse.recordDateReached,
+          coupon: expect.objectContaining({
+            recordDate: new Date(coupon.recordTimeStamp * ONE_THOUSAND),
+            executionDate: new Date(coupon.executionTimeStamp * ONE_THOUSAND),
+            rate: coupon.rate.toString(),
+          }),
+          couponAmount: expect.objectContaining({
+            numerator: expectedResponse.couponAmount.numerator,
+            denominator: expectedResponse.couponAmount.denominator,
+            recordDateReached: expectedResponse.couponAmount.recordDateReached,
+          }),
+          isDisabled: expectedResponse.isDisabled,
+        }),
+      );
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponFor(getCouponForRequest)).rejects.toThrow("Query execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponForQuery(
+          getCouponForRequest.targetId,
+          getCouponForRequest.securityId,
+          getCouponForRequest.couponId,
+        ),
+      );
+    });
+
+    it("should throw error if targetId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        targetId: "invalid",
+      });
+
+      await expect(CouponToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if couponId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        couponId: 0,
+      });
+
+      await expect(CouponToken.getCouponFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getCouponAmountFor", () => {
+    beforeEach(() => {
+      getCouponForRequest = new GetCouponForRequest(GetCouponForRequestFixture.create());
+    });
+
+    it("should get coupon amount for successfully", async () => {
+      const expectedResponse = {
+        numerator: "10",
+        denominator: "4",
+        recordDateReached: true,
+      };
+
+      queryBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.getCouponAmountFor(getCouponForRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponAmountForQuery(
+          getCouponForRequest.targetId,
+          getCouponForRequest.securityId,
+          getCouponForRequest.couponId,
+        ),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          numerator: expectedResponse.numerator,
+          denominator: expectedResponse.denominator,
+          recordDateReached: expectedResponse.recordDateReached,
+        }),
+      );
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow("Query execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponForRequest", getCouponForRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponAmountForQuery(
+          getCouponForRequest.targetId,
+          getCouponForRequest.securityId,
+          getCouponForRequest.couponId,
+        ),
+      );
+    });
+
+    it("should throw error if targetId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        targetId: "invalid",
+      });
+
+      await expect(CouponToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if couponId is invalid", async () => {
+      getCouponForRequest = new GetCouponForRequest({
+        ...GetCouponForRequestFixture.create(),
+        couponId: 0,
+      });
+
+      await expect(CouponToken.getCouponAmountFor(getCouponForRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getCoupon", () => {
+    getCouponRequest = new GetCouponRequest(GetCouponRequestFixture.create());
+
+    it("should get coupon successfully", async () => {
+      const expectedResponse = {
+        coupon: CouponFixture.create(),
+      };
+
+      queryBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.getCoupon(getCouponRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponRequest", getCouponRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponQuery(getCouponRequest.securityId, getCouponRequest.couponId),
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          couponId: getCouponRequest.couponId,
+          recordDate: new Date(expectedResponse.coupon.recordTimeStamp * ONE_THOUSAND),
+          executionDate: new Date(expectedResponse.coupon.executionTimeStamp * ONE_THOUSAND),
+          rate: expectedResponse.coupon.rate.toString(),
+        }),
+      );
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCoupon(getCouponRequest)).rejects.toThrow("Query execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponRequest", getCouponRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponQuery(getCouponRequest.securityId, getCouponRequest.couponId),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      getCouponRequest = new GetCouponRequest({
+        ...GetCouponRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.getCoupon(getCouponRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if couponId is invalid", async () => {
+      getCouponRequest = new GetCouponRequest({
+        ...GetCouponRequestFixture.create(),
+        couponId: 0,
+      });
+
+      await expect(CouponToken.getCoupon(getCouponRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getAllCoupons", () => {
+    getAllCouponsRequest = new GetAllCouponsRequest(GetAllCouponsRequestFixture.create());
+
+    it("should get all coupons successfully", async () => {
+      const expectedResponse = {
+        payload: 1,
+      };
+
+      const expectedResponse2 = {
+        coupon: CouponFixture.create(),
+      };
+
+      queryBusMock.execute.mockResolvedValueOnce(expectedResponse).mockResolvedValueOnce(expectedResponse2);
+
+      const result = await CouponToken.getAllCoupons(getAllCouponsRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(2);
+
+      expect(queryBusMock.execute).toHaveBeenNthCalledWith(1, new GetCouponCountQuery(getAllCouponsRequest.securityId));
+
+      expect(queryBusMock.execute).toHaveBeenNthCalledWith(2, new GetCouponQuery(getAllCouponsRequest.securityId, 1));
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            couponId: 1,
+            recordDate: new Date(expectedResponse2.coupon.recordTimeStamp * ONE_THOUSAND),
+            executionDate: new Date(expectedResponse2.coupon.executionTimeStamp * ONE_THOUSAND),
+            rate: expectedResponse2.coupon.rate.toString(),
+            rateDecimals: expectedResponse2.coupon.rateDecimals,
+            startDate: new Date(expectedResponse2.coupon.startTimeStamp * ONE_THOUSAND),
+            endDate: new Date(expectedResponse2.coupon.endTimeStamp * ONE_THOUSAND),
+            fixingDate: new Date(expectedResponse2.coupon.fixingTimeStamp * ONE_THOUSAND),
+            rateStatus: CastRateStatus.toNumber(expectedResponse2.coupon.rateStatus),
+            isDisabled: expectedResponse2.coupon.isDisabled,
+          },
+        ]),
+      );
+    });
+
+    it("should return empty array if count is 0", async () => {
+      const expectedResponse = {
+        payload: 0,
+      };
+      queryBusMock.execute.mockResolvedValueOnce(expectedResponse);
+
+      const result = await CouponToken.getAllCoupons(getAllCouponsRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponCountQuery(getAllCouponsRequest.securityId));
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getAllCoupons(getAllCouponsRequest)).rejects.toThrow("Query execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetAllCouponsRequest", getAllCouponsRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponCountQuery(getAllCouponsRequest.securityId));
+    });
+  });
+
+  describe("getCouponsOrderedList", () => {
+    it("should get coupons ordered list successfully", async () => {
+      const expectedResponse = [1, 2, 3, 4, 5];
+
+      queryBusMock.execute.mockResolvedValue({ payload: expectedResponse });
+
+      const result = await CouponToken.getCouponsOrderedList(getCouponsOrderedListRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponsOrderedListQuery(
+          getCouponsOrderedListRequest.securityId,
+          getCouponsOrderedListRequest.pageIndex,
+          getCouponsOrderedListRequest.pageLength,
+        ),
+      );
+
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponsOrderedList(getCouponsOrderedListRequest)).rejects.toThrow(
+        "Query execution failed",
+      );
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponsOrderedListQuery(
+          getCouponsOrderedListRequest.securityId,
+          getCouponsOrderedListRequest.pageIndex,
+          getCouponsOrderedListRequest.pageLength,
+        ),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      const invalidRequest = new GetCouponsOrderedListRequest({
+        securityId: "invalid",
+        pageIndex: 0,
+        pageLength: 10,
+      });
+
+      await expect(CouponToken.getCouponsOrderedList(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should work with mocked query handler", async () => {
+      const expectedResponse = [10, 20, 30];
+
+      const mockHandler = {
+        execute: jest.fn().mockResolvedValue({ payload: expectedResponse }),
+      };
+
+      queryBusMock.execute.mockImplementation((query) => {
+        if (query instanceof GetCouponsOrderedListQuery) {
+          return mockHandler.execute(query);
+        }
+        return Promise.resolve({});
+      });
+
+      const result = await CouponToken.getCouponsOrderedList(getCouponsOrderedListRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListRequest", getCouponsOrderedListRequest);
+      expect(mockHandler.execute).toHaveBeenCalledWith(
+        new GetCouponsOrderedListQuery(
+          getCouponsOrderedListRequest.securityId,
+          getCouponsOrderedListRequest.pageIndex,
+          getCouponsOrderedListRequest.pageLength,
+        ),
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getCouponsOrderedListTotal", () => {
+    it("should get coupons ordered list total successfully", async () => {
+      const securityId = HederaIdPropsFixture.create().value;
+      const request = new GetCouponsOrderedListTotalRequest({ securityId });
+
+      queryBusMock.execute.mockResolvedValue({ payload: 5 });
+
+      const result = await CouponToken.getCouponsOrderedListTotal(request);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("GetCouponsOrderedListTotalRequest", request);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponsOrderedListTotalQuery(securityId));
+
+      expect(result).toEqual(5);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const securityId = HederaIdPropsFixture.create().value;
+      const request = new GetCouponsOrderedListTotalRequest({ securityId });
+      const error = new Error("Query execution failed");
+
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponsOrderedListTotal(request)).rejects.toThrow("Query execution failed");
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      const request = new GetCouponsOrderedListTotalRequest({ securityId: "invalid" });
+
+      await expect(CouponToken.getCouponsOrderedListTotal(request)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getCouponHolders", () => {
+    getCouponHoldersRequest = new GetCouponHoldersRequest(GetCouponHoldersQueryFixture.create());
+
+    it("should get coupon holders successfully", async () => {
+      const expectedResponse = {
+        payload: [transactionId],
+      };
+
+      queryBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.getCouponHolders(getCouponHoldersRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(GetCouponHoldersRequest.name, getCouponHoldersRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponHoldersQuery(
+          getCouponHoldersRequest.securityId,
+          getCouponHoldersRequest.couponId,
+          getCouponHoldersRequest.start,
+          getCouponHoldersRequest.end,
+        ),
+      );
+
+      expect(result).toStrictEqual(expectedResponse.payload);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow("Query execution failed");
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(GetCouponHoldersRequest.name, getCouponHoldersRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetCouponHoldersQuery(
+          getCouponHoldersRequest.securityId,
+          getCouponHoldersRequest.couponId,
+          getCouponHoldersRequest.start,
+          getCouponHoldersRequest.end,
+        ),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      getCouponHoldersRequest = new GetCouponHoldersRequest({
+        ...GetCouponHoldersQueryFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if couponId is invalid", async () => {
+      getCouponHoldersRequest = new GetCouponHoldersRequest({
+        ...GetCouponHoldersQueryFixture.create(),
+        couponId: -1,
+      });
+
+      await expect(CouponToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if start is invalid", async () => {
+      getCouponHoldersRequest = new GetCouponHoldersRequest({
+        ...GetCouponHoldersQueryFixture.create(),
+        start: -1,
+      });
+
+      await expect(CouponToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if end is invalid", async () => {
+      getCouponHoldersRequest = new GetCouponHoldersRequest({
+        ...GetCouponHoldersQueryFixture.create(),
+        end: -1,
+      });
+
+      await expect(CouponToken.getCouponHolders(getCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getTotalCouponHolders", () => {
+    getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest(GetTotalCouponHoldersRequestFixture.create());
+
+    it("should get total coupon holders successfully", async () => {
+      const expectedResponse = {
+        payload: 1,
+      };
+
+      queryBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await CouponToken.getTotalCouponHolders(getTotalCouponHoldersRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(GetTotalCouponHoldersRequest.name, getTotalCouponHoldersRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetTotalCouponHoldersQuery(getTotalCouponHoldersRequest.securityId, getTotalCouponHoldersRequest.couponId),
+      );
+
+      expect(result).toEqual(expectedResponse.payload);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(
+        "Query execution failed",
+      );
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(GetTotalCouponHoldersRequest.name, getTotalCouponHoldersRequest);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetTotalCouponHoldersQuery(getTotalCouponHoldersRequest.securityId, getTotalCouponHoldersRequest.couponId),
+      );
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest({
+        ...GetTotalCouponHoldersRequestFixture.create(),
+        securityId: "invalid",
+      });
+
+      await expect(CouponToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if couponId is invalid", async () => {
+      getTotalCouponHoldersRequest = new GetTotalCouponHoldersRequest({
+        ...GetTotalCouponHoldersRequestFixture.create(),
+        couponId: -1,
+      });
+
+      await expect(CouponToken.getTotalCouponHolders(getTotalCouponHoldersRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getCouponFromOrderedListAt", () => {
+    it("should get coupon from ordered list at position successfully", async () => {
+      const securityId = HederaIdPropsFixture.create().value;
+      const pos = 3;
+      const request = new GetCouponFromOrderedListAtRequest({ securityId, pos });
+
+      queryBusMock.execute.mockResolvedValue({ couponId: 7 });
+
+      const result = await CouponToken.getCouponFromOrderedListAt(request);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(GetCouponFromOrderedListAtRequest.name, request);
+
+      expect(queryBusMock.execute).toHaveBeenCalledTimes(1);
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(new GetCouponFromOrderedListAtQuery(securityId, pos));
+
+      expect(result).toEqual(7);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const securityId = HederaIdPropsFixture.create().value;
+      const request = new GetCouponFromOrderedListAtRequest({ securityId, pos: 1 });
+      const error = new Error("Query execution failed");
+
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(CouponToken.getCouponFromOrderedListAt(request)).rejects.toThrow("Query execution failed");
+    });
+
+    it("should throw error if securityId is invalid", async () => {
+      const request = new GetCouponFromOrderedListAtRequest({ securityId: "invalid", pos: 1 });
+
+      await expect(CouponToken.getCouponFromOrderedListAt(request)).rejects.toThrow(ValidationError);
+    });
+  });
+});

--- a/packages/ats/sdk/src/port/in/index.ts
+++ b/packages/ats/sdk/src/port/in/index.ts
@@ -5,6 +5,7 @@ import Role from "./role/Role";
 import Security from "./security/Security";
 import Equity from "./equity/Equity";
 import Bond from "./bond/Bond";
+import Coupon from "./coupon/Coupon";
 import Event from "./event/Event";
 import Network from "./network/Network";
 import Factory from "./factory/Factory";
@@ -21,6 +22,7 @@ export {
   Security,
   Equity,
   Bond,
+  Coupon,
   Account,
   Role,
   Event,
@@ -42,6 +44,7 @@ export * from "./response";
 export * from "./security/Security";
 export * from "./equity/Equity";
 export * from "./bond/Bond";
+export * from "./coupon/Coupon";
 export * from "./account/Account";
 export * from "./role/Role";
 export * from "./event/Event";

--- a/packages/ats/sdk/src/port/in/request/bond/GetCouponsForRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/bond/GetCouponsForRequest.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { MIN_ID } from "@domain/context/security/CorporateAction";
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import FormatValidation from "../FormatValidation";
+
+export default class GetCouponsForRequest extends ValidatedRequest<GetCouponsForRequest> {
+  securityId: string;
+  couponId: number;
+  pageIndex: number;
+  pageLength: number;
+
+  constructor({
+    securityId,
+    couponId,
+    pageIndex,
+    pageLength,
+  }: {
+    securityId: string;
+    couponId: number;
+    pageIndex: number;
+    pageLength: number;
+  }) {
+    super({
+      securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
+      couponId: FormatValidation.checkNumber({
+        max: undefined,
+        min: MIN_ID,
+      }),
+      pageIndex: FormatValidation.checkNumber({
+        max: undefined,
+        min: 0,
+      }),
+      pageLength: FormatValidation.checkNumber({
+        max: undefined,
+        min: 1,
+      }),
+    });
+    this.securityId = securityId;
+    this.couponId = couponId;
+    this.pageIndex = pageIndex;
+    this.pageLength = pageLength;
+  }
+}

--- a/packages/ats/sdk/src/port/in/request/index.ts
+++ b/packages/ats/sdk/src/port/in/request/index.ts
@@ -25,6 +25,7 @@ import GetVotingRightsForRequest from "./equity/GetVotingRightsForRequest";
 import GetVotingRightsRequest from "./equity/GetVotingRightsRequest";
 import GetAllVotingRightsRequest from "./equity/GetAllVotingRightsRequest";
 import GetCouponForRequest from "./bond/GetCouponForRequest";
+import GetCouponsForRequest from "./bond/GetCouponsForRequest";
 import GetCouponRequest from "./bond/GetCouponRequest";
 import GetCouponsOrderedListRequest from "./bond/GetCouponsOrderedListRequest";
 import GetCouponsOrderedListTotalRequest from "./bond/GetCouponsOrderedListTotalRequest";
@@ -253,6 +254,7 @@ export {
   GetVotingRightsRequest,
   GetAllVotingRightsRequest,
   GetCouponForRequest,
+  GetCouponsForRequest,
   GetCouponFromOrderedListAtRequest,
   GetPrincipalForRequest,
   GetCouponRequest,

--- a/packages/ats/sdk/src/port/in/response/CouponForViewModel.ts
+++ b/packages/ats/sdk/src/port/in/response/CouponForViewModel.ts
@@ -1,9 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { QueryResponse } from "@core/query/QueryResponse";
+import CouponAmountForViewModel from "./CouponAmountForViewModel";
 
 export default interface CouponForViewModel extends QueryResponse {
   tokenBalance: string;
+  nominalValue: string;
   decimals: string;
+  recordDateReached: boolean;
+  coupon: {
+    recordDate: Date;
+    executionDate: Date;
+    rate: string;
+    rateDecimals: number;
+    startDate: Date;
+    endDate: Date;
+    fixingDate: Date;
+    rateStatus: number;
+  };
+  couponAmount: CouponAmountForViewModel;
   isDisabled: boolean;
 }

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -20,6 +20,7 @@ import { HederaId } from "@domain/context/shared/HederaId";
 import {
   AccessControlFacet__factory,
   BondRead__factory,
+  Coupon__factory,
   CapFacet__factory,
   ClearingActionsFacet__factory,
   ClearingHoldCreationFacet__factory,
@@ -456,15 +457,86 @@ export class RPCQueryAdapter {
   async getCouponFor(address: EvmAddress, target: EvmAddress, coupon: number): Promise<CouponFor> {
     LogService.logTrace(`Getting Coupon for`);
 
-    const couponFor = await this.connect(BondRead__factory, address.toString()).getCouponFor(coupon, target.toString());
+    const couponFor = await this.connect(Coupon__factory, address.toString()).getCouponFor(coupon, target.toString());
 
-    return new CouponFor(new BigDecimal(couponFor.tokenBalance), Number(couponFor.decimals), couponFor.isDisabled);
+    const couponDomain = new Coupon(
+      Number(couponFor.coupon.recordDate),
+      Number(couponFor.coupon.executionDate),
+      new BigDecimal(couponFor.coupon.rate.toString()),
+      Number(couponFor.coupon.rateDecimals),
+      Number(couponFor.coupon.startDate),
+      Number(couponFor.coupon.endDate),
+      Number(couponFor.coupon.fixingDate),
+      CastRateStatus.fromBigint(couponFor.coupon.rateStatus),
+    );
+
+    const couponAmountDomain = new CouponAmountFor(
+      couponFor.couponAmount.numerator.toString(),
+      couponFor.couponAmount.denominator.toString(),
+      couponFor.couponAmount.recordDateReached,
+    );
+
+    return new CouponFor(
+      new BigDecimal(couponFor.tokenBalance),
+      new BigDecimal(couponFor.nominalValue),
+      Number(couponFor.decimals),
+      couponFor.recordDateReached,
+      couponDomain,
+      couponAmountDomain,
+      couponFor.isDisabled,
+    );
+  }
+
+  async getCouponsFor(
+    address: EvmAddress,
+    couponId: number,
+    pageIndex: number,
+    pageLength: number,
+  ): Promise<{ coupons: CouponFor[]; accounts: string[] }> {
+    LogService.logTrace(`Getting Coupons for`);
+
+    const result = await this.connect(Coupon__factory, address.toString()).getCouponsFor(
+      couponId,
+      pageIndex,
+      pageLength,
+    );
+
+    const coupons = result.couponFor_.map((couponFor) => {
+      const couponDomain = new Coupon(
+        Number(couponFor.coupon.recordDate),
+        Number(couponFor.coupon.executionDate),
+        new BigDecimal(couponFor.coupon.rate.toString()),
+        Number(couponFor.coupon.rateDecimals),
+        Number(couponFor.coupon.startDate),
+        Number(couponFor.coupon.endDate),
+        Number(couponFor.coupon.fixingDate),
+        CastRateStatus.fromBigint(couponFor.coupon.rateStatus),
+      );
+
+      const couponAmountDomain = new CouponAmountFor(
+        couponFor.couponAmount.numerator.toString(),
+        couponFor.couponAmount.denominator.toString(),
+        couponFor.couponAmount.recordDateReached,
+      );
+
+      return new CouponFor(
+        new BigDecimal(couponFor.tokenBalance),
+        new BigDecimal(couponFor.nominalValue),
+        Number(couponFor.decimals),
+        couponFor.recordDateReached,
+        couponDomain,
+        couponAmountDomain,
+        couponFor.isDisabled,
+      );
+    });
+
+    return { coupons, accounts: [...result.accounts_] };
   }
 
   async getCouponAmountFor(address: EvmAddress, target: EvmAddress, coupon: number): Promise<CouponAmountFor> {
     LogService.logTrace(`Getting Coupon Amount for`);
 
-    const couponAmountFor = await this.connect(BondRead__factory, address.toString()).getCouponAmountFor(
+    const couponAmountFor = await this.connect(Coupon__factory, address.toString()).getCouponAmountFor(
       coupon,
       target.toString(),
     );
@@ -487,7 +559,7 @@ export class RPCQueryAdapter {
   async getCoupon(address: EvmAddress, coupon: number): Promise<Coupon> {
     LogService.logTrace(`Getting Coupon`);
 
-    const { registeredCoupon_, isDisabled_ } = await this.connect(BondRead__factory, address.toString()).getCoupon(
+    const { registeredCoupon_, isDisabled_ } = await this.connect(Coupon__factory, address.toString()).getCoupon(
       coupon,
     );
 
@@ -508,7 +580,7 @@ export class RPCQueryAdapter {
   async getCouponCount(address: EvmAddress): Promise<number> {
     LogService.logTrace(`Getting Coupon count`);
 
-    const couponCount = await this.connect(BondRead__factory, address.toString()).getCouponCount();
+    const couponCount = await this.connect(Coupon__factory, address.toString()).getCouponCount();
 
     return Number(couponCount);
   }
@@ -1304,13 +1376,13 @@ export class RPCQueryAdapter {
 
   async getCouponHolders(address: EvmAddress, couponId: number, start: number, end: number): Promise<string[]> {
     LogService.logTrace(`Getting coupon holders for coupon ${couponId} for security ${address.toString()}`);
-    return await this.connect(BondRead__factory, address.toString()).getCouponHolders(couponId, start, end);
+    return await this.connect(Coupon__factory, address.toString()).getCouponHolders(couponId, start, end);
   }
 
   async getTotalCouponHolders(address: EvmAddress, couponId: number): Promise<number> {
     LogService.logTrace(`Getting total coupon holders for coupon ${couponId} for security ${address.toString()}`);
 
-    const total = await this.connect(BondRead__factory, address.toString()).getTotalCouponHolders(couponId);
+    const total = await this.connect(Coupon__factory, address.toString()).getTotalCouponHolders(couponId);
 
     return Number(total);
   }
@@ -1318,7 +1390,7 @@ export class RPCQueryAdapter {
   async getCouponFromOrderedListAt(address: EvmAddress, pos: number): Promise<number> {
     LogService.logTrace(`Getting coupon from ordered list at position ${pos} for security ${address.toString()}`);
 
-    const couponId = await this.connect(BondRead__factory, address.toString()).getCouponFromOrderedListAt(pos);
+    const couponId = await this.connect(Coupon__factory, address.toString()).getCouponFromOrderedListAt(pos);
 
     return Number(couponId);
   }
@@ -1330,22 +1402,22 @@ export class RPCQueryAdapter {
 
     // If pagination parameters are provided, use paginated call
     if (pageIndex !== undefined && pageLength !== undefined) {
-      const couponIds = await this.connect(BondRead__factory, address.toString()).getCouponsOrderedList(
+      const couponIds = await this.connect(Coupon__factory, address.toString()).getCouponsOrderedList(
         pageIndex,
         pageLength,
       );
-      return couponIds.map((id) => Number(id));
+      return couponIds.map((id: bigint) => Number(id));
     }
 
     // Otherwise get all coupons (simulate by getting first page with large length)
-    const couponIds = await this.connect(BondRead__factory, address.toString()).getCouponsOrderedList(0, 1000);
-    return couponIds.map((id) => Number(id));
+    const couponIds = await this.connect(Coupon__factory, address.toString()).getCouponsOrderedList(0, 1000);
+    return couponIds.map((id: bigint) => Number(id));
   }
 
   async getCouponsOrderedListTotal(address: EvmAddress): Promise<number> {
     LogService.logTrace(`Getting coupons ordered list total for security ${address.toString()}`);
 
-    const total = await this.connect(BondRead__factory, address.toString()).getCouponsOrderedListTotal();
+    const total = await this.connect(Coupon__factory, address.toString()).getCouponsOrderedListTotal();
 
     return Number(total);
   }

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -57,6 +57,7 @@ import { SecurityDataBuilder } from "@domain/context/util/SecurityDataBuilder";
 import {
   AccessControlFacet__factory,
   Bond__factory,
+  Coupon__factory,
   CapFacet__factory,
   ClearingActionsFacet__factory,
   ClearingHoldCreationFacet__factory,
@@ -645,7 +646,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
       endDate: ${endDate},
       fixingDate: ${fixingDate}`,
     );
-    const couponStruct: IBondTypes.CouponStruct = {
+    const couponStruct = {
       recordDate: recordDate.toBigInt(),
       executionDate: executionDate.toBigInt(),
       rate: rate.toBigInt(),
@@ -657,7 +658,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     };
 
     return this.executeTransaction(
-      Bond__factory.connect(security.toString(), this.getSignerOrProvider()),
+      Coupon__factory.connect(security.toString(), this.getSignerOrProvider()),
       "setCoupon",
       [couponStruct],
       GAS.SET_COUPON,
@@ -669,7 +670,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     LogService.logTrace(`Cancelling coupon: ${couponId} for bond: ${security}`);
 
     return this.executeTransaction(
-      Bond__factory.connect(security.toString(), this.getSignerOrProvider()),
+      Coupon__factory.connect(security.toString(), this.getSignerOrProvider()),
       "cancelCoupon",
       [couponId],
       GAS.CANCEL_COUPON,


### PR DESCRIPTION
## Summary
Split coupon functionality out of the Bond facet into a dedicated Coupon facet family on the lib-diamond architecture.

## Contracts
- New `layer_2/coupon/` facet family with four variants: standard `CouponFacet`, `CouponFixedRateFacet`, `CouponKpiLinkedRateFacet`, `CouponSustainabilityPerformanceTargetRateFacet`. Interface split into `ICoupon` (functions, events, errors) + `ICouponTypes` (structs, enum).
- New `CouponStorageWrapper` library with a dedicated storage slot. Coupon storage and logic moved out of `BondStorageWrapper`; legacy bond-stored coupon IDs preserved via a deprecated field for backward compatibility.
- Bond facet (`Bond`, `BondRead`, `IBond`, `IBondTypes`, `IBondManagement`, `IBondRead`) no longer exposes coupon API.
- `BondUSAFacetBase` and `BondUSAReadFacetBase` drop coupon selectors. `BondUSAFixedRateFacet` no longer overrides the (now-orphaned) `_prepareCoupon` hook.
- Rate-specialisation handled via a single `_prepareCoupon` virtual hook on `Coupon.sol`: `CouponFixedRateFacet` fills the rate from `InterestRateStorageWrapper.getRate()` at write time; `CouponKpiLinkedRateFacet` validates input and lets the rate compute on-the-fly at fixing date; `CouponSustainabilityPerformanceTargetRateFacet` differs only by resolver key.
- `CouponStorageWrapper.getCoupon` performs on-the-fly KPI/SPT rate calculation when `fixingDate` has passed, mirroring the previous in-Bond behaviour.
- `Factory.checkBondDates` now also requires `maturityDate` to be strictly future (`WrongTimestamp`).
- Test infrastructure: four `Coupon*FacetTimeTravel` aliases plus two `ERC1594*RateFacetTimeTravel` aliases. `MockBond` simplified to bond-only fields. `TimeTravelFacet` exposes a test-only helper to seed deprecated bond-stored coupon IDs.

## SDK
- New `Coupon` port (`packages/ats/sdk/src/port/in/coupon/Coupon.ts`) exposing `setCoupon`, `cancelCoupon`, `getCoupon`, `getCouponFor`, `getCouponsFor`, `getCouponAmountFor`, `getAllCoupons`, `getCouponCount`, `getCouponHolders`, `getTotalCouponHolders`, `getCouponFromOrderedListAt`, `getCouponsOrderedList`, `getCouponsOrderedListTotal`. Coupon methods removed from `Bond` port.
- New `GetCouponsForQuery` / handler / request / view-model.
- `RPCQueryAdapter` and `RPCTransactionAdapter` route coupon calls through `Coupon__factory` instead of `Bond__factory`/`BondRead__factory`. `getCouponFor` now returns the enriched `CouponFor` (token balance, nominal value, decimals, recordDateReached, coupon, couponAmount, isDisabled).
- Bond/Equity test fixtures grant `_NOMINAL_VALUE_ROLE` to the deployer.

## Web
- `apps/ats/web/src/services/SDKService.ts` reroutes all coupon calls from the `Bond` port to the new `Coupon` port.

## Test plan
- [ ] CI green on contracts, SDK, web
- [ ] Smoke: deploy a fixed-rate, KPI-linked, and SPT bond; set/cancel coupons; verify rates fill at fixing date