### PR TITLE
fix(mp): add IBalanceTrackerAtSnapshot interface import and update workflow triggers

### DIFF
--- a/.changeset/mp-ats-contracts-ci-trigger.md
+++ b/.changeset/mp-ats-contracts-ci-trigger.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/mass-payout-contracts": patch
+---
+
+Add `packages/ats/contracts/**` to MP test workflow trigger paths so ATS contract changes automatically run MP tests and catch interface breakages.

--- a/.github/workflows/101-flow-mp-test.yaml
+++ b/.github/workflows/101-flow-mp-test.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - "packages/mass-payout/**"
       - "apps/mass-payout/**"
+      - "packages/ats/contracts/**"
       - "package.json"
       - ".github/workflows/*mp*.yaml"
   workflow_dispatch:

--- a/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
+++ b/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
@@ -13,6 +13,9 @@ import { ICore } from "@hashgraph/asset-tokenization-contracts/contracts/facets/
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISnapshots } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_1/snapshot/ISnapshots.sol";
+import {
+    IBalanceTrackerAtSnapshot
+} from "@hashgraph/asset-tokenization-contracts/contracts/facets/balanceTrackerAtSnapshot/IBalanceTrackerAtSnapshot.sol";
 import { IBond } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBond.sol";
 import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
 import { IBondRead } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondRead.sol";
@@ -335,7 +338,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
     function _getSnapshotAmountByAmount(
         ILifeCycleCashFlow.SnapshotAmountInfo memory amountInfo
     ) internal view returns (uint256) {
-        uint256 holderTokens = ISnapshots(amountInfo.asset).balanceOfAtSnapshot(
+        uint256 holderTokens = IBalanceTrackerAtSnapshot(amountInfo.asset).balanceOfAtSnapshot(
             amountInfo.snapshotID,
             amountInfo.holder
         );
@@ -355,7 +358,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
     function _getSnapshotAmountByPercentage(
         ILifeCycleCashFlow.SnapshotAmountInfo memory amountInfo
     ) internal view returns (uint256) {
-        uint256 holderTokens = ISnapshots(amountInfo.asset).balanceOfAtSnapshot(
+        uint256 holderTokens = IBalanceTrackerAtSnapshot(amountInfo.asset).balanceOfAtSnapshot(
             amountInfo.snapshotID,
             amountInfo.holder
         );
@@ -793,7 +796,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
      * @return The asset total supply
      */
     function _getTotalSupplyAtSnapshot(address _asset, uint256 _snapshotID) private view returns (uint256) {
-        return ISnapshots(_asset).totalSupplyAtSnapshot(_snapshotID);
+        return IBalanceTrackerAtSnapshot(_asset).totalSupplyAtSnapshot(_snapshotID);
     }
 
     /*


### PR DESCRIPTION
## Summary

- Fixed MP contract compile failure: `LifeCycleCashFlowStorageWrapper.sol` now imports and uses `IBalanceTrackerAtSnapshot` interface instead of incomplete `ISnapshots` cast
- Updated 3 cast sites to target the correct interface (lines 340, 360, 798)
- Added `packages/ats/contracts/**` to MP test workflow trigger paths to catch similar integration breaks automatically in CI

## Test plan

- [ ] MP contracts compile without errors
- [ ] Existing MP tests pass
- [ ] CI workflow triggers correctly on ATS contract changes