### PR TITLE
refactor: split voting into dedicated Diamond facet

### DIFF
--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -635,6 +635,9 @@ bytes32 constant _KPIS_LATEST_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KE
 // keccak256('security.token.standard.nominalValue.resolverKey');
 bytes32 constant _NOMINAL_VALUE_RESOLVER_KEY = 0x48903d4da8b1f0a5e9a9874be74ec5d2f8043d4d5b65cc093173c3dae103df8f;
 
+// keccak256("security.token.standard.voting.resolverKey")
+bytes32 constant _VOTING_RESOLVER_KEY = 0x97e0ffc69e5d5dd7c4635bfce0a5cf15b1c313433d49edbd55813da224b03768;
+
 // Layer 3 Resolver Keys
 
 // keccak256("security.token.standard.transferAndLock.resolverKey")

--- a/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
@@ -4,13 +4,11 @@ pragma solidity >=0.8.0 <0.9.0;
 import { _EQUITY_STORAGE_POSITION } from "../../constants/storagePositions.sol";
 import {
     DIVIDEND_CORPORATE_ACTION_TYPE,
-    VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
     BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE,
     SNAPSHOT_RESULT_ID,
     SNAPSHOT_TASK_TYPE,
     BALANCE_ADJUSTMENT_TASK_TYPE,
     KPI_EQUITY_DIVIDEND_DATA,
-    KPI_EQUITY_VOTING_DATA,
     KPI_EQUITY_BALANCE_ADJ
 } from "../../constants/values.sol";
 import { IEquity } from "../../facets/layer_2/equity/IEquity.sol";
@@ -94,41 +92,6 @@ library EquityStorageWrapper {
 
         ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newDividend.recordDate, SNAPSHOT_TASK_TYPE);
         ScheduledTasksStorageWrapper.addScheduledSnapshot(newDividend.recordDate, actionId);
-    }
-
-    function setVoting(
-        IEquity.Voting calldata newVoting
-    ) internal returns (bytes32 corporateActionId_, uint256 voteID_) {
-        bytes memory data = abi.encode(newVoting);
-
-        (corporateActionId_, voteID_) = CorporateActionsStorageWrapper.addCorporateAction(
-            VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
-            data
-        );
-
-        initVotingRights(corporateActionId_, data);
-    }
-
-    function cancelVoting(uint256 voteId) internal returns (bool success_) {
-        IEquity.RegisteredVoting memory registeredVoting;
-        bytes32 corporateActionId;
-        (registeredVoting, corporateActionId, ) = getVoting(voteId);
-        if (registeredVoting.voting.recordDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
-            revert IEquity.VotingAlreadyRecorded(corporateActionId, voteId);
-        }
-        CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
-        success_ = true;
-    }
-
-    function initVotingRights(bytes32 actionId, bytes memory data) internal {
-        if (actionId == bytes32(0)) {
-            revert IEquity.VotingRightsCreationFailed();
-        }
-
-        IEquity.Voting memory newVoting = abi.decode(data, (IEquity.Voting));
-
-        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newVoting.recordDate, SNAPSHOT_TASK_TYPE);
-        ScheduledTasksStorageWrapper.addScheduledSnapshot(newVoting.recordDate, actionId);
     }
 
     function setScheduledBalanceAdjustment(
@@ -250,12 +213,13 @@ library EquityStorageWrapper {
         uint256 dividendID,
         address account
     ) internal view returns (IEquity.DividendFor memory dividendFor_) {
-        (IEquity.RegisteredDividend memory registeredDividend, , ) = getDividends(dividendID);
+        (IEquity.RegisteredDividend memory registeredDividend, , bool isDisabled) = getDividends(dividendID);
 
         dividendFor_.amount = registeredDividend.dividend.amount;
         dividendFor_.amountDecimals = registeredDividend.dividend.amountDecimals;
         dividendFor_.recordDate = registeredDividend.dividend.recordDate;
         dividendFor_.executionDate = registeredDividend.dividend.executionDate;
+        dividendFor_.isDisabled = isDisabled;
 
         (
             dividendFor_.tokenBalance,
@@ -309,83 +273,6 @@ library EquityStorageWrapper {
 
         if (registeredDividend.snapshotId != 0)
             return SnapshotsStorageWrapper.totalTokenHoldersAt(registeredDividend.snapshotId);
-
-        return ERC1410StorageWrapper.getTotalTokenHolders();
-    }
-
-    function getVoting(
-        uint256 voteID
-    )
-        internal
-        view
-        returns (IEquity.RegisteredVoting memory registeredVoting_, bytes32 corporateActionId_, bool isDisabled_)
-    {
-        corporateActionId_ = CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(
-            VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
-            voteID - 1
-        );
-
-        bytes memory data;
-        (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
-
-        _checkUnexpectedError(data.length == 0, KPI_EQUITY_VOTING_DATA);
-        (registeredVoting_.voting) = abi.decode(data, (IEquity.Voting));
-
-        registeredVoting_.snapshotId = CorporateActionsStorageWrapper.getUintResultAt(
-            corporateActionId_,
-            SNAPSHOT_RESULT_ID
-        );
-    }
-
-    /**
-     * @dev returns the properties and related snapshots (if any) of a voting.
-     *
-     * @param voteID The vote Id
-     * @param account The account
-     */
-    function getVotingFor(uint256 voteID, address account) internal view returns (IEquity.VotingFor memory votingFor_) {
-        (IEquity.RegisteredVoting memory registeredVoting, , ) = getVoting(voteID);
-
-        votingFor_.recordDate = registeredVoting.voting.recordDate;
-        votingFor_.data = registeredVoting.voting.data;
-
-        (
-            votingFor_.tokenBalance,
-            votingFor_.decimals,
-            votingFor_.recordDateReached
-        ) = getSnapshotBalanceForIfDateReached(
-            registeredVoting.voting.recordDate,
-            registeredVoting.snapshotId,
-            account
-        );
-    }
-
-    function getVotingCount() internal view returns (uint256 votingCount_) {
-        return CorporateActionsStorageWrapper.getCorporateActionCountByType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE);
-    }
-
-    function getVotingHolders(
-        uint256 voteID,
-        uint256 pageIndex,
-        uint256 pageLength
-    ) internal view returns (address[] memory holders_) {
-        (IEquity.RegisteredVoting memory registeredVoting, , ) = getVoting(voteID);
-
-        if (registeredVoting.voting.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return holders_;
-
-        if (registeredVoting.snapshotId != 0)
-            return SnapshotsStorageWrapper.tokenHoldersAt(registeredVoting.snapshotId, pageIndex, pageLength);
-
-        return ERC1410StorageWrapper.getTokenHolders(pageIndex, pageLength);
-    }
-
-    function getTotalVotingHolders(uint256 voteID) internal view returns (uint256) {
-        (IEquity.RegisteredVoting memory registeredVoting, , ) = getVoting(voteID);
-
-        if (registeredVoting.voting.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return 0;
-
-        if (registeredVoting.snapshotId != 0)
-            return SnapshotsStorageWrapper.totalTokenHoldersAt(registeredVoting.snapshotId);
 
         return ERC1410StorageWrapper.getTotalTokenHolders();
     }

--- a/packages/ats/contracts/contracts/domain/asset/voting/VotingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/voting/VotingStorageWrapper.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {
+    VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
+    SNAPSHOT_RESULT_ID,
+    SNAPSHOT_TASK_TYPE
+} from "../../../constants/values.sol";
+import { CorporateActionsStorageWrapper } from "../../core/CorporateActionsStorageWrapper.sol";
+import { ERC1410StorageWrapper } from "../ERC1410StorageWrapper.sol";
+import { ERC20StorageWrapper } from "../ERC20StorageWrapper.sol";
+import { ERC3643StorageWrapper } from "../../core/ERC3643StorageWrapper.sol";
+import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
+import { IVoting } from "../../../facets/layer_2/voting/IVoting.sol";
+import { IVotingTypes } from "../../../facets/layer_2/voting/IVotingTypes.sol";
+import { ScheduledTasksStorageWrapper } from "../ScheduledTasksStorageWrapper.sol";
+import { SnapshotsStorageWrapper } from "../SnapshotsStorageWrapper.sol";
+import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
+
+library VotingStorageWrapper {
+    function setVoting(
+        IVotingTypes.Voting calldata newVoting
+    ) internal returns (bytes32 corporateActionId_, uint256 voteID_) {
+        bytes memory data = abi.encode(newVoting);
+
+        (corporateActionId_, voteID_) = CorporateActionsStorageWrapper.addCorporateAction(
+            VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
+            data
+        );
+
+        initVotingRights(corporateActionId_, data);
+
+        emit IVoting.VotingSet(
+            corporateActionId_,
+            voteID_,
+            EvmAccessors.getMsgSender(),
+            newVoting.recordDate,
+            newVoting.data
+        );
+    }
+
+    function cancelVoting(uint256 voteId) internal returns (bool success_) {
+        (IVoting.RegisteredVoting memory registeredVoting, bytes32 corporateActionId, ) = getVoting(voteId);
+
+        if (registeredVoting.voting.recordDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
+            revert IVoting.VotingAlreadyRecorded(corporateActionId, voteId);
+        }
+
+        CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
+        success_ = true;
+
+        emit IVoting.VotingCancelled(voteId, EvmAccessors.getMsgSender());
+    }
+
+    function initVotingRights(bytes32 actionId, bytes memory data) internal {
+        if (actionId == bytes32(0)) {
+            revert IVoting.VotingRightsCreationFailed();
+        }
+
+        IVotingTypes.Voting memory newVoting = abi.decode(data, (IVotingTypes.Voting));
+
+        ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(newVoting.recordDate, SNAPSHOT_TASK_TYPE);
+        ScheduledTasksStorageWrapper.addScheduledSnapshot(newVoting.recordDate, actionId);
+    }
+
+    function getVoting(
+        uint256 voteID
+    )
+        internal
+        view
+        returns (IVoting.RegisteredVoting memory registeredVoting_, bytes32 corporateActionId_, bool isDisabled_)
+    {
+        corporateActionId_ = CorporateActionsStorageWrapper.getCorporateActionIdByTypeIndex(
+            VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
+            voteID - 1
+        );
+
+        bytes memory data;
+        (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
+
+        assert(data.length > 0);
+        (registeredVoting_.voting) = abi.decode(data, (IVotingTypes.Voting));
+
+        registeredVoting_.snapshotId = CorporateActionsStorageWrapper.getUintResultAt(
+            corporateActionId_,
+            SNAPSHOT_RESULT_ID
+        );
+    }
+
+    function getVotingFor(
+        uint256 voteID,
+        address account
+    ) internal view returns (IVotingTypes.VotingFor memory votingFor_) {
+        (IVoting.RegisteredVoting memory registeredVoting, , bool isDisabled_) = getVoting(voteID);
+
+        votingFor_.recordDate = registeredVoting.voting.recordDate;
+        votingFor_.data = registeredVoting.voting.data;
+        votingFor_.isDisabled = isDisabled_;
+
+        (
+            votingFor_.tokenBalance,
+            votingFor_.decimals,
+            votingFor_.recordDateReached
+        ) = getSnapshotBalanceForIfDateReached(
+            registeredVoting.voting.recordDate,
+            registeredVoting.snapshotId,
+            account
+        );
+    }
+
+    function getVotingCount() internal view returns (uint256 votingCount_) {
+        return CorporateActionsStorageWrapper.getCorporateActionCountByType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE);
+    }
+
+    function getVotingHolders(
+        uint256 voteID,
+        uint256 pageIndex,
+        uint256 pageLength
+    ) internal view returns (address[] memory holders_) {
+        (IVoting.RegisteredVoting memory registeredVoting, , ) = getVoting(voteID);
+
+        if (registeredVoting.voting.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return holders_;
+
+        if (registeredVoting.snapshotId != 0)
+            return SnapshotsStorageWrapper.tokenHoldersAt(registeredVoting.snapshotId, pageIndex, pageLength);
+
+        return ERC1410StorageWrapper.getTokenHolders(pageIndex, pageLength);
+    }
+
+    function getTotalVotingHolders(uint256 voteID) internal view returns (uint256) {
+        (IVoting.RegisteredVoting memory registeredVoting, , ) = getVoting(voteID);
+
+        if (registeredVoting.voting.recordDate >= TimeTravelStorageWrapper.getBlockTimestamp()) return 0;
+
+        if (registeredVoting.snapshotId != 0)
+            return SnapshotsStorageWrapper.totalTokenHoldersAt(registeredVoting.snapshotId);
+
+        return ERC1410StorageWrapper.getTotalTokenHolders();
+    }
+
+    function getSnapshotBalanceForIfDateReached(
+        uint256 date,
+        uint256 snapshotId,
+        address account
+    ) private view returns (uint256 balance_, uint8 decimals_, bool dateReached_) {
+        if (date >= TimeTravelStorageWrapper.getBlockTimestamp()) return (balance_, decimals_, dateReached_);
+        dateReached_ = true;
+
+        balance_ = (snapshotId != 0)
+            ? SnapshotsStorageWrapper.getTotalBalanceOfAtSnapshot(snapshotId, account)
+            : ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(account, date);
+
+        decimals_ = (snapshotId != 0)
+            ? SnapshotsStorageWrapper.decimalsAtSnapshot(snapshotId)
+            : ERC20StorageWrapper.decimalsAdjustedAt(date);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/equity/Equity.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/equity/Equity.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.0 <0.9.0;
 import { _CORPORATE_ACTION_ROLE } from "../../../constants/roles.sol";
 import {
     DIVIDEND_CORPORATE_ACTION_TYPE,
-    VOTING_RIGHTS_CORPORATE_ACTION_TYPE,
     BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE
 } from "../../../constants/values.sol";
 import { IEquity } from "./IEquity.sol";
@@ -34,27 +33,6 @@ abstract contract Equity is IEquity, Modifiers {
             _newDividend.executionDate,
             _newDividend.amount,
             _newDividend.amountDecimals
-        );
-    }
-
-    function setVoting(
-        Voting calldata _newVoting
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(_CORPORATE_ACTION_ROLE)
-        onlyValidTimestamp(_newVoting.recordDate)
-        returns (uint256 voteID_)
-    {
-        bytes32 corporateActionID;
-        (corporateActionID, voteID_) = EquityStorageWrapper.setVoting(_newVoting);
-        emit IEquity.VotingSet(
-            corporateActionID,
-            voteID_,
-            EvmAccessors.getMsgSender(),
-            _newVoting.recordDate,
-            _newVoting.data
         );
     }
 
@@ -89,15 +67,6 @@ abstract contract Equity is IEquity, Modifiers {
         (success_) = EquityStorageWrapper.cancelDividend(_dividendId);
         if (success_) {
             emit IEquity.DividendCancelled(_dividendId, EvmAccessors.getMsgSender());
-        }
-    }
-
-    function cancelVoting(
-        uint256 _voteId
-    ) external override onlyUnpaused onlyRole(_CORPORATE_ACTION_ROLE) returns (bool success_) {
-        (success_) = EquityStorageWrapper.cancelVoting(_voteId);
-        if (success_) {
-            emit IEquity.VotingCancelled(_voteId, EvmAccessors.getMsgSender());
         }
     }
 
@@ -166,47 +135,6 @@ abstract contract Equity is IEquity, Modifiers {
 
     function getTotalDividendHolders(uint256 _dividendID) external view returns (uint256) {
         return EquityStorageWrapper.getTotalDividendHolders(_dividendID);
-    }
-
-    function getVoting(
-        uint256 _voteID
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE, _voteID - 1)
-        returns (RegisteredVoting memory registeredVoting_, bool isDisabled_)
-    {
-        (registeredVoting_, , isDisabled_) = EquityStorageWrapper.getVoting(_voteID);
-    }
-
-    function getVotingFor(
-        uint256 _voteID,
-        address _account
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE, _voteID - 1)
-        returns (VotingFor memory votingFor_)
-    {
-        return EquityStorageWrapper.getVotingFor(_voteID, _account);
-    }
-
-    function getVotingCount() external view override returns (uint256 votingCount_) {
-        return EquityStorageWrapper.getVotingCount();
-    }
-
-    function getVotingHolders(
-        uint256 _voteID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_) {
-        return EquityStorageWrapper.getVotingHolders(_voteID, _pageIndex, _pageLength);
-    }
-
-    function getTotalVotingHolders(uint256 _voteID) external view returns (uint256) {
-        return EquityStorageWrapper.getTotalVotingHolders(_voteID);
     }
 
     function getScheduledBalanceAdjustment(

--- a/packages/ats/contracts/contracts/facets/layer_2/equity/IEquity.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/equity/IEquity.sol
@@ -22,16 +22,6 @@ interface IEquity {
         uint8 nominalValueDecimals;
     }
 
-    struct Voting {
-        uint256 recordDate;
-        bytes data;
-    }
-
-    struct RegisteredVoting {
-        Voting voting;
-        uint256 snapshotId;
-    }
-
     struct Dividend {
         uint256 recordDate;
         uint256 executionDate;
@@ -61,28 +51,11 @@ interface IEquity {
         bool recordDateReached;
     }
 
-    struct VotingFor {
-        uint256 tokenBalance;
-        uint256 recordDate;
-        bytes data;
-        uint8 decimals;
-        bool recordDateReached;
-        bool isDisabled;
-    }
-
     struct ScheduledBalanceAdjustment {
         uint256 executionDate;
         uint256 factor;
         uint8 decimals;
     }
-
-    event VotingSet(
-        bytes32 corporateActionId,
-        uint256 voteId,
-        address indexed operator,
-        uint256 indexed recordDate,
-        bytes data
-    );
 
     event DividendSet(
         bytes32 corporateActionId,
@@ -105,15 +78,11 @@ interface IEquity {
 
     event DividendCancelled(uint256 dividendId, address indexed operator);
 
-    event VotingCancelled(uint256 voteId, address indexed operator);
-
     event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator);
 
     error DividendCreationFailed();
-    error VotingRightsCreationFailed();
     error BalanceAdjustmentCreationFailed();
     error DividendAlreadyExecuted(bytes32 corporateActionId, uint256 dividendId);
-    error VotingAlreadyRecorded(bytes32 corporateActionId, uint256 voteId);
     error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId);
 
     /**
@@ -121,12 +90,6 @@ interface IEquity {
      * @dev Can only be called by an account with the corporate actions role
      */
     function setDividend(Dividend calldata _newDividend) external returns (uint256 dividendID_);
-
-    /**
-     * @notice Sets a new voting
-     * @dev Can only be called by an account with the corporate actions role
-     */
-    function setVoting(Voting calldata _newVoting) external returns (uint256 voteID_);
 
     /**
      * @notice Sets a new scheduled balance adjustment
@@ -137,7 +100,6 @@ interface IEquity {
     ) external returns (uint256 balanceAdjustmentID_);
 
     function cancelDividend(uint256 _dividendID) external returns (bool success_);
-    function cancelVoting(uint256 _voteID) external returns (bool success_);
     function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) external returns (bool success_);
 
     function getEquityDetails() external view returns (EquityDetailsData memory equityDetailsData_);
@@ -188,37 +150,6 @@ interface IEquity {
      * @notice Returns the total number of token holders for a given dividend
      */
     function getTotalDividendHolders(uint256 _dividendID) external view returns (uint256);
-
-    /**
-     * @notice Returns the details of a previously registered voting
-     */
-    function getVoting(
-        uint256 _voteID
-    ) external view returns (RegisteredVoting memory registeredVoting_, bool isDisabled_);
-
-    /**
-     * @notice Returns the voting details for an account
-     */
-    function getVotingFor(uint256 _voteID, address _account) external view returns (VotingFor memory votingFor_);
-
-    /**
-     * @notice Returns the total number of votings
-     */
-    function getVotingCount() external view returns (uint256 votingCount_);
-
-    /**
-     * @notice Returns the list of token holders for a given voting
-     */
-    function getVotingHolders(
-        uint256 _voteID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_);
-
-    /**
-     * @notice Returns the total number of token holders for a given voting
-     */
-    function getTotalVotingHolders(uint256 _voteID) external view returns (uint256);
 
     /**
      * @notice Returns the details of a previously scheduled balance adjustment

--- a/packages/ats/contracts/contracts/facets/layer_2/voting/IVoting.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/voting/IVoting.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IVotingTypes } from "./IVotingTypes.sol";
+
+/// @title IVoting
+/// @notice Interface for voting rights management functionality
+interface IVoting is IVotingTypes {
+    /// @notice Emitted when a voting is set
+    /// @param corporateActionId The ID of the corporate action
+    /// @param voteId The ID of the voting
+    /// @param operator The address of the operator who set the voting
+    /// @param recordDate The voting record date
+    /// @param data The voting payload
+    event VotingSet(
+        bytes32 corporateActionId,
+        uint256 voteId,
+        address indexed operator,
+        uint256 indexed recordDate,
+        bytes data
+    );
+
+    /// @notice Emitted when a voting is cancelled
+    /// @param voteId The ID of the cancelled voting
+    /// @param operator The address of the operator who cancelled the voting
+    event VotingCancelled(uint256 voteId, address indexed operator);
+
+    /// @notice Raised when voting rights creation fails
+    error VotingRightsCreationFailed();
+
+    /// @notice Raised when attempting to cancel a voting that has already been recorded
+    /// @param corporateActionId The ID of the corporate action
+    /// @param voteId The ID of the voting
+    error VotingAlreadyRecorded(bytes32 corporateActionId, uint256 voteId);
+
+    /// @notice Sets a new voting for the security
+    /// @param _newVoting The new voting to be set
+    /// @return voteID_ The created voting identifier
+    function setVoting(Voting calldata _newVoting) external returns (uint256 voteID_);
+
+    /// @notice Cancels an existing voting
+    /// @param _voteId The ID of the voting to be cancelled
+    /// @return success_ Whether the cancellation was successful
+    function cancelVoting(uint256 _voteId) external returns (bool success_);
+
+    /// @notice Retrieves a registered voting by its ID
+    /// @param _voteID The ID of the voting to retrieve
+    /// @return registeredVoting_ The registered voting data
+    /// @return isDisabled_ Whether the voting is disabled
+    function getVoting(
+        uint256 _voteID
+    ) external view returns (RegisteredVoting memory registeredVoting_, bool isDisabled_);
+
+    /// @notice Retrieves voting information for a specific account and voting ID
+    /// @dev Return value includes user balance at voting record date
+    /// @param _voteID The ID of the voting
+    /// @param _account The account address
+    /// @return votingFor_ Voting information for the specified account
+    function getVotingFor(uint256 _voteID, address _account) external view returns (VotingFor memory votingFor_);
+
+    /// @notice Retrieves the total number of votings
+    /// @return votingCount_ The total count of votings
+    function getVotingCount() external view returns (uint256 votingCount_);
+
+    /// @notice Retrieves the list of token holders for a given voting with pagination
+    /// @param _voteID The ID of the voting
+    /// @param _pageIndex The page index for pagination
+    /// @param _pageLength The page length for pagination
+    /// @return holders_ The paginated list of token holder addresses
+    function getVotingHolders(
+        uint256 _voteID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (address[] memory holders_);
+
+    /// @notice Retrieves the total number of token holders for a given voting
+    /// @param _voteID The ID of the voting
+    /// @return totalHolders_ The total number of token holders at the voting record date
+    function getTotalVotingHolders(uint256 _voteID) external view returns (uint256 totalHolders_);
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/voting/IVotingTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/voting/IVotingTypes.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/// @title IVotingTypes
+/// @notice Voting data structures for token voting mechanisms
+interface IVotingTypes {
+    /// @notice Voting data structure
+    struct Voting {
+        uint256 recordDate;
+        bytes data;
+    }
+
+    /// @notice Registered voting with snapshot information
+    struct RegisteredVoting {
+        Voting voting;
+        uint256 snapshotId;
+    }
+
+    /// @notice Voting details for a specific account
+    struct VotingFor {
+        uint256 tokenBalance;
+        uint256 recordDate;
+        bytes data;
+        uint8 decimals;
+        bool recordDateReached;
+        bool isDisabled;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/voting/Voting.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/voting/Voting.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IVoting } from "./IVoting.sol";
+import { IVotingTypes } from "./IVotingTypes.sol";
+import { _CORPORATE_ACTION_ROLE } from "../../../constants/roles.sol";
+import { VOTING_RIGHTS_CORPORATE_ACTION_TYPE } from "../../../constants/values.sol";
+import { Modifiers } from "../../../services/Modifiers.sol";
+import { VotingStorageWrapper } from "../../../domain/asset/voting/VotingStorageWrapper.sol";
+
+/// @title Voting
+/// @notice Abstract contract for voting rights management
+abstract contract Voting is IVoting, Modifiers {
+    /// @notice Sets a new voting for the security
+    /// @param _newVoting The new voting to be set
+    /// @return voteID_ The created voting identifier
+    function setVoting(
+        IVotingTypes.Voting calldata _newVoting
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(_CORPORATE_ACTION_ROLE)
+        onlyValidTimestamp(_newVoting.recordDate)
+        returns (uint256 voteID_)
+    {
+        (, voteID_) = VotingStorageWrapper.setVoting(_newVoting);
+    }
+
+    /// @notice Cancels an existing voting
+    /// @param _voteId The ID of the voting to be cancelled
+    /// @return success_ Whether the cancellation was successful
+    function cancelVoting(
+        uint256 _voteId
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(_CORPORATE_ACTION_ROLE)
+        onlyMatchingActionType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE, _voteId - 1)
+        returns (bool success_)
+    {
+        success_ = VotingStorageWrapper.cancelVoting(_voteId);
+    }
+
+    /// @notice Retrieves a registered voting by its ID
+    /// @param _voteID The ID of the voting to retrieve
+    /// @return registeredVoting_ The registered voting data
+    /// @return isDisabled_ Whether the voting is disabled
+    function getVoting(
+        uint256 _voteID
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE, _voteID - 1)
+        returns (IVotingTypes.RegisteredVoting memory registeredVoting_, bool isDisabled_)
+    {
+        (registeredVoting_, , isDisabled_) = VotingStorageWrapper.getVoting(_voteID);
+    }
+
+    /// @notice Retrieves voting information for a specific account and voting ID
+    /// @param _voteID The ID of the voting
+    /// @param _account The account address
+    /// @return votingFor_ Voting information for the specified account
+    function getVotingFor(
+        uint256 _voteID,
+        address _account
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(VOTING_RIGHTS_CORPORATE_ACTION_TYPE, _voteID - 1)
+        returns (IVotingTypes.VotingFor memory votingFor_)
+    {
+        return VotingStorageWrapper.getVotingFor(_voteID, _account);
+    }
+
+    /// @notice Retrieves the total number of votings
+    /// @return votingCount_ The total count of votings
+    function getVotingCount() external view override returns (uint256 votingCount_) {
+        return VotingStorageWrapper.getVotingCount();
+    }
+
+    /// @notice Retrieves the list of token holders for a given voting with pagination
+    /// @param _voteID The ID of the voting
+    /// @param _pageIndex The page index for pagination
+    /// @param _pageLength The page length for pagination
+    /// @return holders_ The paginated list of token holder addresses
+    function getVotingHolders(
+        uint256 _voteID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view override returns (address[] memory holders_) {
+        return VotingStorageWrapper.getVotingHolders(_voteID, _pageIndex, _pageLength);
+    }
+
+    /// @notice Retrieves the total number of token holders for a given voting
+    /// @param _voteID The ID of the voting
+    /// @return totalHolders_ The total number of token holders at the voting record date
+    function getTotalVotingHolders(uint256 _voteID) external view override returns (uint256 totalHolders_) {
+        return VotingStorageWrapper.getTotalVotingHolders(_voteID);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/voting/VotingFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/voting/VotingFacet.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { Voting } from "./Voting.sol";
+import { IVoting } from "./IVoting.sol";
+import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _VOTING_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
+
+/// @title VotingFacet
+/// @notice Concrete implementation of voting rights management facet
+contract VotingFacet is Voting, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _VOTING_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        staticFunctionSelectors_ = new bytes4[](7);
+        uint256 selectorIndex;
+        staticFunctionSelectors_[selectorIndex++] = this.setVoting.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.cancelVoting.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getVoting.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getVotingFor.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getVotingCount.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getVotingHolders.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.getTotalVotingHolders.selector;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        staticInterfaceIds_ = new bytes4[](1);
+        staticInterfaceIds_[0] = type(IVoting).interfaceId;
+    }
+}

--- a/packages/ats/contracts/contracts/facets/layer_3/equityUSA/EquityUSAFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/equityUSA/EquityUSAFacet.sol
@@ -15,7 +15,7 @@ contract EquityUSAFacet is EquityUSA, IStaticFunctionSelectors {
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](24);
+        staticFunctionSelectors_ = new bytes4[](17);
         staticFunctionSelectors_[selectorIndex++] = this._initialize_equityUSA.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getEquityDetails.selector;
         staticFunctionSelectors_[selectorIndex++] = this.setDividend.selector;
@@ -23,10 +23,6 @@ contract EquityUSAFacet is EquityUSA, IStaticFunctionSelectors {
         staticFunctionSelectors_[selectorIndex++] = this.getDividendFor.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getDividendAmountFor.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getDividendsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setVoting.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getVoting.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getVotingFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getVotingCount.selector;
         staticFunctionSelectors_[selectorIndex++] = this.setScheduledBalanceAdjustment.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getScheduledBalanceAdjustment.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getScheduledBalanceAdjustmentCount.selector;
@@ -35,10 +31,7 @@ contract EquityUSAFacet is EquityUSA, IStaticFunctionSelectors {
         staticFunctionSelectors_[selectorIndex++] = this.getTotalSecurityHolders.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getDividendHolders.selector;
         staticFunctionSelectors_[selectorIndex++] = this.getTotalDividendHolders.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getVotingHolders.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getTotalVotingHolders.selector;
         staticFunctionSelectors_[selectorIndex++] = this.cancelDividend.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.cancelVoting.selector;
         staticFunctionSelectors_[selectorIndex++] = this.cancelScheduledBalanceAdjustment.selector;
     }
 

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IEquity.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IEquity.sol
@@ -27,16 +27,6 @@ interface TRexIEquity {
         uint8 nominalValueDecimals;
     }
 
-    struct Voting {
-        uint256 recordDate;
-        bytes data;
-    }
-
-    struct RegisteredVoting {
-        Voting voting;
-        uint256 snapshotId;
-    }
-
     struct Dividend {
         uint256 recordDate;
         uint256 executionDate;
@@ -66,28 +56,11 @@ interface TRexIEquity {
         bool recordDateReached;
     }
 
-    struct VotingFor {
-        uint256 tokenBalance;
-        uint256 recordDate;
-        bytes data;
-        uint8 decimals;
-        bool recordDateReached;
-        bool isDisabled;
-    }
-
     struct ScheduledBalanceAdjustment {
         uint256 executionDate;
         uint256 factor;
         uint8 decimals;
     }
-
-    event VotingSet(
-        bytes32 corporateActionId,
-        uint256 voteId,
-        address indexed operator,
-        uint256 indexed recordDate,
-        bytes data
-    );
 
     event DividendSet(
         bytes32 corporateActionId,
@@ -110,15 +83,11 @@ interface TRexIEquity {
 
     event DividendCancelled(uint256 dividendId, address indexed operator);
 
-    event VotingCancelled(uint256 voteId, address indexed operator);
-
     event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator);
 
     error DividendCreationFailed();
-    error VotingRightsCreationFailed();
     error BalanceAdjustmentCreationFailed();
     error DividendAlreadyExecuted(bytes32 corporateActionId, uint256 dividendId);
-    error VotingAlreadyRecorded(bytes32 corporateActionId, uint256 voteId);
     error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId);
 
     /**
@@ -126,12 +95,6 @@ interface TRexIEquity {
      * @dev Can only be called by an account with the corporate actions role
      */
     function setDividend(Dividend calldata _newDividend) external returns (uint256 dividendID_);
-
-    /**
-     * @notice Sets a new voting
-     * @dev Can only be called by an account with the corporate actions role
-     */
-    function setVoting(Voting calldata _newVoting) external returns (uint256 voteID_);
 
     /**
      * @notice Sets a new scheduled balance adjustment
@@ -142,7 +105,6 @@ interface TRexIEquity {
     ) external returns (uint256 balanceAdjustmentID_);
 
     function cancelDividend(uint256 _dividendID) external returns (bool success_);
-    function cancelVoting(uint256 _voteID) external returns (bool success_);
     function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) external returns (bool success_);
 
     function getEquityDetails() external view returns (EquityDetailsData memory equityDetailsData_);
@@ -193,37 +155,6 @@ interface TRexIEquity {
      * @notice Returns the total number of token holders for a given dividend
      */
     function getTotalDividendHolders(uint256 _dividendID) external view returns (uint256);
-
-    /**
-     * @notice Returns the details of a previously registered voting
-     */
-    function getVoting(
-        uint256 _voteID
-    ) external view returns (RegisteredVoting memory registeredVoting_, bool isDisabled_);
-
-    /**
-     * @notice Returns the voting details for an account
-     */
-    function getVotingFor(uint256 _voteID, address _account) external view returns (VotingFor memory votingFor_);
-
-    /**
-     * @notice Returns the total number of votings
-     */
-    function getVotingCount() external view returns (uint256 votingCount_);
-
-    /**
-     * @notice Returns the list of token holders for a given voting
-     */
-    function getVotingHolders(
-        uint256 _voteID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_);
-
-    /**
-     * @notice Returns the total number of token holders for a given voting
-     */
-    function getTotalVotingHolders(uint256 _voteID) external view returns (uint256);
 
     /**
      * @notice Returns the details of a previously scheduled balance adjustment

--- a/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/voting/VotingFacetTimeTravel.sol
+++ b/packages/ats/contracts/contracts/test/testTimeTravel/facetsTimeTravel/voting/VotingFacetTimeTravel.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { VotingFacet } from "../../../../facets/layer_2/voting/VotingFacet.sol";
+
+contract VotingFacetTimeTravel is VotingFacet {}

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-14T15:09:42.335Z
- * Facets: 73
+ * Generated: 2026-04-14T16:45:43.547Z
+ * Facets: 74
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -92,6 +92,7 @@ import {
   TransferAndLockFixedRateFacet__factory,
   TransferAndLockKpiLinkedRateFacet__factory,
   TransferAndLockSustainabilityPerformanceTargetRateFacet__factory,
+  VotingFacet__factory,
   AccessControlFacetTimeTravel__factory,
   AdjustBalancesFacetTimeTravel__factory,
   BondUSAFacetTimeTravel__factory,
@@ -163,6 +164,7 @@ import {
   TransferAndLockFixedRateFacetTimeTravel__factory,
   TransferAndLockKpiLinkedRateFacetTimeTravel__factory,
   TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory,
+  VotingFacetTimeTravel__factory,
 } from "@contract-types";
 import { getLibLinks } from "./orchestratorLibraries";
 
@@ -4327,14 +4329,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x564387f9",
       },
       {
-        name: "cancelVoting",
-        signature: {
-          full: "function cancelVoting(uint256 _voteId) returns (bool success_)",
-          canonical: "cancelVoting(uint256)",
-        },
-        selector: "0x549bdd6e",
-      },
-      {
         name: "getDividend",
         signature: {
           full: "function getDividend(uint256 _dividendID) view returns (((uint256 recordDate, uint256 executionDate, uint256 amount, uint8 amountDecimals) dividend, uint256 snapshotId) registeredDividend_, bool isDisabled_)",
@@ -4431,46 +4425,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xbd007c8f",
       },
       {
-        name: "getTotalVotingHolders",
-        signature: {
-          full: "function getTotalVotingHolders(uint256 _voteID) view returns (uint256)",
-          canonical: "getTotalVotingHolders(uint256)",
-        },
-        selector: "0x92c51818",
-      },
-      {
-        name: "getVoting",
-        signature: {
-          full: "function getVoting(uint256 _voteID) view returns (((uint256 recordDate, bytes data) voting, uint256 snapshotId) registeredVoting_, bool isDisabled_)",
-          canonical: "getVoting(uint256)",
-        },
-        selector: "0x3afc7282",
-      },
-      {
-        name: "getVotingCount",
-        signature: {
-          full: "function getVotingCount() view returns (uint256 votingCount_)",
-          canonical: "getVotingCount()",
-        },
-        selector: "0x9c2aab5e",
-      },
-      {
-        name: "getVotingFor",
-        signature: {
-          full: "function getVotingFor(uint256 _voteID, address _account) view returns ((uint256 tokenBalance, uint256 recordDate, bytes data, uint8 decimals, bool recordDateReached, bool isDisabled) votingFor_)",
-          canonical: "getVotingFor(uint256,address)",
-        },
-        selector: "0x7633eccf",
-      },
-      {
-        name: "getVotingHolders",
-        signature: {
-          full: "function getVotingHolders(uint256 _voteID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getVotingHolders(uint256,uint256,uint256)",
-        },
-        selector: "0x009f64ac",
-      },
-      {
         name: "setDividend",
         signature: {
           full: "function setDividend((uint256 recordDate, uint256 executionDate, uint256 amount, uint8 amountDecimals) _newDividend) returns (uint256 dividendID_)",
@@ -4485,14 +4439,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "setScheduledBalanceAdjustment((uint256,uint256,uint8))",
         },
         selector: "0xd1661084",
-      },
-      {
-        name: "setVoting",
-        signature: {
-          full: "function setVoting((uint256 recordDate, bytes data) _newVoting) returns (uint256 voteID_)",
-          canonical: "setVoting((uint256,bytes))",
-        },
-        selector: "0x5adaa49e",
       },
     ],
     events: [
@@ -4527,22 +4473,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "ScheduledBalanceAdjustmentSet(bytes32,uint256,address,uint256,uint256,uint256)",
         },
         topic0: "0x71cd63a6f86ff487645dcceb29d3eac904f16d7006cfa7b1da3ea951a77a9666",
-      },
-      {
-        name: "VotingCancelled",
-        signature: {
-          full: "event VotingCancelled(uint256 voteId, address indexed operator)",
-          canonical: "VotingCancelled(uint256,address)",
-        },
-        topic0: "0x0ca8f69518859b63e253a165f70a3ef3ad0db94215d1703ebcadd269c4c860bc",
-      },
-      {
-        name: "VotingSet",
-        signature: {
-          full: "event VotingSet(bytes32 corporateActionId, uint256 voteId, address indexed operator, uint256 indexed recordDate, bytes data)",
-          canonical: "VotingSet(bytes32,uint256,address,uint256,bytes)",
-        },
-        topic0: "0x5ca20e6ec9818c8d574ae3452d46ed4c9dc9d8df2ffa263150507c7e9124ac2f",
       },
     ],
     errors: [
@@ -4620,19 +4550,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
         selector: "0xc9622656",
-      },
-      {
-        name: "VotingAlreadyRecorded",
-        signature: {
-          full: "error VotingAlreadyRecorded(bytes32 corporateActionId, uint256 voteId)",
-          canonical: "VotingAlreadyRecorded(bytes32,uint256)",
-        },
-        selector: "0x7a2e2617",
-      },
-      {
-        name: "VotingRightsCreationFailed",
-        signature: { full: "error VotingRightsCreationFailed()", canonical: "VotingRightsCreationFailed()" },
-        selector: "0x0cc16600",
       },
       {
         name: "WrongDates",
@@ -11866,12 +11783,161 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) =>
       new TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
   },
+
+  VotingFacet: {
+    name: "VotingFacet",
+    resolverKey: {
+      name: "_VOTING_RESOLVER_KEY",
+      value: "0x97e0ffc69e5d5dd7c4635bfce0a5cf15b1c313433d49edbd55813da224b03768",
+    },
+    inheritance: ["Voting", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "cancelVoting",
+        signature: {
+          full: "function cancelVoting(uint256 _voteId) returns (bool success_)",
+          canonical: "cancelVoting(uint256)",
+        },
+        selector: "0x549bdd6e",
+      },
+      {
+        name: "getTotalVotingHolders",
+        signature: {
+          full: "function getTotalVotingHolders(uint256 _voteID) view returns (uint256 totalHolders_)",
+          canonical: "getTotalVotingHolders(uint256)",
+        },
+        selector: "0x92c51818",
+      },
+      {
+        name: "getVoting",
+        signature: {
+          full: "function getVoting(uint256 _voteID) view returns (((uint256 recordDate, bytes data) voting, uint256 snapshotId) registeredVoting_, bool isDisabled_)",
+          canonical: "getVoting(uint256)",
+        },
+        selector: "0x3afc7282",
+      },
+      {
+        name: "getVotingCount",
+        signature: {
+          full: "function getVotingCount() view returns (uint256 votingCount_)",
+          canonical: "getVotingCount()",
+        },
+        selector: "0x9c2aab5e",
+      },
+      {
+        name: "getVotingFor",
+        signature: {
+          full: "function getVotingFor(uint256 _voteID, address _account) view returns ((uint256 tokenBalance, uint256 recordDate, bytes data, uint8 decimals, bool recordDateReached, bool isDisabled) votingFor_)",
+          canonical: "getVotingFor(uint256,address)",
+        },
+        selector: "0x7633eccf",
+      },
+      {
+        name: "getVotingHolders",
+        signature: {
+          full: "function getVotingHolders(uint256 _voteID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getVotingHolders(uint256,uint256,uint256)",
+        },
+        selector: "0x009f64ac",
+      },
+      {
+        name: "setVoting",
+        signature: {
+          full: "function setVoting((uint256 recordDate, bytes data) _newVoting) returns (uint256 voteID_)",
+          canonical: "setVoting((uint256,bytes))",
+        },
+        selector: "0x5adaa49e",
+      },
+    ],
+    events: [
+      {
+        name: "VotingCancelled",
+        signature: {
+          full: "event VotingCancelled(uint256 voteId, address indexed operator)",
+          canonical: "VotingCancelled(uint256,address)",
+        },
+        topic0: "0x0ca8f69518859b63e253a165f70a3ef3ad0db94215d1703ebcadd269c4c860bc",
+      },
+      {
+        name: "VotingSet",
+        signature: {
+          full: "event VotingSet(bytes32 corporateActionId, uint256 voteId, address indexed operator, uint256 indexed recordDate, bytes data)",
+          canonical: "VotingSet(bytes32,uint256,address,uint256,bytes)",
+        },
+        topic0: "0x5ca20e6ec9818c8d574ae3452d46ed4c9dc9d8df2ffa263150507c7e9124ac2f",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "VotingAlreadyRecorded",
+        signature: {
+          full: "error VotingAlreadyRecorded(bytes32 corporateActionId, uint256 voteId)",
+          canonical: "VotingAlreadyRecorded(bytes32,uint256)",
+        },
+        selector: "0x7a2e2617",
+      },
+      {
+        name: "VotingRightsCreationFailed",
+        signature: { full: "error VotingRightsCreationFailed()", canonical: "VotingRightsCreationFailed()" },
+        selector: "0x0cc16600",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+    ],
+    factory: (signer) => new VotingFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) => new VotingFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
 };
 
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 73 as const;
+export const TOTAL_FACETS = 74 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).
@@ -12492,12 +12558,17 @@ export const STORAGE_WRAPPER_REGISTRY: Record<string, StorageWrapperDefinition> 
     name: "TimeTravelStorageWrapper",
     methods: [],
   },
+
+  VotingStorageWrapper: {
+    name: "VotingStorageWrapper",
+    methods: [],
+  },
 };
 
 /**
  * Total number of storage wrapper contracts in the registry.
  */
-export const TOTAL_STORAGE_WRAPPERS = 33 as const;
+export const TOTAL_STORAGE_WRAPPERS = 34 as const;
 
 /**
  * All role identifiers extracted from contracts.

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -24,10 +24,10 @@ import { EQUITY_CONFIG_ID } from "../constants";
 import { atsRegistry } from "../atsRegistry";
 
 /**
- * Equity-specific facets list (41 facets total).
+ * Equity-specific facets list (42 facets total).
  *
  * This is an explicit positive list of all facets required for equity tokens.
- * Includes all common facets plus EquityUSAFacet.
+ * Includes all common facets plus EquityUSAFacet and VotingFacet.
  *
  * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
  * so we only include DiamondFacet to avoid selector collisions.
@@ -89,6 +89,7 @@ const EQUITY_FACETS = [
   "ScheduledSnapshotsFacet",
   "SsiManagementFacet",
   "TransferAndLockFacet",
+  "VotingFacet",
 
   // Jurisdiction-Specific (1)
   "EquityUSAFacet",
@@ -99,7 +100,7 @@ const EQUITY_FACETS = [
  *
  * Thin wrapper that calls the generic core operation with equity-specific data:
  * - Configuration ID: EQUITY_CONFIG_ID
- * - Facet list: EQUITY_FACETS (43 facets)
+ * - Facet list: EQUITY_FACETS (42 facets)
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.

--- a/packages/ats/contracts/test/contracts/integration/layer_1/equity/equity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/equity/equity.test.ts
@@ -11,6 +11,7 @@ import {
   Lock,
   IHold,
   type IERC1410,
+  type VotingFacet,
   Kyc,
   SsiManagement,
   ClearingActionsFacet,
@@ -71,6 +72,7 @@ describe("Equity Tests", () => {
   let signer_C: HardhatEthersSigner;
 
   let equityFacet: EquityUSA;
+  let votingFacet: VotingFacet;
   let accessControlFacet: AccessControl;
   let pauseFacet: Pause;
   let lockFacet: Lock;
@@ -79,10 +81,10 @@ describe("Equity Tests", () => {
   let timeTravelFacet: TimeTravelFacet;
   let kycFacet: Kyc;
   let ssiManagementFacet: SsiManagement;
+  let scheduledTasksFacet: ScheduledCrossOrderedTasks;
   let clearingActionsFacet: ClearingActionsFacet;
   let clearingTransferFacet: ClearingTransferFacet;
   let freezeFacet: FreezeFacet;
-  let scheduledTasksFacet: ScheduledCrossOrderedTasks;
 
   async function deploySecurityFixtureSinglePartition() {
     const base = await deployEquityTokenFixture();
@@ -112,7 +114,8 @@ describe("Equity Tests", () => {
     erc1410Facet = await ethers.getContractAt("IERC1410", diamond.target, signer_A);
     timeTravelFacet = await ethers.getContractAt("TimeTravelFacet", diamond.target, signer_A);
     accessControlFacet = await ethers.getContractAt("AccessControl", diamond.target, signer_A);
-    equityFacet = await ethers.getContractAt("EquityUSAFacetTimeTravel", diamond.target, signer_A);
+    equityFacet = await ethers.getContractAt("EquityUSA", diamond.target, signer_A);
+    votingFacet = await ethers.getContractAt("VotingFacet", diamond.target, signer_A);
     kycFacet = await ethers.getContractAt("Kyc", diamond.target, signer_B);
     ssiManagementFacet = await ethers.getContractAt("SsiManagement", diamond.target, signer_A);
     clearingTransferFacet = await ethers.getContractAt("ClearingTransferFacet", diamond.target, signer_A);
@@ -174,7 +177,7 @@ describe("Equity Tests", () => {
 
       await expect(
         equityFacet._initialize_equityUSA(getEquityDetails(), regulationData, additionalSecurityData),
-      ).to.be.revertedWithCustomError(equityFacet, "AlreadyInitialized");
+      ).to.be.rejectedWith("AlreadyInitialized");
     });
 
     it("GIVEN an equity token WHEN getEquityDetails is called THEN returns correct equity details", async () => {
@@ -219,8 +222,9 @@ describe("Equity Tests", () => {
         data: "0x",
       });
 
-      const [dividend] = await equityFacet.getDividend(1);
+      const [dividend, isDisabled] = await equityFacet.getDividend(1);
       expect(dividend.snapshotId).to.not.equal(0);
+      expect(isDisabled).to.equal(false);
 
       // Verify getDividendHolders returns holders from snapshot (line 211-212)
       const dividendHolders = await equityFacet.getDividendHolders(1, 0, 99);
@@ -265,8 +269,9 @@ describe("Equity Tests", () => {
       await timeTravelFacet.changeSystemTimestamp(dividendsRecordDateInSeconds + 1);
 
       // Verify snapshot was NOT executed (snapshotId == 0)
-      const [dividend] = await equityFacet.getDividend(1);
+      const [dividend, isDisabled] = await equityFacet.getDividend(1);
       expect(dividend.snapshotId).to.equal(0);
+      expect(isDisabled).to.equal(false);
 
       // Get total dividend holders using _getTotalTokenHolders (line 224 in EquityStorageWrapper.sol)
       const totalHolders = await equityFacet.getTotalDividendHolders(1);
@@ -277,15 +282,12 @@ describe("Equity Tests", () => {
       expect([...holders]).to.have.members([signer_A.address]);
     });
 
-    it("GIVEN an account without corporateActions role WHEN setDividends THEN transaction fails with AccountHasNoRole", async () => {
+    it("GIVEN an account without corporateActions role WHEN setDividend THEN transaction fails with AccountHasNoRole", async () => {
       // set dividend fails
-      await expect(equityFacet.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(
-        accessControlFacet,
-        "AccountHasNoRole",
-      );
+      await expect(equityFacet.connect(signer_C).setDividend(dividendData)).to.be.rejectedWith("AccountHasNoRole");
     });
 
-    it("GIVEN a paused Token WHEN setDividends THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setDividend THEN transaction fails with TokenIsPaused", async () => {
       // Granting Role to account C and Pause
       await grantRoleAndPauseToken(
         accessControlFacet,
@@ -297,13 +299,10 @@ describe("Equity Tests", () => {
       );
 
       // set dividend fails
-      await expect(equityFacet.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(
-        pauseFacet,
-        "TokenIsPaused",
-      );
+      await expect(equityFacet.connect(signer_C).setDividend(dividendData)).to.be.rejectedWith("TokenIsPaused");
     });
 
-    it("GIVEN an account with corporateActions role WHEN setDividends with wrong dates THEN transaction fails", async () => {
+    it("GIVEN an account with corporateActions role WHEN setDividend with wrong dates THEN transaction fails", async () => {
       const currentTimestamp = await timeTravelFacet.blockTimestamp();
       await timeTravelFacet.changeSystemTimestamp(currentTimestamp + 100n);
       // Granting Role to account C
@@ -335,7 +334,7 @@ describe("Equity Tests", () => {
       );
     });
 
-    it("GIVEN an account with corporateActions role WHEN setDividends THEN transaction succeeds", async () => {
+    it("GIVEN an account with corporateActions role WHEN setDividend THEN transaction succeeds", async () => {
       // Granting Role to account C
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
@@ -353,16 +352,17 @@ describe("Equity Tests", () => {
         );
 
       // check list members
-      await expect(equityFacet.getDividend(1000)).to.be.revertedWithCustomError(equityFacet, "WrongIndexForAction");
+      await expect(equityFacet.getDividend(1000)).to.be.rejectedWith("WrongIndexForAction");
 
       const listCount = await equityFacet.getDividendsCount();
-      const [dividend] = await equityFacet.getDividend(1);
+      const [dividend, isDisabled] = await equityFacet.getDividend(1);
       const dividendFor = await equityFacet.getDividendFor(1, signer_A.address);
       const dividendAmountFor = await equityFacet.getDividendAmountFor(1, signer_A.address);
       const dividendTotalHolder = await equityFacet.getTotalDividendHolders(1);
       const dividendHolders = await equityFacet.getDividendHolders(1, 0, dividendTotalHolder);
 
       expect(listCount).to.equal(1);
+      expect(isDisabled).to.equal(false);
       expect(dividend.snapshotId).to.equal(0);
       expect(dividend.dividend.recordDate).to.equal(dividendsRecordDateInSeconds);
       expect(dividend.dividend.executionDate).to.equal(dividendsExecutionDateInSeconds);
@@ -382,7 +382,7 @@ describe("Equity Tests", () => {
       expect(dividendAmountFor.denominator).to.equal(0);
     });
 
-    it("GIVEN an account with corporateActions role WHEN setDividends and lock THEN transaction succeeds", async () => {
+    it("GIVEN an account with corporateActions role WHEN setDividend and lock THEN transaction succeeds", async () => {
       // Granting Role to account C
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._LOCKER_ROLE, signer_C.address);
@@ -423,6 +423,7 @@ describe("Equity Tests", () => {
 
       expect(dividendFor.tokenBalance).to.equal(TotalAmount);
       expect(dividendFor.recordDateReached).to.equal(true);
+      expect(dividendFor.isDisabled).to.be.false;
       expect(dividendTotalHolder).to.equal(1);
       expect(dividendHolders.length).to.equal(dividendTotalHolder);
       expect([...dividendHolders]).to.have.members([signer_A.address]);
@@ -431,7 +432,7 @@ describe("Equity Tests", () => {
       expect(dividendAmountFor.denominator).to.equal(10n ** (dividendFor.decimals + dividendFor.amountDecimals));
     });
 
-    it("GIVEN an account with corporateActions role WHEN setDividends and hold THEN transaction succeeds", async () => {
+    it("GIVEN an account with corporateActions role WHEN setDividend and hold THEN transaction succeeds", async () => {
       // Granting Role to account C
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
@@ -596,122 +597,121 @@ describe("Equity Tests", () => {
       expect(dividendAmountFor.numerator).to.equal(expectedDividendNumerator);
       expect(dividendAmountFor.denominator).to.equal(expectedDividendDenominator);
     });
-  });
 
-  describe("Cancel Dividend", () => {
-    it("GIVEN an account without corporateActions role WHEN cancelDividend THEN transaction fails with AccountHasNoRole", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setDividend(dividendData);
-      await expect(equityFacet.connect(signer_C).cancelDividend(1)).to.be.rejectedWith("AccountHasNoRole");
-    });
-
-    it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with TokenIsPaused", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setDividend(dividendData);
-      await pauseFacet.connect(signer_B).pause();
-
-      await expect(equityFacet.connect(signer_B).cancelDividend(1)).to.be.rejectedWith("TokenIsPaused");
-    });
-
-    it("GIVEN a dividend already executed WHEN cancelDividend THEN transaction fails with DividendAlreadyExecuted", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await equityFacet.connect(signer_C).setDividend(dividendData);
-
-      await timeTravelFacet.changeSystemTimestamp(dividendsExecutionDateInSeconds + 1000);
-
-      await expect(equityFacet.connect(signer_C).cancelDividend(1)).to.be.revertedWithCustomError(
-        equityFacet,
-        "DividendAlreadyExecuted",
-      );
-    });
-
-    it("GIVEN a dividend not yet executed WHEN cancelDividend THEN transaction succeeds", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await equityFacet.connect(signer_C).setDividend(dividendData);
-
-      await expect(equityFacet.connect(signer_C).cancelDividend(1))
-        .to.emit(equityFacet, "DividendCancelled")
-        .withArgs(1, signer_C.address);
-      expect((await equityFacet.getDividend(1)).isDisabled_).to.equal(true);
-      const dividendFor = await equityFacet.getDividendFor(1, signer_A.address);
-      expect(dividendFor.amount).to.equal(dividendsAmountPerEquity);
-      expect(dividendFor.amountDecimals).to.equal(dividendsAmountDecimalsPerEquity);
-    });
-
-    it("GIVEN a cancelled dividend WHEN getDividend THEN isDisabled is true", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await equityFacet.connect(signer_C).setDividend(dividendData);
-
-      await equityFacet.connect(signer_C).cancelDividend(1);
-
-      const [dividend, isDisabled] = await equityFacet.getDividend(1);
-      expect(isDisabled).to.equal(true);
-      expect(dividend.dividend.recordDate).to.equal(dividendsRecordDateInSeconds);
-      expect(dividend.dividend.executionDate).to.equal(dividendsExecutionDateInSeconds);
-    });
-
-    it("GIVEN a cancelled dividend WHEN getDividendFor THEN isDisabled is true and amount is still available", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: 1000n,
-        data: "0x",
+    describe("Cancel Dividend", () => {
+      it("GIVEN an account without corporateActions role WHEN cancelDividend THEN transaction fails with AccountHasNoRole", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await equityFacet.connect(signer_B).setDividend(dividendData);
+        await expect(equityFacet.connect(signer_C).cancelDividend(1)).to.be.rejectedWith("AccountHasNoRole");
       });
 
-      await equityFacet.connect(signer_C).setDividend(dividendData);
+      it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with TokenIsPaused", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await equityFacet.connect(signer_B).setDividend(dividendData);
+        await pauseFacet.connect(signer_B).pause();
 
-      await equityFacet.connect(signer_C).cancelDividend(1);
+        await expect(equityFacet.connect(signer_B).cancelDividend(1)).to.be.rejectedWith("TokenIsPaused");
+      });
 
-      const [, isDisabled] = await equityFacet.getDividend(1);
-      expect(isDisabled).to.equal(true);
-      const dividendFor = await equityFacet.getDividendFor(1, signer_A.address);
-      expect(dividendFor.amount).to.equal(dividendsAmountPerEquity);
-      expect(dividendFor.amountDecimals).to.equal(dividendsAmountDecimalsPerEquity);
-    });
+      it("GIVEN a dividend already executed WHEN cancelDividend THEN transaction fails with DividendAlreadyExecuted", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-    it("GIVEN a non-existent dividend WHEN cancelDividend THEN transaction fails", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await equityFacet.connect(signer_C).setDividend(dividendData);
 
-      await expect(equityFacet.connect(signer_C).cancelDividend(999)).to.be.rejected;
-    });
+        await timeTravelFacet.changeSystemTimestamp(dividendsExecutionDateInSeconds + 1000);
 
-    it("GIVEN multiple dividends WHEN cancelDividend on one THEN only that dividend is cancelled", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await expect(equityFacet.connect(signer_C).cancelDividend(1)).to.be.revertedWithCustomError(
+          equityFacet,
+          "DividendAlreadyExecuted",
+        );
+      });
 
-      // Create first dividend
-      await equityFacet.connect(signer_C).setDividend(dividendData);
+      it("GIVEN a dividend not yet executed WHEN cancelDividend THEN transaction succeeds", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-      // Create second dividend with different execution date
-      const secondDividendData = {
-        recordDate: dividendsRecordDateInSeconds.toString(),
-        executionDate: (dividendsExecutionDateInSeconds + 10000).toString(),
-        amount: 20,
-        amountDecimals: 0,
-      };
-      await equityFacet.connect(signer_C).setDividend(secondDividendData);
+        await equityFacet.connect(signer_C).setDividend(dividendData);
 
-      // Cancel only first dividend
-      await expect(equityFacet.connect(signer_C).cancelDividend(1))
-        .to.emit(equityFacet, "DividendCancelled")
-        .withArgs(1, signer_C.address);
+        await expect(equityFacet.connect(signer_C).cancelDividend(1))
+          .to.emit(equityFacet, "DividendCancelled")
+          .withArgs(1, signer_C.address);
+        expect((await equityFacet.getDividend(1)).isDisabled_).to.equal(true);
+        const dividendFor = await equityFacet.getDividendFor(1, signer_A.address);
+        expect(dividendFor.amount).to.equal(dividendsAmountPerEquity);
+        expect(dividendFor.amountDecimals).to.equal(dividendsAmountDecimalsPerEquity);
+        expect(dividendFor.isDisabled).to.be.true;
+      });
 
-      // Check first dividend is cancelled
-      const [, isDisabled1] = await equityFacet.getDividend(1);
-      expect(isDisabled1).to.equal(true);
+      it("GIVEN a cancelled dividend WHEN getDividend THEN isDisabled is true", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-      // Check second dividend is still active
-      const [dividend2, isDisabled2] = await equityFacet.getDividend(2);
-      expect(isDisabled2).to.equal(false);
-      expect(dividend2.dividend.amount).to.equal(20);
+        await equityFacet.connect(signer_C).setDividend(dividendData);
+
+        await equityFacet.connect(signer_C).cancelDividend(1);
+
+        const [dividend, isDisabled] = await equityFacet.getDividend(1);
+        expect(isDisabled).to.equal(true);
+        expect(dividend.dividend.recordDate).to.equal(dividendsRecordDateInSeconds);
+        expect(dividend.dividend.executionDate).to.equal(dividendsExecutionDateInSeconds);
+      });
+
+      it("GIVEN a cancelled dividend WHEN getDividendFor THEN isDisabled is true and amount is still available", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+        await erc1410Facet.connect(signer_C).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: 1000n,
+          data: "0x",
+        });
+
+        await equityFacet.connect(signer_C).setDividend(dividendData);
+
+        await equityFacet.connect(signer_C).cancelDividend(1);
+
+        const dividendFor = await equityFacet.getDividendFor(1, signer_A.address);
+        expect(dividendFor.isDisabled).to.equal(true);
+        expect(dividendFor.amount).to.equal(dividendsAmountPerEquity);
+        expect(dividendFor.amountDecimals).to.equal(dividendsAmountDecimalsPerEquity);
+      });
+
+      it("GIVEN a non-existent dividend WHEN cancelDividend THEN transaction fails", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+        await expect(equityFacet.connect(signer_C).cancelDividend(999)).to.be.rejected;
+      });
+
+      it("GIVEN multiple dividends WHEN cancelDividend on one THEN only that dividend is cancelled", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+        // Create first dividend
+        await equityFacet.connect(signer_C).setDividend(dividendData);
+
+        // Create second dividend with different execution date
+        const secondDividendData = {
+          recordDate: dividendsRecordDateInSeconds.toString(),
+          executionDate: (dividendsExecutionDateInSeconds + 10000).toString(),
+          amount: 20,
+          amountDecimals: 0,
+        };
+        await equityFacet.connect(signer_C).setDividend(secondDividendData);
+
+        // Cancel only first dividend
+        await expect(equityFacet.connect(signer_C).cancelDividend(1))
+          .to.emit(equityFacet, "DividendCancelled")
+          .withArgs(1, signer_C.address);
+
+        // Check first dividend is cancelled
+        const [, isDisabled1] = await equityFacet.getDividend(1);
+        expect(isDisabled1).to.equal(true);
+
+        // Check second dividend is still active
+        const [dividend2, isDisabled2] = await equityFacet.getDividend(2);
+        expect(isDisabled2).to.equal(false);
+        expect(dividend2.dividend.amount).to.equal(20);
+      });
     });
   });
-
   describe("Voting rights", () => {
     it("GIVEN voting with executed snapshot WHEN getting voting holders THEN returns holders from snapshot", async () => {
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
@@ -725,8 +725,8 @@ describe("Equity Tests", () => {
         data: "0x",
       });
 
-      await expect(equityFacet.connect(signer_C).setVoting(votingData))
-        .to.emit(equityFacet, "VotingSet")
+      await expect(votingFacet.connect(signer_C).setVoting(votingData))
+        .to.emit(votingFacet, "VotingSet")
         .withArgs(
           "0x0000000000000000000000000000000000000000000000000000000000000001",
           1,
@@ -744,20 +744,22 @@ describe("Equity Tests", () => {
         data: "0x",
       });
 
-      const [voting] = await equityFacet.getVoting(1);
+      const [voting, isDisabled] = await votingFacet.getVoting(1);
       expect(voting.snapshotId).to.not.equal(0);
+      expect(isDisabled).to.equal(false);
 
       // Verify getVotingHolders returns holders from snapshot (line 279)
-      const votingHolders = await equityFacet.getVotingHolders(1, 0, 99);
+      const votingHolders = await votingFacet.getVotingHolders(1, 0, 99);
       expect([...votingHolders]).to.have.members([signer_A.address]);
 
       // Verify getTotalVotingHolders returns count from snapshot (line 292)
-      const totalHolders = await equityFacet.getTotalVotingHolders(1);
+      const totalHolders = await votingFacet.getTotalVotingHolders(1);
       expect(totalHolders).to.equal(1);
 
-      const votingFor = await equityFacet.getVotingFor(1, signer_A.address);
+      const votingFor = await votingFacet.getVotingFor(1, signer_A.address);
       expect(votingFor.tokenBalance).to.equal(1000n);
       expect(votingFor.recordDateReached).to.equal(true);
+      expect(votingFor.isDisabled).to.be.false;
     });
 
     it("GIVEN voting without executed snapshot WHEN getting total voting holders THEN returns current total holders", async () => {
@@ -773,8 +775,8 @@ describe("Equity Tests", () => {
       });
 
       // Create voting (schedules a snapshot for recordDate)
-      await expect(equityFacet.connect(signer_C).setVoting(votingData))
-        .to.emit(equityFacet, "VotingSet")
+      await expect(votingFacet.connect(signer_C).setVoting(votingData))
+        .to.emit(votingFacet, "VotingSet")
         .withArgs(
           "0x0000000000000000000000000000000000000000000000000000000000000001",
           1,
@@ -788,24 +790,22 @@ describe("Equity Tests", () => {
       await timeTravelFacet.changeSystemTimestamp(votingRecordDateInSeconds + 1);
 
       // Verify snapshot was NOT executed (snapshotId == 0)
-      const [voting] = await equityFacet.getVoting(1);
+      const [voting, isDisabled] = await votingFacet.getVoting(1);
       expect(voting.snapshotId).to.equal(0);
+      expect(isDisabled).to.equal(false);
 
       // Get total voting holders using _getTotalTokenHolders (line 294 in EquityStorageWrapper.sol)
-      const totalHolders = await equityFacet.getTotalVotingHolders(1);
+      const totalHolders = await votingFacet.getTotalVotingHolders(1);
       expect(totalHolders).to.equal(1);
 
       // Also verify getVotingHolders returns current holders (line 281)
-      const holders = await equityFacet.getVotingHolders(1, 0, 99);
+      const holders = await votingFacet.getVotingHolders(1, 0, 99);
       expect([...holders]).to.have.members([signer_A.address]);
     });
 
     it("GIVEN an account without corporateActions role WHEN setVoting THEN transaction fails with AccountHasNoRole", async () => {
       // set voting fails
-      await expect(equityFacet.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(
-        accessControlFacet,
-        "AccountHasNoRole",
-      );
+      await expect(votingFacet.connect(signer_C).setVoting(votingData)).to.be.rejectedWith("AccountHasNoRole");
     });
 
     it("GIVEN a paused Token WHEN setVoting THEN transaction fails with TokenIsPaused", async () => {
@@ -820,10 +820,7 @@ describe("Equity Tests", () => {
       );
 
       // set voting fails
-      await expect(equityFacet.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(
-        pauseFacet,
-        "TokenIsPaused",
-      );
+      await expect(votingFacet.connect(signer_C).setVoting(votingData)).to.be.rejectedWith("TokenIsPaused");
     });
 
     it("GIVEN an account with corporateActions role WHEN setVoting with invalid timestamp THEN transaction fails with WrongTimestamp", async () => {
@@ -836,8 +833,8 @@ describe("Equity Tests", () => {
         data: voteData,
       };
 
-      await expect(equityFacet.connect(signer_C).setVoting(invalidVotingData)).to.be.revertedWithCustomError(
-        equityFacet,
+      await expect(votingFacet.connect(signer_C).setVoting(invalidVotingData)).to.be.revertedWithCustomError(
+        votingFacet,
         "WrongTimestamp",
       );
     });
@@ -846,19 +843,16 @@ describe("Equity Tests", () => {
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
       // Create a voting
-      await equityFacet.connect(signer_C).setVoting(votingData);
+      await votingFacet.connect(signer_C).setVoting(votingData);
 
       // Create a dividend to have different action types
       await equityFacet.connect(signer_C).setDividend(dividendData);
 
       // Try to access voting with dividend ID (should fail)
-      await expect(equityFacet.getVoting(2)).to.be.revertedWithCustomError(equityFacet, "WrongIndexForAction");
+      await expect(votingFacet.getVoting(2)).to.be.rejectedWith("WrongIndexForAction");
 
       // Try to access voting details with wrong ID (getVotingFor has the modifier)
-      await expect(equityFacet.getVotingFor(2, signer_A.address)).to.be.revertedWithCustomError(
-        equityFacet,
-        "WrongIndexForAction",
-      );
+      await expect(votingFacet.getVotingFor(2, signer_A.address)).to.be.rejectedWith("WrongIndexForAction");
 
       // Note: getVotingHolders and getTotalVotingHolders don't have onlyMatchingActionType modifier
     });
@@ -870,25 +864,16 @@ describe("Equity Tests", () => {
       await equityFacet.connect(signer_C).setDividend(dividendData);
 
       // Create a voting to have different action types
-      await equityFacet.connect(signer_C).setVoting(votingData);
+      await votingFacet.connect(signer_C).setVoting(votingData);
 
       // Try to access dividend with voting ID (should fail)
-      await expect(equityFacet.getDividend(2)).to.be.revertedWithCustomError(equityFacet, "WrongIndexForAction");
-      await expect(equityFacet.getDividendFor(2, signer_A.address)).to.be.revertedWithCustomError(
-        equityFacet,
-        "WrongIndexForAction",
-      );
-      await expect(equityFacet.getDividendAmountFor(2, signer_A.address)).to.be.revertedWithCustomError(
-        equityFacet,
-        "WrongIndexForAction",
-      );
+      await expect(equityFacet.getDividend(2)).to.be.rejectedWith("WrongIndexForAction");
+      await expect(equityFacet.getDividendFor(2, signer_A.address)).to.be.rejectedWith("WrongIndexForAction");
+      await expect(equityFacet.getDividendAmountFor(2, signer_A.address)).to.be.rejectedWith("WrongIndexForAction");
     });
     it("GIVEN an account without corporateActions role WHEN setVoting THEN transaction fails with AccountHasNoRole", async () => {
       // set dividend fails
-      await expect(equityFacet.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(
-        accessControlFacet,
-        "AccountHasNoRole",
-      );
+      await expect(votingFacet.connect(signer_C).setVoting(votingData)).to.be.rejectedWith("AccountHasNoRole");
     });
 
     it("GIVEN a paused Token WHEN setVoting THEN transaction fails with TokenIsPaused", async () => {
@@ -903,9 +888,17 @@ describe("Equity Tests", () => {
       );
 
       // set dividend fails
-      await expect(equityFacet.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(
-        pauseFacet,
-        "TokenIsPaused",
+      await expect(votingFacet.connect(signer_C).setVoting(votingData)).to.be.rejectedWith("TokenIsPaused");
+    });
+
+    it("GIVEN a duplicate voting WHEN setVoting THEN transaction fails with VotingRightsCreationFailed", async () => {
+      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+      await votingFacet.connect(signer_C).setVoting(votingData);
+
+      await expect(votingFacet.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(
+        votingFacet,
+        "VotingRightsCreationFailed",
       );
     });
 
@@ -914,8 +907,8 @@ describe("Equity Tests", () => {
       await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
       // set dividend
-      await expect(equityFacet.connect(signer_C).setVoting(votingData))
-        .to.emit(equityFacet, "VotingSet")
+      await expect(votingFacet.connect(signer_C).setVoting(votingData))
+        .to.emit(votingFacet, "VotingSet")
         .withArgs(
           "0x0000000000000000000000000000000000000000000000000000000000000001",
           1,
@@ -925,24 +918,24 @@ describe("Equity Tests", () => {
         );
 
       // check list members
-      // await expect(equityFacet.getVoting(1000)).to.be.rejectedWith(
+      // await expect(votingFacet.getVoting(1000)).to.be.rejectedWith(
       //     'WrongIndexForAction'
       // )
 
-      const listCount = await equityFacet.getVotingCount();
-      const [voting] = await equityFacet.getVoting(1);
-      const votingFor = await equityFacet.getVotingFor(1, signer_A.address);
-      const votingTotalHolder = await equityFacet.getTotalVotingHolders(1);
-      const votingHolders = await equityFacet.getVotingHolders(1, 0, votingTotalHolder);
+      const listCount = await votingFacet.getVotingCount();
+      const [voting, isDisabled] = await votingFacet.getVoting(1);
+      const votingFor = await votingFacet.getVotingFor(1, signer_A.address);
+      const votingTotalHolder = await votingFacet.getTotalVotingHolders(1);
+      const votingHolders = await votingFacet.getVotingHolders(1, 0, votingTotalHolder);
 
       expect(listCount).to.equal(1);
       expect(voting.snapshotId).to.equal(0);
       expect(voting.voting.recordDate).to.equal(votingRecordDateInSeconds);
       expect(voting.voting.data).to.equal(voteData);
-      expect(votingFor.recordDate).to.equal(dividendsRecordDateInSeconds);
-      expect(votingFor.data).to.equal(voteData);
+      expect(isDisabled).to.equal(false);
       expect(votingFor.tokenBalance).to.equal(0);
       expect(votingFor.recordDateReached).to.equal(false);
+      expect(votingFor.isDisabled).to.be.false;
       expect(votingTotalHolder).to.equal(0);
       expect(votingHolders.length).to.equal(votingTotalHolder);
     });
@@ -966,8 +959,8 @@ describe("Equity Tests", () => {
       await lockFacet.connect(signer_C).lock(LockedAmount, signer_A.address, 99999999999);
 
       // set dividend
-      await expect(equityFacet.connect(signer_C).setVoting(votingData))
-        .to.emit(equityFacet, "VotingSet")
+      await expect(votingFacet.connect(signer_C).setVoting(votingData))
+        .to.emit(votingFacet, "VotingSet")
         .withArgs(
           "0x0000000000000000000000000000000000000000000000000000000000000001",
           1,
@@ -977,86 +970,87 @@ describe("Equity Tests", () => {
         );
 
       await timeTravelFacet.changeSystemTimestamp(votingRecordDateInSeconds + 1);
-      const votingFor = await equityFacet.getVotingFor(1, signer_A.address);
-      const votingTotalHolder = await equityFacet.getTotalVotingHolders(1);
-      const votingHolders = await equityFacet.getVotingHolders(1, 0, votingTotalHolder);
+      const votingFor = await votingFacet.getVotingFor(1, signer_A.address);
+      const votingTotalHolder = await votingFacet.getTotalVotingHolders(1);
+      const votingHolders = await votingFacet.getVotingHolders(1, 0, votingTotalHolder);
 
       expect(votingFor.tokenBalance).to.equal(TotalAmount);
       expect(votingFor.recordDateReached).to.equal(true);
+      expect(votingFor.isDisabled).to.be.false;
       expect(votingTotalHolder).to.equal(1);
       expect(votingHolders.length).to.equal(votingTotalHolder);
       expect([...votingHolders]).to.have.members([signer_A.address]);
     });
-  });
+    describe("Cancel Voting", () => {
+      it("GIVEN an account without corporateActions role WHEN cancelVoting THEN transaction fails with AccountHasNoRole", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await votingFacet.connect(signer_B).setVoting(votingData);
+        await expect(votingFacet.connect(signer_C).cancelVoting(1)).to.be.rejectedWith("AccountHasNoRole");
+      });
 
-  describe("Cancel Voting", () => {
-    it("GIVEN an account without corporateActions role WHEN cancelVoting THEN transaction fails with AccountHasNoRole", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setVoting(votingData);
-      await expect(equityFacet.connect(signer_C).cancelVoting(1)).to.be.rejectedWith("AccountHasNoRole");
-    });
+      it("GIVEN a paused Token WHEN cancelVoting THEN transaction fails with TokenIsPaused", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await votingFacet.connect(signer_B).setVoting(votingData);
+        await pauseFacet.connect(signer_B).pause();
 
-    it("GIVEN a paused Token WHEN cancelVoting THEN transaction fails with TokenIsPaused", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setVoting(votingData);
-      await pauseFacet.connect(signer_B).pause();
+        await expect(votingFacet.connect(signer_B).cancelVoting(1)).to.be.rejectedWith("TokenIsPaused");
+      });
 
-      await expect(equityFacet.connect(signer_B).cancelVoting(1)).to.be.rejectedWith("TokenIsPaused");
-    });
+      it("GIVEN a voting already recorded WHEN cancelVoting THEN transaction fails with VotingAlreadyRecorded", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-    it("GIVEN a voting already recorded WHEN cancelVoting THEN transaction fails with VotingAlreadyRecorded", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await votingFacet.connect(signer_C).setVoting(votingData);
 
-      await equityFacet.connect(signer_C).setVoting(votingData);
+        await timeTravelFacet.changeSystemTimestamp(votingRecordDateInSeconds + 1);
 
-      await timeTravelFacet.changeSystemTimestamp(votingRecordDateInSeconds + 1);
+        await expect(votingFacet.connect(signer_C).cancelVoting(1)).to.be.revertedWithCustomError(
+          votingFacet,
+          "VotingAlreadyRecorded",
+        );
+      });
 
-      await expect(equityFacet.connect(signer_C).cancelVoting(1)).to.be.revertedWithCustomError(
-        equityFacet,
-        "VotingAlreadyRecorded",
-      );
-    });
+      it("GIVEN a voting not yet recorded WHEN cancelVoting THEN transaction succeeds", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-    it("GIVEN a voting not yet recorded WHEN cancelVoting THEN transaction succeeds", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await votingFacet.connect(signer_C).setVoting(votingData);
 
-      await equityFacet.connect(signer_C).setVoting(votingData);
+        await expect(votingFacet.connect(signer_C).cancelVoting(1))
+          .to.emit(votingFacet, "VotingCancelled")
+          .withArgs(1, signer_C.address);
+        expect((await votingFacet.getVoting(1)).isDisabled_).to.equal(true);
+        const votingFor = await votingFacet.getVotingFor(1, signer_A.address);
+        expect(votingFor.recordDate).to.equal(votingRecordDateInSeconds);
+        expect(votingFor.isDisabled).to.be.true;
+      });
 
-      await expect(equityFacet.connect(signer_C).cancelVoting(1))
-        .to.emit(equityFacet, "VotingCancelled")
-        .withArgs(1, signer_C.address);
-      expect((await equityFacet.getVoting(1)).isDisabled_).to.equal(true);
-      const votingFor = await equityFacet.getVotingFor(1, signer_A.address);
-      expect(votingFor.recordDate).to.equal(votingRecordDateInSeconds);
-    });
+      it("GIVEN a non-existent voting WHEN cancelVoting THEN transaction fails", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-    it("GIVEN a non-existent voting WHEN cancelVoting THEN transaction fails", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await expect(votingFacet.connect(signer_C).cancelVoting(999)).to.be.rejected;
+      });
 
-      await expect(equityFacet.connect(signer_C).cancelVoting(999)).to.be.rejected;
-    });
+      it("GIVEN multiple votings WHEN cancelVoting on one THEN only that voting is cancelled", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-    it("GIVEN multiple votings WHEN cancelVoting on one THEN only that voting is cancelled", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await votingFacet.connect(signer_C).setVoting(votingData);
 
-      await equityFacet.connect(signer_C).setVoting(votingData);
+        const secondVotingData = {
+          recordDate: (votingRecordDateInSeconds + 10000).toString(),
+          data: "0xAABBCC",
+        };
+        await votingFacet.connect(signer_C).setVoting(secondVotingData);
 
-      const secondVotingData = {
-        recordDate: (votingRecordDateInSeconds + 10000).toString(),
-        data: "0xAABBCC",
-      };
-      await equityFacet.connect(signer_C).setVoting(secondVotingData);
+        await expect(votingFacet.connect(signer_C).cancelVoting(1))
+          .to.emit(votingFacet, "VotingCancelled")
+          .withArgs(1, signer_C.address);
 
-      await expect(equityFacet.connect(signer_C).cancelVoting(1))
-        .to.emit(equityFacet, "VotingCancelled")
-        .withArgs(1, signer_C.address);
+        const [, isDisabled1] = await votingFacet.getVoting(1);
+        expect(isDisabled1).to.equal(true);
 
-      const [, isDisabled1] = await equityFacet.getVoting(1);
-      expect(isDisabled1).to.equal(true);
-
-      const [voting2, isDisabled2] = await equityFacet.getVoting(2);
-      expect(isDisabled2).to.equal(false);
-      expect(voting2.voting.recordDate).to.equal(votingRecordDateInSeconds + 10000);
+        const [voting2, isDisabled2] = await votingFacet.getVoting(2);
+        expect(isDisabled2).to.equal(false);
+        expect(voting2.voting.recordDate).to.equal(votingRecordDateInSeconds + 10000);
+      });
     });
   });
 
@@ -1085,30 +1079,6 @@ describe("Equity Tests", () => {
       ).to.be.rejectedWith("TokenIsPaused");
     });
 
-    it("GIVEN an account without corporateActions role WHEN setBalanceAdjustment THEN transaction fails with AccountHasNoRole", async () => {
-      // set dividend fails
-      await expect(
-        equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData),
-      ).to.be.revertedWithCustomError(accessControlFacet, "AccountHasNoRole");
-    });
-
-    it("GIVEN a paused Token WHEN setBalanceAdjustment THEN transaction fails with TokenIsPaused", async () => {
-      // Granting Role to account C and Pause
-      await grantRoleAndPauseToken(
-        accessControlFacet,
-        pauseFacet,
-        ATS_ROLES._CORPORATE_ACTION_ROLE,
-        signer_A,
-        signer_B,
-        signer_C.address,
-      );
-
-      // set dividend fails
-      await expect(
-        equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData),
-      ).to.be.revertedWithCustomError(pauseFacet, "TokenIsPaused");
-    });
-
     it("GIVEN an account with corporateActions role WHEN setScheduledBalanceAdjustment with invalid timestamp THEN transaction fails with WrongTimestamp", async () => {
       const currentTimestamp = await timeTravelFacet.blockTimestamp();
       await timeTravelFacet.changeSystemTimestamp(currentTimestamp + 100n);
@@ -1123,6 +1093,33 @@ describe("Equity Tests", () => {
       await expect(
         equityFacet.connect(signer_C).setScheduledBalanceAdjustment(invalidBalanceAdjustmentData),
       ).to.be.revertedWithCustomError(equityFacet, "WrongTimestamp");
+    });
+
+    it("GIVEN an account with corporateActions role WHEN setScheduledBalanceAdjustment with invalid factor THEN transaction fails with FactorIsZero", async () => {
+      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+      const invalidBalanceAdjustmentData = {
+        executionDate: balanceAdjustmentExecutionDateInSeconds.toString(),
+        factor: 0, // Invalid factor: 0
+        decimals: balanceAdjustmentDecimals,
+      };
+
+      await expect(
+        equityFacet.connect(signer_C).setScheduledBalanceAdjustment(invalidBalanceAdjustmentData),
+      ).to.be.revertedWithCustomError(equityFacet, "FactorIsZero");
+    });
+
+    it("GIVEN balance adjustment created WHEN trying to get balance adjustment with wrong ID type THEN transaction fails with WrongIndexForAction", async () => {
+      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+      // Create a balance adjustment
+      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+      // Create a dividend to have different action types
+      await equityFacet.connect(signer_C).setDividend(dividendData);
+
+      // Try to access balance adjustment with dividend ID (should fail)
+      await expect(equityFacet.getScheduledBalanceAdjustment(2)).to.be.rejectedWith("WrongIndexForAction");
     });
 
     it("GIVEN an account with corporateActions role WHEN setScheduledBalanceAdjustment THEN transaction succeeds", async () => {
@@ -1151,172 +1148,118 @@ describe("Equity Tests", () => {
       expect(balanceAdjustment.decimals).to.equal(balanceAdjustmentDecimals);
     });
 
-    it("GIVEN an account with corporateActions role WHEN setScheduledBalanceAdjustment with invalid factor THEN transaction fails with FactorIsZero", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      const invalidBalanceAdjustmentData = {
-        executionDate: balanceAdjustmentExecutionDateInSeconds.toString(),
-        factor: 0, // Invalid factor: 0
-        decimals: balanceAdjustmentDecimals,
-      };
-
-      await expect(
-        equityFacet.connect(signer_C).setScheduledBalanceAdjustment(invalidBalanceAdjustmentData),
-      ).to.be.revertedWithCustomError(equityFacet, "FactorIsZero");
-    });
-
-    it("GIVEN balance adjustment created WHEN trying to get balance adjustment with wrong ID type THEN transaction fails with WrongIndexForAction", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      // Create a balance adjustment
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
-
-      // Create a dividend to have different action types
-      await equityFacet.connect(signer_C).setDividend(dividendData);
-
-      // Try to access balance adjustment with dividend ID (should fail)
-      await expect(equityFacet.getScheduledBalanceAdjustment(2)).to.be.revertedWithCustomError(
-        equityFacet,
-        "WrongIndexForAction",
-      );
-    });
-
-    it("GIVEN an account with corporateActions role WHEN setBalanceAdjustment THEN transaction succeeds", async () => {
-      // Granting Role to account C
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      // set dividend
-      await expect(equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData))
-        .to.emit(equityFacet, "ScheduledBalanceAdjustmentSet")
-        .withArgs(
-          "0x0000000000000000000000000000000000000000000000000000000000000001",
-          1,
-          signer_C.address,
-          balanceAdjustmentExecutionDateInSeconds,
-          balanceAdjustmentFactor,
-          balanceAdjustmentDecimals,
+    describe("Cancel Scheduled Balance Adjustment", () => {
+      it("GIVEN an account without corporateActions role WHEN cancelScheduledBalanceAdjustment THEN transaction fails with AccountHasNoRole", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await equityFacet.connect(signer_B).setScheduledBalanceAdjustment(balanceAdjustmentData);
+        await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1)).to.be.rejectedWith(
+          "AccountHasNoRole",
         );
-
-      const listCount = await equityFacet.getScheduledBalanceAdjustmentCount();
-      const [balanceAdjustment] = await equityFacet.getScheduledBalanceAdjustment(1);
-
-      expect(listCount).to.equal(1);
-      expect(balanceAdjustment.executionDate).to.equal(balanceAdjustmentExecutionDateInSeconds);
-      expect(balanceAdjustment.factor).to.equal(balanceAdjustmentFactor);
-      expect(balanceAdjustment.decimals).to.equal(balanceAdjustmentDecimals);
-    });
-  });
-  describe("Cancel Scheduled Balance Adjustment", () => {
-    it("GIVEN an account without corporateActions role WHEN cancelScheduledBalanceAdjustment THEN transaction fails with AccountHasNoRole", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setScheduledBalanceAdjustment(balanceAdjustmentData);
-      await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1)).to.be.rejectedWith(
-        "AccountHasNoRole",
-      );
-    });
-
-    it("GIVEN a paused Token WHEN cancelScheduledBalanceAdjustment THEN transaction fails with TokenIsPaused", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
-      await equityFacet.connect(signer_B).setScheduledBalanceAdjustment(balanceAdjustmentData);
-      await pauseFacet.connect(signer_B).pause();
-
-      await expect(equityFacet.connect(signer_B).cancelScheduledBalanceAdjustment(1)).to.be.rejectedWith(
-        "TokenIsPaused",
-      );
-    });
-
-    it("GIVEN a balance adjustment already executed WHEN cancelScheduledBalanceAdjustment THEN transaction fails with BalanceAdjustmentAlreadyExecuted", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
-
-      await timeTravelFacet.changeSystemTimestamp(balanceAdjustmentExecutionDateInSeconds + 1000);
-
-      await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1)).to.be.revertedWithCustomError(
-        equityFacet,
-        "BalanceAdjustmentAlreadyExecuted",
-      );
-    });
-
-    it("GIVEN a balance adjustment not yet executed WHEN cancelScheduledBalanceAdjustment THEN transaction succeeds", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
-
-      await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1))
-        .to.emit(equityFacet, "ScheduledBalanceAdjustmentCancelled")
-        .withArgs(1, signer_C.address);
-      const [balanceAdjustment, isDisabled] = await equityFacet.getScheduledBalanceAdjustment(1);
-      expect(isDisabled).to.equal(true);
-      expect(balanceAdjustment.factor).to.equal(balanceAdjustmentFactor);
-      expect(balanceAdjustment.decimals).to.equal(balanceAdjustmentDecimals);
-    });
-
-    it("GIVEN a non-existent balance adjustment WHEN cancelScheduledBalanceAdjustment THEN transaction fails", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(999)).to.be.rejected;
-    });
-
-    it("GIVEN multiple balance adjustments WHEN cancelScheduledBalanceAdjustment on one THEN only that adjustment is cancelled", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-
-      // Create first balance adjustment
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
-
-      // Create second balance adjustment with different execution date
-      const secondBalanceAdjustmentData = {
-        executionDate: (balanceAdjustmentExecutionDateInSeconds + 10000).toString(),
-        factor: 500,
-        decimals: 3,
-      };
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(secondBalanceAdjustmentData);
-
-      // Cancel only first balance adjustment
-      await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1))
-        .to.emit(equityFacet, "ScheduledBalanceAdjustmentCancelled")
-        .withArgs(1, signer_C.address);
-
-      // Verify first adjustment is cancelled by checking it still exists but with correct data
-      const [balanceAdjustment1, isDisabled1] = await equityFacet.getScheduledBalanceAdjustment(1);
-      expect(isDisabled1).to.equal(true);
-      expect(balanceAdjustment1.factor).to.equal(balanceAdjustmentFactor);
-
-      // Verify second adjustment is still active
-      const [balanceAdjustment2, isDisabled2] = await equityFacet.getScheduledBalanceAdjustment(2);
-      expect(isDisabled2).to.equal(false);
-      expect(balanceAdjustment2.factor).to.equal(500);
-      expect(balanceAdjustment2.decimals).to.equal(3);
-    });
-
-    it("GIVEN a cancelled balance adjustment WHEN triggerScheduledCrossOrderedTasks is called THEN scheduled task executes but token balance remains unchanged", async () => {
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
-      await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
-
-      const tokenAmount = 1000n;
-      await erc1410Facet.connect(signer_C).issueByPartition({
-        partition: DEFAULT_PARTITION,
-        tokenHolder: signer_A.address,
-        value: tokenAmount,
-        data: "0x",
       });
 
-      const balanceBeforeAdjustment = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
-      expect(balanceBeforeAdjustment).to.equal(tokenAmount);
+      it("GIVEN a paused Token WHEN cancelScheduledBalanceAdjustment THEN transaction fails with TokenIsPaused", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_B.address);
+        await equityFacet.connect(signer_B).setScheduledBalanceAdjustment(balanceAdjustmentData);
+        await pauseFacet.connect(signer_B).pause();
 
-      await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+        await expect(equityFacet.connect(signer_B).cancelScheduledBalanceAdjustment(1)).to.be.rejectedWith(
+          "TokenIsPaused",
+        );
+      });
 
-      await equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1);
+      it("GIVEN a balance adjustment already executed WHEN cancelScheduledBalanceAdjustment THEN transaction fails with BalanceAdjustmentAlreadyExecuted", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
 
-      const balanceAfterCancel = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
-      expect(balanceAfterCancel).to.equal(balanceBeforeAdjustment);
+        await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
 
-      await timeTravelFacet.changeSystemTimestamp(balanceAdjustmentExecutionDateInSeconds + 1);
+        await timeTravelFacet.changeSystemTimestamp(balanceAdjustmentExecutionDateInSeconds + 1000);
 
-      await scheduledTasksFacet.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+        await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1)).to.be.revertedWithCustomError(
+          equityFacet,
+          "BalanceAdjustmentAlreadyExecuted",
+        );
+      });
 
-      const balanceAfterTrigger = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
-      expect(balanceAfterTrigger).to.equal(balanceBeforeAdjustment);
+      it("GIVEN a balance adjustment not yet executed WHEN cancelScheduledBalanceAdjustment THEN transaction succeeds", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+        await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+        await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1))
+          .to.emit(equityFacet, "ScheduledBalanceAdjustmentCancelled")
+          .withArgs(1, signer_C.address);
+        const [balanceAdjustment, isDisabled] = await equityFacet.getScheduledBalanceAdjustment(1);
+        expect(isDisabled).to.equal(true);
+        expect(balanceAdjustment.factor).to.equal(balanceAdjustmentFactor);
+        expect(balanceAdjustment.decimals).to.equal(balanceAdjustmentDecimals);
+      });
+
+      it("GIVEN a non-existent balance adjustment WHEN cancelScheduledBalanceAdjustment THEN transaction fails", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+        await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(999)).to.be.rejected;
+      });
+
+      it("GIVEN multiple balance adjustments WHEN cancelScheduledBalanceAdjustment on one THEN only that adjustment is cancelled", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+
+        // Create first balance adjustment
+        await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+        // Create second balance adjustment with different execution date
+        const secondBalanceAdjustmentData = {
+          executionDate: (balanceAdjustmentExecutionDateInSeconds + 10000).toString(),
+          factor: 500,
+          decimals: 3,
+        };
+        await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(secondBalanceAdjustmentData);
+
+        // Cancel only first balance adjustment
+        await expect(equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1))
+          .to.emit(equityFacet, "ScheduledBalanceAdjustmentCancelled")
+          .withArgs(1, signer_C.address);
+
+        // Verify first adjustment is cancelled by checking it still exists but with correct data
+        const [balanceAdjustment1, isDisabled1] = await equityFacet.getScheduledBalanceAdjustment(1);
+        expect(isDisabled1).to.equal(true);
+        expect(balanceAdjustment1.factor).to.equal(balanceAdjustmentFactor);
+
+        // Verify second adjustment is still active
+        const [balanceAdjustment2, isDisabled2] = await equityFacet.getScheduledBalanceAdjustment(2);
+        expect(isDisabled2).to.equal(false);
+        expect(balanceAdjustment2.factor).to.equal(500);
+        expect(balanceAdjustment2.decimals).to.equal(3);
+      });
+
+      it("GIVEN a cancelled balance adjustment WHEN triggerScheduledCrossOrderedTasks is called THEN scheduled task executes but token balance remains unchanged", async () => {
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._CORPORATE_ACTION_ROLE, signer_C.address);
+        await accessControlFacet.connect(signer_A).grantRole(ATS_ROLES._ISSUER_ROLE, signer_C.address);
+
+        const tokenAmount = 1000n;
+        await erc1410Facet.connect(signer_C).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: tokenAmount,
+          data: "0x",
+        });
+
+        const balanceBeforeAdjustment = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
+        expect(balanceBeforeAdjustment).to.equal(tokenAmount);
+
+        await equityFacet.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+        await equityFacet.connect(signer_C).cancelScheduledBalanceAdjustment(1);
+
+        const balanceAfterCancel = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
+        expect(balanceAfterCancel).to.equal(balanceBeforeAdjustment);
+
+        await timeTravelFacet.changeSystemTimestamp(balanceAdjustmentExecutionDateInSeconds + 1);
+
+        await scheduledTasksFacet.connect(signer_A).triggerScheduledCrossOrderedTasks(100);
+
+        const balanceAfterTrigger = await erc1410Facet.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
+        expect(balanceAfterTrigger).to.equal(balanceBeforeAdjustment);
+      });
     });
   });
 });

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -64,6 +64,7 @@ import {
   KpiLinkedRate__factory,
   ScheduledCouponListingFacet__factory,
   NominalValue__factory,
+  Voting__factory,
 } from "@hashgraph/asset-tokenization-contracts";
 import { ScheduledSnapshot } from "@domain/context/security/ScheduledSnapshot";
 import { VotingRights } from "@domain/context/equity/VotingRights";
@@ -428,7 +429,7 @@ export class RPCQueryAdapter {
   async getVotingFor(address: EvmAddress, target: EvmAddress, voting: number): Promise<VotingFor> {
     LogService.logTrace(`Getting voting for`);
 
-    const votingFor = await this.connect(Equity__factory, address.toString()).getVotingFor(voting, target.toString());
+    const votingFor = await this.connect(Voting__factory, address.toString()).getVotingFor(voting, target.toString());
 
     return new VotingFor(new BigDecimal(votingFor.tokenBalance), Number(votingFor.decimals), votingFor.isDisabled);
   }
@@ -436,7 +437,7 @@ export class RPCQueryAdapter {
   async getVoting(address: EvmAddress, voting: number): Promise<VotingRights> {
     LogService.logTrace(`Getting voting`);
 
-    const { registeredVoting_, isDisabled_ } = await this.connect(Equity__factory, address.toString()).getVoting(voting);
+    const { registeredVoting_, isDisabled_ } = await this.connect(Voting__factory, address.toString()).getVoting(voting);
 
     return new VotingRights(
       Number(registeredVoting_.voting.recordDate),
@@ -449,7 +450,7 @@ export class RPCQueryAdapter {
   async getVotingsCount(address: EvmAddress): Promise<number> {
     LogService.logTrace(`Getting votings count`);
 
-    const votingsCount = await this.connect(Equity__factory, address.toString()).getVotingCount();
+    const votingsCount = await this.connect(Voting__factory, address.toString()).getVotingCount();
 
     return Number(votingsCount);
   }
@@ -1437,13 +1438,13 @@ export class RPCQueryAdapter {
 
   async getVotingHolders(address: EvmAddress, voteId: number, start: number, end: number): Promise<string[]> {
     LogService.logTrace(`Getting voting holders for vote ${voteId} for security ${address.toString()}`);
-    return await this.connect(Equity__factory, address.toString()).getVotingHolders(voteId, start, end);
+    return await this.connect(Voting__factory, address.toString()).getVotingHolders(voteId, start, end);
   }
 
   async getTotalVotingHolders(address: EvmAddress, voteId: number): Promise<number> {
     LogService.logTrace(`Getting total voting holders for vote ${voteId} for security ${address.toString()}`);
 
-    const total = await this.connect(Equity__factory, address.toString()).getTotalVotingHolders(voteId);
+    const total = await this.connect(Voting__factory, address.toString()).getTotalVotingHolders(voteId);
 
     return Number(total);
   }

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -83,6 +83,7 @@ import {
   HoldTokenHolderFacet__factory,
   IBondTypes,
   IEquity,
+  IVoting,
   KpiLinkedRate__factory,
   Kpis__factory,
   KycFacet__factory,
@@ -100,6 +101,7 @@ import {
   TransferAndLockFacet__factory,
   TREXFactoryAts__factory,
   NominalValue__factory,
+  Voting__factory,
 } from "@hashgraph/asset-tokenization-contracts";
 import { ContractId } from "@hiero-ledger/sdk";
 import EventService from "@service/event/EventService";
@@ -611,13 +613,13 @@ export class RPCTransactionAdapter extends TransactionAdapter {
       `equity: ${security} ,
       recordDate :${recordDate} , `,
     );
-    const votingStruct: IEquity.VotingStruct = {
+    const votingStruct = {
       recordDate: recordDate.toBigInt(),
       data: data,
     };
 
     return this.executeTransaction(
-      Equity__factory.connect(security.toString(), this.getSignerOrProvider()),
+      Voting__factory.connect(security.toString(), this.getSignerOrProvider()),
       "setVoting",
       [votingStruct],
       GAS.SET_VOTING_RIGHTS,
@@ -682,7 +684,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     LogService.logTrace(`Cancelling voting: ${votingId} for equity: ${security}`);
 
     return this.executeTransaction(
-      Equity__factory.connect(security.toString(), this.getSignerOrProvider()),
+      Voting__factory.connect(security.toString(), this.getSignerOrProvider()),
       "cancelVoting",
       [votingId],
       GAS.CANCEL_VOTING,


### PR DESCRIPTION
## Summary

Ports the voting-split from `main` commit `0fe41df4` onto the lib-diamond
migration branch. Voting is extracted from Equity into its own facet family.

### Contracts

- New `facets/layer_2/voting/` facet family: `IVotingTypes`, `IVoting`, `Voting`
  (abstract), `VotingFacet` (concrete, 7 selectors, `_VOTING_RESOLVER_KEY`).
- New `domain/asset/voting/VotingStorageWrapper.sol` library (not abstract
  contract) — mirrors the Coupon precedent.
- `EquityUSAFacet` selector array 24 → 17; voting surface removed from
  `Equity.sol`, `IEquity.sol`, `EquityStorageWrapper.sol`.
- `EquityStorageWrapper.getDividendsFor` now propagates the corporate
  action's `isDisabled` flag (was missing on this branch).
- `IVoting.VotingSet` event uses a 5-arg flat signature (recordDate + data
  flattened) matching the source commit.
- `createConfiguration.ts` (equity) adds `VotingFacet` to the facet list.
- Registry regenerated via `npm run generate:registry`.

### SDK

- `RPCTransactionAdapter` and `RPCQueryAdapter` rewired for 7 voting ops
  (`setVoting`, `cancelVoting`, `getVoting`, `getVotingFor`, `getVotingCount`,
  `getVotingHolders`, `getTotalVotingHolders`) to use `Voting__factory`
  instead of `Equity__factory`.
- Port layer (Equity.ts, command/query handlers, injectable) untouched —
  they call the adapters, which now point to the new facet.

### Tests

- `test/contracts/integration/layer_1/equity/equity.test.ts` copied
  byte-for-byte from `0fe41df4`. Zero-diff verified.
- `VotingFacetTimeTravel.sol` added under
  `test/testTimeTravel/facetsTimeTravel/voting/`, matching the
  migration-branch trivial shape (like the Coupon sibling).

### Verification

- `npx hardhat compile` — 0 errors.
- `npm run ats:contracts:test` — 2217 passing, 0 failing.
- `npm run ats:contracts:lint` — 0 errors.
- `npm run ats:contracts:build` — clean, TypeChain regenerates
  `Voting__factory`.
- `npm run ats:sdk:build` — clean.

### Skipped intentionally

- `.changeset/*` — no changeset per branch policy.
- `contracts/factory/ERC3643/interfaces/IEquity.sol` — auto-generated by
  `tasks/compile.ts` (regenerated mechanically as part of this change).

Base branch: `refactor/BBND-1458-59-60-lib-diamond-migration`.