### PR TITLE
feat: clearing by partition facet

### DIFF
--- a/.changeset/maf-clearing-by-partition-facet.md
+++ b/.changeset/maf-clearing-by-partition-facet.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+feat: ClearingByPartitionFacet — split 12 partition-scoped clearing functions out of ClearingActionsFacet, ClearingRedeemFacet, ClearingTransferFacet, and ClearingReadFacet into a new dedicated facet. Breaking: IClearingActions, IClearingRedeem, IClearingTransfer, and IClearingRead interfaceIds all change.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -90,6 +90,7 @@ export const CONTRACT_NAMES = [
   "ERC1410TokenHolderFacet",
   "BurnFacet",
   "BurnByPartitionFacet",
+  "ClearingByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",
   "DiamondFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -252,6 +252,9 @@ bytes32 constant _CLEARING_READ_RESOLVER_KEY = 0xebb2e29bdf4edaf4ca66a3f9b773508
 // keccak256("security.token.standard.clearing.actions.resolverKey")
 bytes32 constant _CLEARING_ACTIONS_RESOLVER_KEY = 0x5472dfc5c92ad7a8651518ea7d3854d3b6494e5bcaa19f91cd61bf93bf6f2a74;
 
+// keccak256("security.token.standard.clearingByPartition.resolverKey");
+bytes32 constant _CLEARING_BY_PARTITION_RESOLVER_KEY = 0xf85991852d77f3c0148a5664d929193035ee310d0ab31bb92a23ee973184f9a4;
+
 // keccak256("security.token.standard.clearing.transfer.fixed.rate.resolverKey");
 bytes32 constant _CLEARING_TRANSFER_FIXED_RATE_RESOLVER_KEY = 0x1ba056fe3e7ef86779515a9e7f364e84af0f60eb5f4175ac6d6e6e3f4c05fffb;
 

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -90,6 +90,7 @@ import { IComplianceFacet } from "./compliance/IComplianceFacet.sol";
 import { IMint } from "./mint/IMint.sol";
 import { IMintByPartition } from "./mintByPartition/IMintByPartition.sol";
 import { IBurnByPartition } from "./burnByPartition/IBurnByPartition.sol";
+import { IClearingByPartition } from "./clearingByPartition/IClearingByPartition.sol";
 import { IHoldFacet } from "./hold/IHoldFacet.sol";
 import { IBatchController } from "./batchController/IBatchController.sol";
 import { IBurn } from "./burn/IBurn.sol";
@@ -182,6 +183,7 @@ interface IAsset is
     IClearingHoldCreation,
     IOperatorClearingHoldByPartition,
     IClearingRead,
+    IClearingByPartition,
     // Additional ERC
     IComplianceFacet,
     IHoldFacet,

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IClearingByPartition } from "./IClearingByPartition.sol";
+import { CLEARING_VALIDATOR_ROLE } from "../../constants/roles.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+import { ProtectedPartitionsStorageWrapper } from "../../domain/core/ProtectedPartitionsStorageWrapper.sol";
+import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
+import { ClearingOps } from "../../domain/orchestrator/ClearingOps.sol";
+import { ClearingReadOps } from "../../domain/orchestrator/ClearingReadOps.sol";
+import { ClearingStorageWrapper } from "../../domain/asset/ClearingStorageWrapper.sol";
+import { ThirdPartyType } from "../../domain/asset/types/ThirdPartyType.sol";
+import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
+
+/**
+ * @title ClearingByPartition
+ * @author Asset Tokenization Studio Team
+ * @notice Abstract implementation of partition-aware clearing operations: approve/cancel/reclaim actions,
+ *         clearing redeem and transfer creation, and clearing read queries scoped to a partition.
+ * @dev Implements the partition-scoped subset of clearing functionality on top of ClearingOps,
+ *      ClearingReadOps, and ClearingStorageWrapper. Intended to be inherited by ClearingByPartitionFacet.
+ */
+abstract contract ClearingByPartition is IClearingByPartition, Modifiers {
+    /// @inheritdoc IClearingByPartition
+    function approveClearingOperationByPartition(
+        IClearingByPartition.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(CLEARING_VALIDATOR_ROLE)
+        onlyClearingActivated
+        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
+        onlyWithValidClearingId(_clearingOperationIdentifier)
+        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, false)
+        onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))
+        returns (bool success_, bytes32 partition_)
+    {
+        bytes memory operationData;
+        (success_, operationData, partition_) = ClearingOps.approveClearingOperationByPartition(
+            _clearingOperationIdentifier
+        );
+
+        emit ClearingOperationApproved(
+            EvmAccessors.getMsgSender(),
+            _clearingOperationIdentifier.tokenHolder,
+            _clearingOperationIdentifier.partition,
+            _clearingOperationIdentifier.clearingId,
+            _clearingOperationIdentifier.clearingOperationType,
+            operationData
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function cancelClearingOperationByPartition(
+        IClearingByPartition.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(CLEARING_VALIDATOR_ROLE)
+        onlyClearingActivated
+        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
+        onlyWithValidClearingId(_clearingOperationIdentifier)
+        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, false)
+        returns (bool success_)
+    {
+        success_ = ClearingOps.cancelClearingOperationByPartition(_clearingOperationIdentifier);
+        emit ClearingOperationCanceled(
+            EvmAccessors.getMsgSender(),
+            _clearingOperationIdentifier.tokenHolder,
+            _clearingOperationIdentifier.partition,
+            _clearingOperationIdentifier.clearingId,
+            _clearingOperationIdentifier.clearingOperationType
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function reclaimClearingOperationByPartition(
+        IClearingByPartition.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    )
+        external
+        override
+        onlyUnpaused
+        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
+        onlyWithValidClearingId(_clearingOperationIdentifier)
+        onlyClearingActivated
+        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, true)
+        onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))
+        returns (bool success_)
+    {
+        success_ = ClearingOps.reclaimClearingOperationByPartition(_clearingOperationIdentifier);
+        emit ClearingOperationReclaimed(
+            EvmAccessors.getMsgSender(),
+            _clearingOperationIdentifier.tokenHolder,
+            _clearingOperationIdentifier.partition,
+            _clearingOperationIdentifier.clearingId,
+            _clearingOperationIdentifier.clearingOperationType
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    /// @dev Emits {ClearedRedeemByPartition} via ClearingOps.clearingRedeemCreation.
+    function clearingRedeemByPartition(
+        ClearingOperation calldata _clearingOperation,
+        uint256 _amount
+    )
+        external
+        override
+        onlyUnpaused
+        onlyClearingActivated
+        onlyWithValidExpirationTimestamp(_clearingOperation.expirationTimestamp)
+        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
+        onlyDefaultPartitionWithSinglePartition(_clearingOperation.partition)
+        onlyUnProtectedPartitionsOrWildCardRole
+        returns (bool success_, uint256 clearingId_)
+    {
+        (success_, clearingId_) = ClearingOps.clearingRedeemCreation(
+            _clearingOperation,
+            _amount,
+            EvmAccessors.getMsgSender(),
+            "",
+            ThirdPartyType.NULL
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    /// @dev Emits {ClearedRedeemFromByPartition} via ClearingOps.clearingRedeemCreation.
+    function clearingRedeemFromByPartition(
+        ClearingOperationFrom calldata _clearingOperationFrom,
+        uint256 _amount
+    )
+        external
+        override
+        onlyUnpaused
+        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
+        onlyUnrecoveredAddress(_clearingOperationFrom.from)
+        onlyClearingActivated
+        onlyWithValidExpirationTimestamp(_clearingOperationFrom.clearingOperation.expirationTimestamp)
+        notZeroAddress(_clearingOperationFrom.from)
+        onlyDefaultPartitionWithSinglePartition(_clearingOperationFrom.clearingOperation.partition)
+        onlyUnProtectedPartitionsOrWildCardRole
+        returns (bool success_, uint256 clearingId_)
+    {
+        (success_, clearingId_) = ClearingOps.clearingRedeemCreation(
+            _clearingOperationFrom.clearingOperation,
+            _amount,
+            _clearingOperationFrom.from,
+            _clearingOperationFrom.operatorData,
+            ThirdPartyType.AUTHORIZED
+        );
+        ClearingOps.decreaseAllowedBalanceForClearing(
+            _clearingOperationFrom.clearingOperation.partition,
+            clearingId_,
+            ClearingOperationType.Redeem,
+            _clearingOperationFrom.from,
+            _amount
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    /// @dev Emits {ClearedTransferByPartition} via ClearingOps.clearingTransferCreation.
+    function clearingTransferByPartition(
+        ClearingOperation calldata _clearingOperation,
+        uint256 _amount,
+        address _to
+    )
+        external
+        override
+        onlyUnpaused
+        onlyClearingActivated
+        onlyWithValidExpirationTimestamp(_clearingOperation.expirationTimestamp)
+        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
+        onlyUnrecoveredAddress(_to)
+        notZeroAddress(_to)
+        onlyDefaultPartitionWithSinglePartition(_clearingOperation.partition)
+        onlyUnProtectedPartitionsOrWildCardRole
+        returns (bool success_, uint256 clearingId_)
+    {
+        (success_, clearingId_) = ClearingOps.clearingTransferCreation(
+            _clearingOperation,
+            _amount,
+            _to,
+            EvmAccessors.getMsgSender(),
+            "",
+            ThirdPartyType.NULL
+        );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    /// @dev Emits {ClearedTransferFromByPartition} via ClearingOps.clearingTransferCreation.
+    function clearingTransferFromByPartition(
+        ClearingOperationFrom calldata _clearingOperationFrom,
+        uint256 _amount,
+        address _to
+    )
+        external
+        override
+        onlyUnpaused
+        onlyClearingActivated
+        onlyWithValidExpirationTimestamp(_clearingOperationFrom.clearingOperation.expirationTimestamp)
+        notZeroAddress(_clearingOperationFrom.from)
+        notZeroAddress(_to)
+        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
+        onlyUnrecoveredAddress(_to)
+        onlyUnrecoveredAddress(_clearingOperationFrom.from)
+        returns (bool success_, uint256 clearingId_)
+    {
+        return _clearingTransferFromByPartition(_clearingOperationFrom, _amount, _to);
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function getClearingRedeemForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _clearingId
+    ) external view override returns (ClearingRedeemData memory clearingRedeemData_) {
+        return
+            ClearingReadOps.getClearingRedeemForByPartitionAdjustedAt(
+                _partition,
+                _tokenHolder,
+                _clearingId,
+                TimeTravelStorageWrapper.getBlockTimestamp()
+            );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function getClearingTransferForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _clearingId
+    ) external view override returns (ClearingTransferData memory clearingTransferData_) {
+        return
+            ClearingReadOps.getClearingTransferForByPartitionAdjustedAt(
+                _partition,
+                _tokenHolder,
+                _clearingId,
+                TimeTravelStorageWrapper.getBlockTimestamp()
+            );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function getClearedAmountForByPartition(
+        bytes32 _partition,
+        address _tokenHolder
+    ) external view override returns (uint256 amount_) {
+        return
+            ClearingReadOps.getClearedAmountForByPartitionAdjustedAt(
+                _partition,
+                _tokenHolder,
+                TimeTravelStorageWrapper.getBlockTimestamp()
+            );
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function getClearingCountForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        ClearingOperationType _clearingOperationType
+    ) external view override returns (uint256 clearingCount_) {
+        return ClearingStorageWrapper.getClearingCountForByPartition(_partition, _tokenHolder, _clearingOperationType);
+    }
+
+    /// @inheritdoc IClearingByPartition
+    function getClearingsIdForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        ClearingOperationType _clearingOperationType,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view override returns (uint256[] memory clearingsId_) {
+        return
+            ClearingStorageWrapper.getClearingsIdForByPartition(
+                _partition,
+                _tokenHolder,
+                _clearingOperationType,
+                _pageIndex,
+                _pageLength
+            );
+    }
+
+    function _clearingTransferFromByPartition(
+        ClearingOperationFrom calldata _clearingOperationFrom,
+        uint256 _amount,
+        address _to
+    ) internal returns (bool success_, uint256 clearingId_) {
+        ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(
+            _clearingOperationFrom.clearingOperation.partition
+        );
+        ProtectedPartitionsStorageWrapper.requireUnProtectedPartitionsOrWildCardRole();
+        (success_, clearingId_) = ClearingOps.clearingTransferCreation(
+            _clearingOperationFrom.clearingOperation,
+            _amount,
+            _to,
+            _clearingOperationFrom.from,
+            _clearingOperationFrom.operatorData,
+            ThirdPartyType.AUTHORIZED
+        );
+        ClearingOps.decreaseAllowedBalanceForClearing(
+            _clearingOperationFrom.clearingOperation.partition,
+            clearingId_,
+            ClearingOperationType.Transfer,
+            _clearingOperationFrom.from,
+            _amount
+        );
+    }
+}

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingByPartition } from "./IClearingByPartition.sol";
 import { CLEARING_VALIDATOR_ROLE } from "../../constants/roles.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
-import { ProtectedPartitionsStorageWrapper } from "../../domain/core/ProtectedPartitionsStorageWrapper.sol";
-import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { ClearingOps } from "../../domain/orchestrator/ClearingOps.sol";
 import { ClearingReadOps } from "../../domain/orchestrator/ClearingReadOps.sol";
@@ -205,6 +203,8 @@ abstract contract ClearingByPartition is IClearingByPartition, Modifiers {
         onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
         onlyUnrecoveredAddress(_to)
         onlyUnrecoveredAddress(_clearingOperationFrom.from)
+        onlyDefaultPartitionWithSinglePartition(_clearingOperationFrom.clearingOperation.partition)
+        onlyUnProtectedPartitionsOrWildCardRole
         returns (bool success_, uint256 clearingId_)
     {
         return _clearingTransferFromByPartition(_clearingOperationFrom, _amount, _to);
@@ -285,10 +285,6 @@ abstract contract ClearingByPartition is IClearingByPartition, Modifiers {
         uint256 _amount,
         address _to
     ) internal returns (bool success_, uint256 clearingId_) {
-        ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(
-            _clearingOperationFrom.clearingOperation.partition
-        );
-        ProtectedPartitionsStorageWrapper.requireUnProtectedPartitionsOrWildCardRole();
         (success_, clearingId_) = ClearingOps.clearingTransferCreation(
             _clearingOperationFrom.clearingOperation,
             _amount,

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartitionFacet.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IClearingByPartition } from "./IClearingByPartition.sol";
+import { ClearingByPartition } from "./ClearingByPartition.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _CLEARING_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title ClearingByPartitionFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes the partition-scoped clearing operations: approve, cancel,
+ *         reclaim, clearing redeem/transfer creation and their associated read queries.
+ * @dev Registers 12 selectors under _CLEARING_BY_PARTITION_RESOLVER_KEY. All mutation functions
+ *      require clearing to be activated and the token to be unpaused.
+ */
+contract ClearingByPartitionFacet is ClearingByPartition, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _CLEARING_BY_PARTITION_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 12;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.getClearingsIdForByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getClearingCountForByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getClearedAmountForByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getClearingTransferForByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.clearingTransferFromByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.clearingTransferByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getClearingRedeemForByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.clearingRedeemFromByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.clearingRedeemByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.reclaimClearingOperationByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.cancelClearingOperationByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.approveClearingOperationByPartition.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IClearingByPartition).interfaceId;
+        }
+    }
+}

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
@@ -3,12 +3,22 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { IClearingTypes } from "../layer_1/clearing/IClearingTypes.sol";
 
+/**
+ * @title IClearingByPartition
+ * @author Asset Tokenization Studio Team
+ * @notice Interface for partition-scoped clearing operations: approve, cancel, reclaim,
+ *         clearing redeems and transfers, and read queries scoped to a single partition.
+ * @dev Extends IClearingTypes. Implementations must enforce single-partition mode,
+ *      protected-partition access control, and standard clearing lifecycle guards.
+ */
 interface IClearingByPartition is IClearingTypes {
     /**
      * @notice Approves a clearing operation previously requested by a token holder
      * @dev Can only be called before expiration date
      *
      * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
+     * @return success_ True if the operation was approved successfully
+     * @return partition_ Partition of the approved clearing operation
      */
     function approveClearingOperationByPartition(
         IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
@@ -19,6 +29,7 @@ interface IClearingByPartition is IClearingTypes {
      * @dev Can only be called before expiration date
      *
      * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
+     * @return success_ True if the operation was cancelled successfully
      */
     function cancelClearingOperationByPartition(
         IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
@@ -26,6 +37,9 @@ interface IClearingByPartition is IClearingTypes {
 
     /**
      * @notice Reclaims a clearing operation returning funds back to the token holder
+     * @dev Callable by the token holder once the operation has expired.
+     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
+     * @return success_ True if the operation was reclaimed successfully
      */
     function reclaimClearingOperationByPartition(
         IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
@@ -36,6 +50,8 @@ interface IClearingByPartition is IClearingTypes {
      *
      * @param _clearingOperation The clearing operation details
      * @param _amount The amount to redeem
+     * @return success_ True if the clearing redeem was created successfully
+     * @return clearingId_ Identifier assigned to the new clearing operation
      */
     function clearingRedeemByPartition(
         IClearingTypes.ClearingOperation calldata _clearingOperation,
@@ -48,6 +64,8 @@ interface IClearingByPartition is IClearingTypes {
      *
      * @param _clearingOperationFrom The clearing operation details
      * @param _amount The amount to redeem
+     * @return success_ True if the clearing redeem was created successfully
+     * @return clearingId_ Identifier assigned to the new clearing operation
      */
     function clearingRedeemFromByPartition(
         IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
@@ -60,6 +78,8 @@ interface IClearingByPartition is IClearingTypes {
      * @param _clearingOperation The clearing operation details
      * @param _amount The amount to transfer
      * @param _to The address to transfer the tokens to
+     * @return success_ True if the clearing transfer was created successfully
+     * @return clearingId_ Identifier assigned to the new clearing operation
      */
     function clearingTransferByPartition(
         IClearingTypes.ClearingOperation calldata _clearingOperation,
@@ -74,6 +94,8 @@ interface IClearingByPartition is IClearingTypes {
      * @param _clearingOperationFrom The clearing operation details
      * @param _amount The amount to transfer
      * @param _to The address to transfer the tokens to
+     * @return success_ True if the clearing transfer was created successfully
+     * @return clearingId_ Identifier assigned to the new clearing operation
      */
     function clearingTransferFromByPartition(
         IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
@@ -113,6 +135,9 @@ interface IClearingByPartition is IClearingTypes {
 
     /**
      * @notice Gets the total cleared amount for a token holder by partition
+     * @param _partition The partition of the token
+     * @param _tokenHolder The address of the token holder
+     * @return amount_ Total amount of tokens currently locked in clearing for the holder
      */
     function getClearedAmountForByPartition(
         bytes32 _partition,
@@ -121,6 +146,10 @@ interface IClearingByPartition is IClearingTypes {
 
     /**
      * @notice Gets the total clearing count for a token holder by partition and clearing operation type
+     * @param _partition The partition of the token
+     * @param _tokenHolder The address of the token holder
+     * @param _clearingOperationType Type of clearing operation (Transfer, Redeem, or HoldCreation)
+     * @return clearingCount_ Number of active clearing operations of the given type
      */
     function getClearingCountForByPartition(
         bytes32 _partition,
@@ -130,6 +159,12 @@ interface IClearingByPartition is IClearingTypes {
 
     /**
      * @notice Gets the ids of the clearings for a token holder by partition and clearing operation type
+     * @param _partition The partition of the token
+     * @param _tokenHolder The address of the token holder
+     * @param _clearingOperationType Type of clearing operation (Transfer, Redeem, or HoldCreation)
+     * @param _pageIndex Zero-based page index for pagination
+     * @param _pageLength Maximum number of IDs to return per page
+     * @return clearingsId_ Array of clearing operation IDs for the given page
      */
     function getClearingsIdForByPartition(
         bytes32 _partition,

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IClearingTypes } from "../layer_1/clearing/IClearingTypes.sol";
+
+interface IClearingByPartition is IClearingTypes {
+    /**
+     * @notice Approves a clearing operation previously requested by a token holder
+     * @dev Can only be called before expiration date
+     *
+     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
+     */
+    function approveClearingOperationByPartition(
+        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    ) external returns (bool success_, bytes32 partition_);
+
+    /**
+     * @notice Cancels a clearing operation returning funds back to the token holder
+     * @dev Can only be called before expiration date
+     *
+     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
+     */
+    function cancelClearingOperationByPartition(
+        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    ) external returns (bool success_);
+
+    /**
+     * @notice Reclaims a clearing operation returning funds back to the token holder
+     */
+    function reclaimClearingOperationByPartition(
+        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
+    ) external returns (bool success_);
+
+    /**
+     * @notice Creates a redeem clearing operation for a partition
+     *
+     * @param _clearingOperation The clearing operation details
+     * @param _amount The amount to redeem
+     */
+    function clearingRedeemByPartition(
+        IClearingTypes.ClearingOperation calldata _clearingOperation,
+        uint256 _amount
+    ) external returns (bool success_, uint256 clearingId_);
+
+    /**
+     * @notice Creates a redeem clearing operation for a partition from a third party
+     * @dev Caller needs to have approval to transfer the tokens from the token holder
+     *
+     * @param _clearingOperationFrom The clearing operation details
+     * @param _amount The amount to redeem
+     */
+    function clearingRedeemFromByPartition(
+        IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
+        uint256 _amount
+    ) external returns (bool success_, uint256 clearingId_);
+
+    /**
+     * @notice Creates a transfer clearing operation for a partition
+     *
+     * @param _clearingOperation The clearing operation details
+     * @param _amount The amount to transfer
+     * @param _to The address to transfer the tokens to
+     */
+    function clearingTransferByPartition(
+        IClearingTypes.ClearingOperation calldata _clearingOperation,
+        uint256 _amount,
+        address _to
+    ) external returns (bool success_, uint256 clearingId_);
+
+    /**
+     * @notice Creates a transfer clearing operation for a partition from a third party
+     * @dev Caller needs to have approval to transfer the tokens from the token holder
+     *
+     * @param _clearingOperationFrom The clearing operation details
+     * @param _amount The amount to transfer
+     * @param _to The address to transfer the tokens to
+     */
+    function clearingTransferFromByPartition(
+        IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
+        uint256 _amount,
+        address _to
+    ) external returns (bool success_, uint256 clearingId_);
+
+    /**
+     * @notice Gets the clearing redeem data for a given partition, token holder and clearing ID
+     *
+     * @param _partition The partition of the token
+     * @param _tokenHolder The address of the token holder
+     * @param _clearingId The ID of the clearing operation
+     *
+     * @return clearingRedeemData_ The clearing redeem data
+     */
+    function getClearingRedeemForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _clearingId
+    ) external view returns (IClearingTypes.ClearingRedeemData memory clearingRedeemData_);
+
+    /**
+     * @notice Gets the clearing transfer data for a given partition, token holder and clearing ID
+     *
+     * @param _partition The partition of the token
+     * @param _tokenHolder The address of the token holder
+     * @param _clearingId The ID of the clearing operation
+     *
+     * @return clearingTransferData_ The clearing transfer data
+     */
+    function getClearingTransferForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _clearingId
+    ) external view returns (IClearingTypes.ClearingTransferData memory clearingTransferData_);
+
+    /**
+     * @notice Gets the total cleared amount for a token holder by partition
+     */
+    function getClearedAmountForByPartition(
+        bytes32 _partition,
+        address _tokenHolder
+    ) external view returns (uint256 amount_);
+
+    /**
+     * @notice Gets the total clearing count for a token holder by partition and clearing operation type
+     */
+    function getClearingCountForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        IClearingTypes.ClearingOperationType _clearingOperationType
+    ) external view returns (uint256 clearingCount_);
+
+    /**
+     * @notice Gets the ids of the clearings for a token holder by partition and clearing operation type
+     */
+    function getClearingsIdForByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        IClearingTypes.ClearingOperationType _clearingOperationType,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (uint256[] memory clearingsId_);
+}

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingActions.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingActions.sol
@@ -2,11 +2,9 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IClearingActions } from "./IClearingActions.sol";
-import { IClearingTypes } from "./IClearingTypes.sol";
-import { CLEARING_VALIDATOR_ROLE, CLEARING_ROLE } from "../../../constants/roles.sol";
+import { CLEARING_ROLE } from "../../../constants/roles.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
 import { ClearingStorageWrapper } from "../../../domain/asset/ClearingStorageWrapper.sol";
-import { ClearingOps } from "../../../domain/orchestrator/ClearingOps.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract ClearingActions is IClearingActions, Modifiers {
@@ -22,81 +20,6 @@ abstract contract ClearingActions is IClearingActions, Modifiers {
     function deactivateClearing() external onlyUnpaused onlyRole(CLEARING_ROLE) returns (bool success_) {
         emit ClearingDeactivated(EvmAccessors.getMsgSender());
         success_ = ClearingStorageWrapper.setClearing(false);
-    }
-
-    function approveClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(CLEARING_VALIDATOR_ROLE)
-        onlyClearingActivated
-        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
-        onlyWithValidClearingId(_clearingOperationIdentifier)
-        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, false)
-        onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))
-        returns (bool success_, bytes32 partition_)
-    {
-        bytes memory operationData;
-        (success_, operationData, partition_) = ClearingOps.approveClearingOperationByPartition(
-            _clearingOperationIdentifier
-        );
-
-        emit ClearingOperationApproved(
-            EvmAccessors.getMsgSender(),
-            _clearingOperationIdentifier.tokenHolder,
-            _clearingOperationIdentifier.partition,
-            _clearingOperationIdentifier.clearingId,
-            _clearingOperationIdentifier.clearingOperationType,
-            operationData
-        );
-    }
-
-    function cancelClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(CLEARING_VALIDATOR_ROLE)
-        onlyClearingActivated
-        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
-        onlyWithValidClearingId(_clearingOperationIdentifier)
-        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, false)
-        returns (bool success_)
-    {
-        success_ = ClearingOps.cancelClearingOperationByPartition(_clearingOperationIdentifier);
-        emit ClearingOperationCanceled(
-            EvmAccessors.getMsgSender(),
-            _clearingOperationIdentifier.tokenHolder,
-            _clearingOperationIdentifier.partition,
-            _clearingOperationIdentifier.clearingId,
-            _clearingOperationIdentifier.clearingOperationType
-        );
-    }
-
-    function reclaimClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    )
-        external
-        override
-        onlyUnpaused
-        onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
-        onlyWithValidClearingId(_clearingOperationIdentifier)
-        onlyClearingActivated
-        onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, true)
-        onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))
-        returns (bool success_)
-    {
-        success_ = ClearingOps.reclaimClearingOperationByPartition(_clearingOperationIdentifier);
-        emit ClearingOperationReclaimed(
-            EvmAccessors.getMsgSender(),
-            _clearingOperationIdentifier.tokenHolder,
-            _clearingOperationIdentifier.partition,
-            _clearingOperationIdentifier.clearingId,
-            _clearingOperationIdentifier.clearingOperationType
-        );
     }
 
     function isClearingActivated() external view returns (bool) {

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingActionsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingActionsFacet.sol
@@ -12,19 +12,21 @@ contract ClearingActionsFacet is ClearingActions, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeClearing.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.activateClearing.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.deactivateClearing.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.approveClearingOperationByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.cancelClearingOperationByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.reclaimClearingOperationByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isClearingActivated.selector;
+        uint256 selectorIndex = 4;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.isClearingActivated.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.deactivateClearing.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.activateClearing.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.initializeClearing.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IClearingActions).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IClearingActions).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRead.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRead.sol
@@ -12,43 +12,6 @@ abstract contract ClearingRead is IClearingRead {
             ClearingReadOps.getClearedAmountForAdjustedAt(_tokenHolder, TimeTravelStorageWrapper.getBlockTimestamp());
     }
 
-    function getClearedAmountForByPartition(
-        bytes32 _partition,
-        address _tokenHolder
-    ) external view returns (uint256 amount_) {
-        return
-            ClearingReadOps.getClearedAmountForByPartitionAdjustedAt(
-                _partition,
-                _tokenHolder,
-                TimeTravelStorageWrapper.getBlockTimestamp()
-            );
-    }
-
-    function getClearingCountForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        ClearingOperationType _clearingOperationType
-    ) external view override returns (uint256 clearingCount_) {
-        return ClearingStorageWrapper.getClearingCountForByPartition(_partition, _tokenHolder, _clearingOperationType);
-    }
-
-    function getClearingsIdForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        ClearingOperationType _clearingOperationType,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view override returns (uint256[] memory clearingsId_) {
-        return
-            ClearingStorageWrapper.getClearingsIdForByPartition(
-                _partition,
-                _tokenHolder,
-                _clearingOperationType,
-                _pageIndex,
-                _pageLength
-            );
-    }
-
     function getClearingThirdParty(
         bytes32 _partition,
         address _tokenHolder,

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingReadFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingReadFacet.sol
@@ -12,17 +12,19 @@ contract ClearingReadFacet is ClearingRead, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.getClearedAmountFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearedAmountForByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearingCountForByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearingsIdForByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearingThirdParty.selector;
+        uint256 selectorIndex = 2;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.getClearingThirdParty.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getClearedAmountFor.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IClearingRead).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IClearingRead).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRedeem.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRedeem.sol
@@ -4,69 +4,12 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingRedeem } from "./IClearingRedeem.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
 import { ProtectedPartitionsStorageWrapper } from "../../../domain/core/ProtectedPartitionsStorageWrapper.sol";
-import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { ClearingOps } from "../../../domain/orchestrator/ClearingOps.sol";
 import { ClearingProtectedOps } from "../../../domain/orchestrator/ClearingProtectedOps.sol";
-import { ClearingReadOps } from "../../../domain/orchestrator/ClearingReadOps.sol";
 import { ThirdPartyType } from "../../../domain/asset/types/ThirdPartyType.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract ClearingRedeem is IClearingRedeem, Modifiers {
-    function clearingRedeemByPartition(
-        ClearingOperation calldata _clearingOperation,
-        uint256 _amount
-    )
-        external
-        override
-        onlyUnpaused
-        onlyClearingActivated
-        onlyWithValidExpirationTimestamp(_clearingOperation.expirationTimestamp)
-        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
-        onlyDefaultPartitionWithSinglePartition(_clearingOperation.partition)
-        onlyUnProtectedPartitionsOrWildCardRole
-        returns (bool success_, uint256 clearingId_)
-    {
-        (success_, clearingId_) = ClearingOps.clearingRedeemCreation(
-            _clearingOperation,
-            _amount,
-            EvmAccessors.getMsgSender(),
-            "",
-            ThirdPartyType.NULL
-        );
-    }
-
-    function clearingRedeemFromByPartition(
-        ClearingOperationFrom calldata _clearingOperationFrom,
-        uint256 _amount
-    )
-        external
-        override
-        onlyUnpaused
-        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
-        onlyUnrecoveredAddress(_clearingOperationFrom.from)
-        onlyClearingActivated
-        onlyWithValidExpirationTimestamp(_clearingOperationFrom.clearingOperation.expirationTimestamp)
-        notZeroAddress(_clearingOperationFrom.from)
-        onlyDefaultPartitionWithSinglePartition(_clearingOperationFrom.clearingOperation.partition)
-        onlyUnProtectedPartitionsOrWildCardRole
-        returns (bool success_, uint256 clearingId_)
-    {
-        (success_, clearingId_) = ClearingOps.clearingRedeemCreation(
-            _clearingOperationFrom.clearingOperation,
-            _amount,
-            _clearingOperationFrom.from,
-            _clearingOperationFrom.operatorData,
-            ThirdPartyType.AUTHORIZED
-        );
-        ClearingOps.decreaseAllowedBalanceForClearing(
-            _clearingOperationFrom.clearingOperation.partition,
-            clearingId_,
-            ClearingOperationType.Redeem,
-            _clearingOperationFrom.from,
-            _amount
-        );
-    }
-
     function operatorClearingRedeemByPartition(
         ClearingOperationFrom calldata _clearingOperationFrom,
         uint256 _amount
@@ -118,19 +61,5 @@ abstract contract ClearingRedeem is IClearingRedeem, Modifiers {
             _amount,
             _signature
         );
-    }
-
-    function getClearingRedeemForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _clearingId
-    ) external view override returns (ClearingRedeemData memory clearingRedeemData_) {
-        return
-            ClearingReadOps.getClearingRedeemForByPartitionAdjustedAt(
-                _partition,
-                _tokenHolder,
-                _clearingId,
-                TimeTravelStorageWrapper.getBlockTimestamp()
-            );
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRedeemFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingRedeemFacet.sol
@@ -12,17 +12,19 @@ contract ClearingRedeemFacet is ClearingRedeem, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.clearingRedeemByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.clearingRedeemFromByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.operatorClearingRedeemByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.protectedClearingRedeemByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearingRedeemForByPartition.selector;
+        uint256 selectorIndex = 2;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.protectedClearingRedeemByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.operatorClearingRedeemByPartition.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IClearingRedeem).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IClearingRedeem).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingTransfer.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingTransfer.sol
@@ -4,62 +4,12 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingTransfer } from "./IClearingTransfer.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
 import { ProtectedPartitionsStorageWrapper } from "../../../domain/core/ProtectedPartitionsStorageWrapper.sol";
-import { ERC1410StorageWrapper } from "../../../domain/asset/ERC1410StorageWrapper.sol";
-import { TimeTravelStorageWrapper } from "../../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { ClearingOps } from "../../../domain/orchestrator/ClearingOps.sol";
 import { ClearingProtectedOps } from "../../../domain/orchestrator/ClearingProtectedOps.sol";
-import { ClearingReadOps } from "../../../domain/orchestrator/ClearingReadOps.sol";
 import { ThirdPartyType } from "../../../domain/asset/types/ThirdPartyType.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract ClearingTransfer is IClearingTransfer, Modifiers {
-    function clearingTransferByPartition(
-        ClearingOperation calldata _clearingOperation,
-        uint256 _amount,
-        address _to
-    )
-        external
-        override
-        onlyUnpaused
-        onlyClearingActivated
-        onlyWithValidExpirationTimestamp(_clearingOperation.expirationTimestamp)
-        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
-        onlyUnrecoveredAddress(_to)
-        notZeroAddress(_to)
-        onlyDefaultPartitionWithSinglePartition(_clearingOperation.partition)
-        onlyUnProtectedPartitionsOrWildCardRole
-        returns (bool success_, uint256 clearingId_)
-    {
-        (success_, clearingId_) = ClearingOps.clearingTransferCreation(
-            _clearingOperation,
-            _amount,
-            _to,
-            EvmAccessors.getMsgSender(),
-            "",
-            ThirdPartyType.NULL
-        );
-    }
-
-    function clearingTransferFromByPartition(
-        ClearingOperationFrom calldata _clearingOperationFrom,
-        uint256 _amount,
-        address _to
-    )
-        external
-        override
-        onlyUnpaused
-        onlyClearingActivated
-        onlyWithValidExpirationTimestamp(_clearingOperationFrom.clearingOperation.expirationTimestamp)
-        notZeroAddress(_clearingOperationFrom.from)
-        notZeroAddress(_to)
-        onlyUnrecoveredAddress(EvmAccessors.getMsgSender())
-        onlyUnrecoveredAddress(_to)
-        onlyUnrecoveredAddress(_clearingOperationFrom.from)
-        returns (bool success_, uint256 clearingId_)
-    {
-        return _clearingTransferFromByPartition(_clearingOperationFrom, _amount, _to);
-    }
-
     function operatorClearingTransferByPartition(
         ClearingOperationFrom calldata _clearingOperationFrom,
         uint256 _amount,
@@ -117,46 +67,6 @@ abstract contract ClearingTransfer is IClearingTransfer, Modifiers {
             _amount,
             _to,
             _signature
-        );
-    }
-
-    function getClearingTransferForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _clearingId
-    ) external view override returns (ClearingTransferData memory clearingTransferData_) {
-        return
-            ClearingReadOps.getClearingTransferForByPartitionAdjustedAt(
-                _partition,
-                _tokenHolder,
-                _clearingId,
-                TimeTravelStorageWrapper.getBlockTimestamp()
-            );
-    }
-
-    function _clearingTransferFromByPartition(
-        ClearingOperationFrom calldata _clearingOperationFrom,
-        uint256 _amount,
-        address _to
-    ) internal returns (bool success_, uint256 clearingId_) {
-        ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(
-            _clearingOperationFrom.clearingOperation.partition
-        );
-        ProtectedPartitionsStorageWrapper.requireUnProtectedPartitionsOrWildCardRole();
-        (success_, clearingId_) = ClearingOps.clearingTransferCreation(
-            _clearingOperationFrom.clearingOperation,
-            _amount,
-            _to,
-            _clearingOperationFrom.from,
-            _clearingOperationFrom.operatorData,
-            ThirdPartyType.AUTHORIZED
-        );
-        ClearingOps.decreaseAllowedBalanceForClearing(
-            _clearingOperationFrom.clearingOperation.partition,
-            clearingId_,
-            ClearingOperationType.Transfer,
-            _clearingOperationFrom.from,
-            _amount
         );
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingTransferFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/ClearingTransferFacet.sol
@@ -12,17 +12,19 @@ contract ClearingTransferFacet is ClearingTransfer, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.clearingTransferByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.clearingTransferFromByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.operatorClearingTransferByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.protectedClearingTransferByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getClearingTransferForByPartition.selector;
+        uint256 selectorIndex = 2;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.protectedClearingTransferByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.operatorClearingTransferByPartition.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IClearingTransfer).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IClearingTransfer).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingActions.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingActions.sol
@@ -17,33 +17,6 @@ interface IClearingActions is IClearingTypes {
     function deactivateClearing() external returns (bool success_);
 
     /**
-     * @notice Approves a clearing operation previously requested by a token holder
-     * @dev Can only be called before expiration date
-     *
-     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
-     */
-    function approveClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    ) external returns (bool success_, bytes32 partition_);
-
-    /**
-     * @notice Cancels a clearing operation returning funds back to the token holder
-     * @dev Can only be called before expiration date
-     *
-     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
-     */
-    function cancelClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    ) external returns (bool success_);
-
-    /**
-     * @notice Reclaims a clearing operation returning funds back to the token holder
-     */
-    function reclaimClearingOperationByPartition(
-        IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier
-    ) external returns (bool success_);
-
-    /**
      * @notice Returns whether the clearing functionality is activated or not
      *
      * @return bool true if activated, false otherwise

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingRead.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingRead.sol
@@ -10,34 +10,6 @@ interface IClearingRead is IClearingTypes {
     function getClearedAmountFor(address _tokenHolder) external view returns (uint256 amount_);
 
     /**
-     * @notice Gets the total cleared amount for a token holder by partition
-     */
-    function getClearedAmountForByPartition(
-        bytes32 _partition,
-        address _tokenHolder
-    ) external view returns (uint256 amount_);
-
-    /**
-     * @notice Gets the total clearing count for a token holder by partition and clearing operation type
-     */
-    function getClearingCountForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        IClearingTypes.ClearingOperationType _clearingOperationType
-    ) external view returns (uint256 clearingCount_);
-
-    /**
-     * @notice Gets the ids of the clearings for a token holder by partition and clearing operation type
-     */
-    function getClearingsIdForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        IClearingTypes.ClearingOperationType _clearingOperationType,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (uint256[] memory clearingsId_);
-
-    /**
      * @notice Gets the address of the party that initiated the clearing operation
      */
     function getClearingThirdParty(

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingRedeem.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingRedeem.sol
@@ -5,29 +5,6 @@ import { IClearingTypes } from "./IClearingTypes.sol";
 
 interface IClearingRedeem is IClearingTypes {
     /**
-     * @notice Creates a redeem clearing operation for a partition
-     *
-     * @param _clearingOperation The clearing operation details
-     * @param _amount The amount to redeem
-     */
-    function clearingRedeemByPartition(
-        IClearingTypes.ClearingOperation calldata _clearingOperation,
-        uint256 _amount
-    ) external returns (bool success_, uint256 clearingId_);
-
-    /**
-     * @notice Creates a redeem clearing operation for a partition from a third party
-     * @dev Caller needs to have approval to transfer the tokens from the token holder
-     *
-     * @param _clearingOperationFrom The clearing operation details
-     * @param _amount The amount to redeem
-     */
-    function clearingRedeemFromByPartition(
-        IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
-        uint256 _amount
-    ) external returns (bool success_, uint256 clearingId_);
-
-    /**
      * @notice Creates a redeem clearing operation for a partition from a third party
      * @dev Caller needs to be a token holder operator
      *
@@ -52,19 +29,4 @@ interface IClearingRedeem is IClearingTypes {
         uint256 _amount,
         bytes calldata _signature
     ) external returns (bool success_, uint256 clearingId_);
-
-    /**
-     * @notice Gets the clearing redeem data for a given partition, token holder and clearing ID
-     *
-     * @param _partition The partition of the token
-     * @param _tokenHolder The address of the token holder
-     * @param _clearingId The ID of the clearing operation
-     *
-     * @return clearingRedeemData_ The clearing reedeem data
-     */
-    function getClearingRedeemForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _clearingId
-    ) external view returns (IClearingTypes.ClearingRedeemData memory clearingRedeemData_);
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTransfer.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTransfer.sol
@@ -5,33 +5,6 @@ import { IClearingTypes } from "./IClearingTypes.sol";
 
 interface IClearingTransfer is IClearingTypes {
     /**
-     * @notice Creates a transfer clearing operation for a partition
-     *
-     * @param _clearingOperation The clearing operation details
-     * @param _amount The amount to redeem
-     * @param _to The address to transfer the tokens to
-     */
-    function clearingTransferByPartition(
-        IClearingTypes.ClearingOperation calldata _clearingOperation,
-        uint256 _amount,
-        address _to
-    ) external returns (bool success_, uint256 clearingId_);
-
-    /**
-     * @notice Creates a transfer clearing operation for a partition from a third party
-     * @dev Caller needs to have approval to transfer the tokens from the token holder
-     *
-     * @param _clearingOperationFrom The clearing operation details
-     * @param _amount The amount to transfer
-     * @param _to The address to transfer the tokens to
-     */
-    function clearingTransferFromByPartition(
-        IClearingTypes.ClearingOperationFrom calldata _clearingOperationFrom,
-        uint256 _amount,
-        address _to
-    ) external returns (bool success_, uint256 clearingId_);
-
-    /**
      * @notice Creates a transfer clearing operation for a partition from a third party
      * @dev Caller needs to be a token holder operator
      *
@@ -59,19 +32,4 @@ interface IClearingTransfer is IClearingTypes {
         address _to,
         bytes calldata _signature
     ) external returns (bool success_, uint256 clearingId_);
-
-    /**
-     * @notice Gets the clearing transfer data for a given partition, token holder and clearing ID
-     *
-     * @param _partition The partition of the token
-     * @param _tokenHolder The address of the token holder
-     * @param _clearingId The ID of the clearing operation
-     *
-     * @return clearingTransferData_ The clearing reedeem data
-     */
-    function getClearingTransferForByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _clearingId
-    ) external view returns (IClearingTypes.ClearingTransferData memory clearingTransferData_);
 }

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-29T07:49:44.474Z
- * Facets: 94
+ * Generated: 2026-04-29T09:41:11.353Z
+ * Facets: 95
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -44,6 +44,7 @@ import {
   BurnFacet__factory,
   CapFacet__factory,
   ClearingActionsFacet__factory,
+  ClearingByPartitionFacet__factory,
   ClearingHoldCreationFacet__factory,
   ClearingReadFacet__factory,
   ClearingRedeemFacet__factory,
@@ -2900,22 +2901,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xab2d18a9",
       },
       {
-        name: "approveClearingOperationByPartition",
-        signature: {
-          full: "function approveClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_, bytes32 partition_)",
-          canonical: "approveClearingOperationByPartition((uint8,bytes32,address,uint256))",
-        },
-        selector: "0xd849cea2",
-      },
-      {
-        name: "cancelClearingOperationByPartition",
-        signature: {
-          full: "function cancelClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_)",
-          canonical: "cancelClearingOperationByPartition((uint8,bytes32,address,uint256))",
-        },
-        selector: "0x679141fb",
-      },
-      {
         name: "deactivateClearing",
         signature: { full: "function deactivateClearing() returns (bool success_)", canonical: "deactivateClearing()" },
         selector: "0x65c21860",
@@ -2929,14 +2914,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "isClearingActivated",
         signature: { full: "function isClearingActivated() view returns (bool)", canonical: "isClearingActivated()" },
         selector: "0x4b4d8990",
-      },
-      {
-        name: "reclaimClearingOperationByPartition",
-        signature: {
-          full: "function reclaimClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_)",
-          canonical: "reclaimClearingOperationByPartition((uint8,bytes32,address,uint256))",
-        },
-        selector: "0x67e57fe2",
       },
     ],
     events: [
@@ -3118,14 +3095,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x5ea0e3b0",
       },
       {
-        name: "PartitionNotAllowedInSinglePartitionMode",
-        signature: {
-          full: "error PartitionNotAllowedInSinglePartitionMode(bytes32 partition)",
-          canonical: "PartitionNotAllowedInSinglePartitionMode(bytes32)",
-        },
-        selector: "0xb96d9539",
-      },
-      {
         name: "TokenIsPaused",
         signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
         selector: "0x649815a5",
@@ -3136,9 +3105,334 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x2e37608c",
       },
     ],
-    factory: (signer) => new ClearingActionsFacet__factory(getLibLinks("clearingOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new ClearingActionsFacetTimeTravel__factory(getLibLinks("clearingOps") as any, signer),
+    factory: (signer) => new ClearingActionsFacet__factory(signer),
+    timeTravelFactory: (signer) => new ClearingActionsFacetTimeTravel__factory(signer),
+  },
+
+  ClearingByPartitionFacet: {
+    name: "ClearingByPartitionFacet",
+    description:
+      "Diamond facet that exposes the partition-scoped clearing operations: approve, cancel, reclaim, clearing redeem/transfer creation and their associated read queries.",
+    resolverKey: {
+      name: "_CLEARING_BY_PARTITION_RESOLVER_KEY",
+      value: "0xf85991852d77f3c0148a5664d929193035ee310d0ab31bb92a23ee973184f9a4",
+    },
+    inheritance: ["ClearingByPartition", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "approveClearingOperationByPartition",
+        signature: {
+          full: "function approveClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_, bytes32 partition_)",
+          canonical: "approveClearingOperationByPartition((uint8,bytes32,address,uint256))",
+        },
+        selector: "0xd849cea2",
+      },
+      {
+        name: "cancelClearingOperationByPartition",
+        signature: {
+          full: "function cancelClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_)",
+          canonical: "cancelClearingOperationByPartition((uint8,bytes32,address,uint256))",
+        },
+        selector: "0x679141fb",
+      },
+      {
+        name: "clearingRedeemByPartition",
+        signature: {
+          full: "function clearingRedeemByPartition((bytes32 partition, uint256 expirationTimestamp, bytes data) _clearingOperation, uint256 _amount) returns (bool success_, uint256 clearingId_)",
+          canonical: "clearingRedeemByPartition((bytes32,uint256,bytes),uint256)",
+        },
+        selector: "0x39921b12",
+      },
+      {
+        name: "clearingRedeemFromByPartition",
+        signature: {
+          full: "function clearingRedeemFromByPartition(((bytes32 partition, uint256 expirationTimestamp, bytes data) clearingOperation, address from, bytes operatorData) _clearingOperationFrom, uint256 _amount) returns (bool success_, uint256 clearingId_)",
+          canonical: "clearingRedeemFromByPartition(((bytes32,uint256,bytes),address,bytes),uint256)",
+        },
+        selector: "0x35114a78",
+      },
+      {
+        name: "clearingTransferByPartition",
+        signature: {
+          full: "function clearingTransferByPartition((bytes32 partition, uint256 expirationTimestamp, bytes data) _clearingOperation, uint256 _amount, address _to) returns (bool success_, uint256 clearingId_)",
+          canonical: "clearingTransferByPartition((bytes32,uint256,bytes),uint256,address)",
+        },
+        selector: "0xde32aaa8",
+      },
+      {
+        name: "clearingTransferFromByPartition",
+        signature: {
+          full: "function clearingTransferFromByPartition(((bytes32 partition, uint256 expirationTimestamp, bytes data) clearingOperation, address from, bytes operatorData) _clearingOperationFrom, uint256 _amount, address _to) returns (bool success_, uint256 clearingId_)",
+          canonical: "clearingTransferFromByPartition(((bytes32,uint256,bytes),address,bytes),uint256,address)",
+        },
+        selector: "0x5c829d67",
+      },
+      {
+        name: "getClearedAmountForByPartition",
+        signature: {
+          full: "function getClearedAmountForByPartition(bytes32 _partition, address _tokenHolder) view returns (uint256 amount_)",
+          canonical: "getClearedAmountForByPartition(bytes32,address)",
+        },
+        selector: "0xfed5a7d4",
+      },
+      {
+        name: "getClearingCountForByPartition",
+        signature: {
+          full: "function getClearingCountForByPartition(bytes32 _partition, address _tokenHolder, uint8 _clearingOperationType) view returns (uint256 clearingCount_)",
+          canonical: "getClearingCountForByPartition(bytes32,address,uint8)",
+        },
+        selector: "0xcab70f17",
+      },
+      {
+        name: "getClearingRedeemForByPartition",
+        signature: {
+          full: "function getClearingRedeemForByPartition(bytes32 _partition, address _tokenHolder, uint256 _clearingId) view returns ((uint256 amount, uint256 expirationTimestamp, bytes data, bytes operatorData, uint8 operatorType) clearingRedeemData_)",
+          canonical: "getClearingRedeemForByPartition(bytes32,address,uint256)",
+        },
+        selector: "0x4ac3d940",
+      },
+      {
+        name: "getClearingsIdForByPartition",
+        signature: {
+          full: "function getClearingsIdForByPartition(bytes32 _partition, address _tokenHolder, uint8 _clearingOperationType, uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] clearingsId_)",
+          canonical: "getClearingsIdForByPartition(bytes32,address,uint8,uint256,uint256)",
+        },
+        selector: "0xcf38dab5",
+      },
+      {
+        name: "getClearingTransferForByPartition",
+        signature: {
+          full: "function getClearingTransferForByPartition(bytes32 _partition, address _tokenHolder, uint256 _clearingId) view returns ((uint256 amount, uint256 expirationTimestamp, address destination, bytes data, bytes operatorData, uint8 operatorType) clearingTransferData_)",
+          canonical: "getClearingTransferForByPartition(bytes32,address,uint256)",
+        },
+        selector: "0x6f438552",
+      },
+      {
+        name: "reclaimClearingOperationByPartition",
+        signature: {
+          full: "function reclaimClearingOperationByPartition((uint8 clearingOperationType, bytes32 partition, address tokenHolder, uint256 clearingId) _clearingOperationIdentifier) returns (bool success_)",
+          canonical: "reclaimClearingOperationByPartition((uint8,bytes32,address,uint256))",
+        },
+        selector: "0x67e57fe2",
+      },
+    ],
+    events: [
+      {
+        name: "ClearedHoldByPartition",
+        signature: {
+          full: "event ClearedHoldByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, (uint256 amount, uint256 expirationTimestamp, address escrow, address to, bytes data) hold, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ClearedHoldByPartition(address,address,bytes32,uint256,(uint256,uint256,address,address,bytes),uint256,bytes,bytes)",
+        },
+        topic0: "0x8013fdb8047ec68adc0c0daf69054177bb5d8480b67f726aeefe6762fe0c01ed",
+      },
+      {
+        name: "ClearedHoldFromByPartition",
+        signature: {
+          full: "event ClearedHoldFromByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, (uint256 amount, uint256 expirationTimestamp, address escrow, address to, bytes data) hold, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ClearedHoldFromByPartition(address,address,bytes32,uint256,(uint256,uint256,address,address,bytes),uint256,bytes,bytes)",
+        },
+        topic0: "0x252da371b753edb80209b16882bb593cf10ba3ae90a37e60b3fb9b5cbb21cc5f",
+      },
+      {
+        name: "ClearedOperatorRedeemByPartition",
+        signature: {
+          full: "event ClearedOperatorRedeemByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical: "ClearedOperatorRedeemByPartition(address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0xfec64ec403134db0b1e479976a765b3e364f24c765f7c73ce9bf4b31e13ed3c8",
+      },
+      {
+        name: "ClearedOperatorTransferByPartition",
+        signature: {
+          full: "event ClearedOperatorTransferByPartition(address indexed operator, address indexed tokenHolder, address indexed to, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ClearedOperatorTransferByPartition(address,address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x8d9578064c4e2cadfe39cab8d79866d9e1c16956b958c6cbaedcec51f80d234a",
+      },
+      {
+        name: "ClearedRedeemByPartition",
+        signature: {
+          full: "event ClearedRedeemByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical: "ClearedRedeemByPartition(address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x7aaaa46250ad330b8cea62db34f608101d55300f94dd9b5ddbe83142bb51dc5f",
+      },
+      {
+        name: "ClearedRedeemFromByPartition",
+        signature: {
+          full: "event ClearedRedeemFromByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical: "ClearedRedeemFromByPartition(address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x376e6c31cfecec25cc3fede988557cb98dee3c5ffa5976b48a0b614b84c45d79",
+      },
+      {
+        name: "ClearedTransferByPartition",
+        signature: {
+          full: "event ClearedTransferByPartition(address indexed operator, address indexed tokenHolder, address indexed to, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical: "ClearedTransferByPartition(address,address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x3d9505d4e04c873230c8ad112ce725e8338ab4fa6c98a7699ea41d4d63c2758f",
+      },
+      {
+        name: "ClearedTransferFromByPartition",
+        signature: {
+          full: "event ClearedTransferFromByPartition(address indexed operator, address indexed tokenHolder, address indexed to, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ClearedTransferFromByPartition(address,address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x374f3552ea6ef855812358112ab8344010038fd2d56b9f47a1d9cb0320c275a2",
+      },
+      {
+        name: "ClearingActivated",
+        signature: {
+          full: "event ClearingActivated(address indexed operator)",
+          canonical: "ClearingActivated(address)",
+        },
+        topic0: "0x569080e4e18c204a1d28f09348d781d7cfb170428b2fd33e1f9b7df132674e15",
+      },
+      {
+        name: "ClearingDeactivated",
+        signature: {
+          full: "event ClearingDeactivated(address indexed operator)",
+          canonical: "ClearingDeactivated(address)",
+        },
+        topic0: "0xdb053585e5b33d19247ef59f5b465bcbb9774e6e5ce23932a7e3ffe829cd80a1",
+      },
+      {
+        name: "ClearingOperationApproved",
+        signature: {
+          full: "event ClearingOperationApproved(address indexed operator, address indexed tokenHolder, bytes32 indexed partition, uint256 clearingId, uint8 clearingOperationType, bytes operationData)",
+          canonical: "ClearingOperationApproved(address,address,bytes32,uint256,uint8,bytes)",
+        },
+        topic0: "0xc7c17dbfb7abbcc2a0ce6f48690f2fe9ae170920a1521b5c1d4d097a0d1a333f",
+      },
+      {
+        name: "ClearingOperationCanceled",
+        signature: {
+          full: "event ClearingOperationCanceled(address indexed operator, address indexed tokenHolder, bytes32 indexed partition, uint256 clearingId, uint8 clearingOperationType)",
+          canonical: "ClearingOperationCanceled(address,address,bytes32,uint256,uint8)",
+        },
+        topic0: "0x15a648856e27e7efec2173850a08afd84f952f7a0475cd26d49622ed6a561985",
+      },
+      {
+        name: "ClearingOperationReclaimed",
+        signature: {
+          full: "event ClearingOperationReclaimed(address indexed operator, address indexed tokenHolder, bytes32 indexed partition, uint256 clearingId, uint8 clearingOperationType)",
+          canonical: "ClearingOperationReclaimed(address,address,bytes32,uint256,uint8)",
+        },
+        topic0: "0x4d9191a307eb4a435af4b64dc128c2274a5907783338a0a1768296b3178896b6",
+      },
+      {
+        name: "ProtectedClearedHoldByPartition",
+        signature: {
+          full: "event ProtectedClearedHoldByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, (uint256 amount, uint256 expirationTimestamp, address escrow, address to, bytes data) hold, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ProtectedClearedHoldByPartition(address,address,bytes32,uint256,(uint256,uint256,address,address,bytes),uint256,bytes,bytes)",
+        },
+        topic0: "0x4808c12d75242665f58dad2f7f4c34c3a56ab0bdfc9a0e7ffa17241c43b822ea",
+      },
+      {
+        name: "ProtectedClearedRedeemByPartition",
+        signature: {
+          full: "event ProtectedClearedRedeemByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical: "ProtectedClearedRedeemByPartition(address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0xdd233f03eaed8aec1fe549f12e218c32dc2e73b3d5777bdeb33afa43e2fa2230",
+      },
+      {
+        name: "ProtectedClearedTransferByPartition",
+        signature: {
+          full: "event ProtectedClearedTransferByPartition(address indexed operator, address indexed tokenHolder, address indexed to, bytes32 partition, uint256 clearingId, uint256 amount, uint256 expirationDate, bytes data, bytes operatorData)",
+          canonical:
+            "ProtectedClearedTransferByPartition(address,address,address,bytes32,uint256,uint256,uint256,bytes,bytes)",
+        },
+        topic0: "0x8aea721bf4270b3b07d0974586b57ecd35862ae7a8b733530161d941489283f1",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "ClearingIsActivated",
+        signature: { full: "error ClearingIsActivated()", canonical: "ClearingIsActivated()" },
+        selector: "0x5b2e3086",
+      },
+      {
+        name: "ClearingIsDisabled",
+        signature: { full: "error ClearingIsDisabled()", canonical: "ClearingIsDisabled()" },
+        selector: "0x9f2523d3",
+      },
+      {
+        name: "ExpirationDateNotReached",
+        signature: { full: "error ExpirationDateNotReached()", canonical: "ExpirationDateNotReached()" },
+        selector: "0xaffb3088",
+      },
+      {
+        name: "ExpirationDateReached",
+        signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
+        selector: "0x5ea0e3b0",
+      },
+      {
+        name: "PartitionNotAllowedInSinglePartitionMode",
+        signature: {
+          full: "error PartitionNotAllowedInSinglePartitionMode(bytes32 partition)",
+          canonical: "PartitionNotAllowedInSinglePartitionMode(bytes32)",
+        },
+        selector: "0xb96d9539",
+      },
+      {
+        name: "PartitionsAreProtectedAndNoRole",
+        signature: {
+          full: "error PartitionsAreProtectedAndNoRole(address account, bytes32 role)",
+          canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
+        },
+        selector: "0x55347310",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "WalletRecovered",
+        signature: { full: "error WalletRecovered()", canonical: "WalletRecovered()" },
+        selector: "0xf9f9bcf9",
+      },
+      {
+        name: "WrongClearingId",
+        signature: { full: "error WrongClearingId()", canonical: "WrongClearingId()" },
+        selector: "0x2e37608c",
+      },
+      {
+        name: "WrongExpirationTimestamp",
+        signature: { full: "error WrongExpirationTimestamp()", canonical: "WrongExpirationTimestamp()" },
+        selector: "0xe39f4776",
+      },
+      {
+        name: "ZeroAddressNotAllowed",
+        signature: { full: "error ZeroAddressNotAllowed()", canonical: "ZeroAddressNotAllowed()" },
+        selector: "0x8579befe",
+      },
+    ],
+    factory: (signer) =>
+      new ClearingByPartitionFacet__factory(getLibLinks("clearingOps", "clearingReadOps") as any, signer),
   },
 
   ClearingHoldCreationFacet: {
@@ -3433,30 +3727,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x46f8bc94",
       },
       {
-        name: "getClearedAmountForByPartition",
-        signature: {
-          full: "function getClearedAmountForByPartition(bytes32 _partition, address _tokenHolder) view returns (uint256 amount_)",
-          canonical: "getClearedAmountForByPartition(bytes32,address)",
-        },
-        selector: "0xfed5a7d4",
-      },
-      {
-        name: "getClearingCountForByPartition",
-        signature: {
-          full: "function getClearingCountForByPartition(bytes32 _partition, address _tokenHolder, uint8 _clearingOperationType) view returns (uint256 clearingCount_)",
-          canonical: "getClearingCountForByPartition(bytes32,address,uint8)",
-        },
-        selector: "0xcab70f17",
-      },
-      {
-        name: "getClearingsIdForByPartition",
-        signature: {
-          full: "function getClearingsIdForByPartition(bytes32 _partition, address _tokenHolder, uint8 _clearingOperationType, uint256 _pageIndex, uint256 _pageLength) view returns (uint256[] clearingsId_)",
-          canonical: "getClearingsIdForByPartition(bytes32,address,uint8,uint256,uint256)",
-        },
-        selector: "0xcf38dab5",
-      },
-      {
         name: "getClearingThirdParty",
         signature: {
           full: "function getClearingThirdParty(bytes32 _partition, address _tokenHolder, uint8 _clearingOpeartionType, uint256 _clearingId) view returns (address thirdParty_)",
@@ -3641,30 +3911,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     },
     inheritance: ["ClearingRedeem", "IStaticFunctionSelectors"],
     methods: [
-      {
-        name: "clearingRedeemByPartition",
-        signature: {
-          full: "function clearingRedeemByPartition((bytes32 partition, uint256 expirationTimestamp, bytes data) _clearingOperation, uint256 _amount) returns (bool success_, uint256 clearingId_)",
-          canonical: "clearingRedeemByPartition((bytes32,uint256,bytes),uint256)",
-        },
-        selector: "0x39921b12",
-      },
-      {
-        name: "clearingRedeemFromByPartition",
-        signature: {
-          full: "function clearingRedeemFromByPartition(((bytes32 partition, uint256 expirationTimestamp, bytes data) clearingOperation, address from, bytes operatorData) _clearingOperationFrom, uint256 _amount) returns (bool success_, uint256 clearingId_)",
-          canonical: "clearingRedeemFromByPartition(((bytes32,uint256,bytes),address,bytes),uint256)",
-        },
-        selector: "0x35114a78",
-      },
-      {
-        name: "getClearingRedeemForByPartition",
-        signature: {
-          full: "function getClearingRedeemForByPartition(bytes32 _partition, address _tokenHolder, uint256 _clearingId) view returns ((uint256 amount, uint256 expirationTimestamp, bytes data, bytes operatorData, uint8 operatorType) clearingRedeemData_)",
-          canonical: "getClearingRedeemForByPartition(bytes32,address,uint256)",
-        },
-        selector: "0x4ac3d940",
-      },
       {
         name: "operatorClearingRedeemByPartition",
         signature: {
@@ -3912,15 +4158,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     factory: (signer) =>
-      new ClearingRedeemFacet__factory(
-        getLibLinks("clearingOps", "clearingProtectedOps", "clearingReadOps") as any,
-        signer,
-      ),
+      new ClearingRedeemFacet__factory(getLibLinks("clearingOps", "clearingProtectedOps") as any, signer),
     timeTravelFactory: (signer) =>
-      new ClearingRedeemFacetTimeTravel__factory(
-        getLibLinks("clearingOps", "clearingProtectedOps", "clearingReadOps") as any,
-        signer,
-      ),
+      new ClearingRedeemFacetTimeTravel__factory(getLibLinks("clearingOps", "clearingProtectedOps") as any, signer),
   },
 
   ClearingTransferFacet: {
@@ -3931,30 +4171,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     },
     inheritance: ["ClearingTransfer", "IStaticFunctionSelectors"],
     methods: [
-      {
-        name: "clearingTransferByPartition",
-        signature: {
-          full: "function clearingTransferByPartition((bytes32 partition, uint256 expirationTimestamp, bytes data) _clearingOperation, uint256 _amount, address _to) returns (bool success_, uint256 clearingId_)",
-          canonical: "clearingTransferByPartition((bytes32,uint256,bytes),uint256,address)",
-        },
-        selector: "0xde32aaa8",
-      },
-      {
-        name: "clearingTransferFromByPartition",
-        signature: {
-          full: "function clearingTransferFromByPartition(((bytes32 partition, uint256 expirationTimestamp, bytes data) clearingOperation, address from, bytes operatorData) _clearingOperationFrom, uint256 _amount, address _to) returns (bool success_, uint256 clearingId_)",
-          canonical: "clearingTransferFromByPartition(((bytes32,uint256,bytes),address,bytes),uint256,address)",
-        },
-        selector: "0x5c829d67",
-      },
-      {
-        name: "getClearingTransferForByPartition",
-        signature: {
-          full: "function getClearingTransferForByPartition(bytes32 _partition, address _tokenHolder, uint256 _clearingId) view returns ((uint256 amount, uint256 expirationTimestamp, address destination, bytes data, bytes operatorData, uint8 operatorType) clearingTransferData_)",
-          canonical: "getClearingTransferForByPartition(bytes32,address,uint256)",
-        },
-        selector: "0x6f438552",
-      },
       {
         name: "operatorClearingTransferByPartition",
         signature: {
@@ -4202,15 +4418,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     factory: (signer) =>
-      new ClearingTransferFacet__factory(
-        getLibLinks("clearingOps", "clearingProtectedOps", "clearingReadOps") as any,
-        signer,
-      ),
+      new ClearingTransferFacet__factory(getLibLinks("clearingOps", "clearingProtectedOps") as any, signer),
     timeTravelFactory: (signer) =>
-      new ClearingTransferFacetTimeTravel__factory(
-        getLibLinks("clearingOps", "clearingProtectedOps", "clearingReadOps") as any,
-        signer,
-      ),
+      new ClearingTransferFacetTimeTravel__factory(getLibLinks("clearingOps", "clearingProtectedOps") as any, signer),
   },
 
   ComplianceFacet: {
@@ -13781,7 +13991,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 94 as const;
+export const TOTAL_FACETS = 95 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -85,6 +85,7 @@ const BOND_FACETS = [
 
   // Clearing & Settlement
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
   "ClearingHoldCreationFacet",
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -80,6 +80,7 @@ const BOND_FIXED_RATE_FACETS = [
 
   // Clearing & Settlement
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
   "ClearingHoldCreationFacet",
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -77,6 +77,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
 
   // Clearing & Settlement
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
   "ClearingHoldCreationFacet",
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -77,6 +77,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
 
   // Clearing & Settlement
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
   "ClearingHoldCreationFacet",
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -78,6 +78,7 @@ const EQUITY_FACETS = [
 
   // Clearing & Settlement (8)
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
   "ClearingHoldCreationFacet",
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -98,6 +98,7 @@ const LOAN_FACETS = [
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
 
   // Scheduled Tasks
   "ScheduledBalanceAdjustmentsFacet",

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -100,6 +100,7 @@ const LOANS_PORTFOLIO_FACETS = [
   "OperatorClearingHoldByPartitionFacet",
   "ClearingReadFacet",
   "ClearingActionsFacet",
+  "ClearingByPartitionFacet",
 
   // Scheduled Tasks
   "ScheduledBalanceAdjustmentsFacet",

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -128,6 +128,7 @@ export const LIBRARY_DEPENDENT_FACETS: Record<string, Array<keyof typeof LIBRARY
   ClearingRedeemFacet: ["clearingOps", "clearingProtectedOps"],
   ClearingHoldCreationFacet: ["clearingOps", "clearingProtectedOps"],
   OperatorClearingHoldByPartitionFacet: ["clearingOps"],
+  ClearingByPartitionFacet: ["clearingOps", "clearingReadOps"],
   // ClearingReadOps dependencies - clearing read operations
   ClearingReadFacet: ["clearingReadOps"],
   // SnapshotsFacet + BalanceTrackerFacet + BalanceTrackerByPartitionFacet depend on SnapshotsStorageWrapper which uses ClearingReadOps

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -1,0 +1,1363 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+import { IAsset, type ResolverProxy } from "@contract-types";
+import { ADDRESS_ZERO, ATS_ROLES, EMPTY_HEX_BYTES, EMPTY_STRING, ZERO } from "@scripts";
+import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
+
+const _DEFAULT_PARTITION = "0x0000000000000000000000000000000000000000000000000000000000000001";
+const _WRONG_PARTITION = "0x0000000000000000000000000000000000000000000000000000000000000321";
+const _AMOUNT = 1000;
+const EMPTY_VC_ID = EMPTY_STRING;
+const ONE_YEAR_IN_SECONDS = 365 * 24 * 60 * 60;
+const SHORT_EXPIRATION_OFFSET = 120; // 2 minutes
+
+// Fixed base timestamp for deterministic tests — set via time travel in fixture
+const BASE_TIMESTAMP = 1_000_000_000;
+const EXPIRATION_TIMESTAMP = BASE_TIMESTAMP + ONE_YEAR_IN_SECONDS;
+const SHORT_EXPIRATION_TIMESTAMP = BASE_TIMESTAMP + SHORT_EXPIRATION_OFFSET;
+
+enum ClearingOperationType {
+  Transfer,
+  Redeem,
+  HoldCreation,
+}
+
+enum ThirdPartyType {
+  NULL,
+  AUTHORIZED,
+  OPERATOR,
+}
+
+describe("ClearingByPartitionFacet Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+  let signer_D: HardhatEthersSigner;
+  let asset: IAsset;
+
+  async function deployFixture() {
+    const base = await deployEquityTokenFixture({
+      equityDataParams: {
+        securityData: {
+          isMultiPartition: false,
+          clearingActive: true,
+        },
+      },
+    });
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+    signer_D = base.user3;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target);
+
+    await executeRbac(asset, [
+      { role: ATS_ROLES.ISSUER_ROLE, members: [signer_B.address] },
+      { role: ATS_ROLES.PAUSER_ROLE, members: [signer_D.address] },
+      { role: ATS_ROLES.KYC_ROLE, members: [signer_B.address] },
+      { role: ATS_ROLES.SSI_MANAGER_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.CLEARING_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.CLEARING_VALIDATOR_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.PROTECTED_PARTITIONS_ROLE, members: [signer_A.address] },
+    ]);
+
+    await asset.connect(signer_A).addIssuer(signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+
+    await asset.connect(signer_B).issueByPartition({
+      partition: _DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: 3 * _AMOUNT,
+      data: EMPTY_HEX_BYTES,
+    });
+
+    await asset.changeSystemTimestamp(BASE_TIMESTAMP);
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployFixture);
+  });
+
+  afterEach(async () => {
+    await asset.resetSystemTimestamp();
+  });
+
+  // ─── clearingRedeemByPartition ─────────────────────────────────────────────
+
+  describe("clearingRedeemByPartition", () => {
+    it("GIVEN a token holder with balance WHEN clearingRedeemByPartition THEN balance is locked and clearedAmount increases", async () => {
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+
+      await expect(asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT))
+        .to.emit(asset, "ClearedRedeemByPartition")
+        .withArgs(
+          signer_A.address,
+          signer_A.address,
+          _DEFAULT_PARTITION,
+          1,
+          _AMOUNT,
+          EXPIRATION_TIMESTAMP,
+          EMPTY_HEX_BYTES,
+          EMPTY_HEX_BYTES,
+        );
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+    });
+
+    it("GIVEN a paused token WHEN clearingRedeemByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.connect(signer_D).pause();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN clearing deactivated WHEN clearingRedeemByPartition THEN reverts with ClearingIsDisabled", async () => {
+      await asset.connect(signer_A).deactivateClearing();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN a recovered sender WHEN clearingRedeemByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN non-default partition WHEN clearingRedeemByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperation = {
+        partition: _WRONG_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN protected partitions without wildcard role WHEN clearingRedeemByPartition THEN reverts with PartitionsAreProtectedAndNoRole", async () => {
+      await asset.connect(signer_A).protectPartitions();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "PartitionsAreProtectedAndNoRole");
+    });
+
+    it("GIVEN protected partitions with wildcard role WHEN clearingRedeemByPartition THEN succeeds", async () => {
+      await asset.connect(signer_A).protectPartitions();
+      await asset.grantRole(ATS_ROLES.WILD_CARD_ROLE, signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT)).to.not.be.reverted;
+    });
+
+    it("GIVEN amount exceeds balance WHEN clearingRedeemByPartition THEN reverts with InsufficientBalance", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, 4 * _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "InsufficientBalance");
+    });
+
+    it("GIVEN a past expiration timestamp WHEN clearingRedeemByPartition THEN reverts with WrongExpirationTimestamp", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: BASE_TIMESTAMP - 1,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+  });
+
+  // ─── clearingRedeemFromByPartition ────────────────────────────────────────
+
+  describe("clearingRedeemFromByPartition", () => {
+    it("GIVEN a caller with allowance WHEN clearingRedeemFromByPartition THEN balance is locked and allowance consumed", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+
+      await expect(asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT))
+        .to.emit(asset, "ClearedRedeemFromByPartition")
+        .withArgs(
+          signer_B.address,
+          signer_A.address,
+          _DEFAULT_PARTITION,
+          1,
+          _AMOUNT,
+          EXPIRATION_TIMESTAMP,
+          EMPTY_HEX_BYTES,
+          EMPTY_HEX_BYTES,
+        );
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(0);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+    });
+
+    it("GIVEN a paused token WHEN clearingRedeemFromByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.connect(signer_D).pause();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN a recovered sender WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN a recovered from address WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN clearing deactivated WHEN clearingRedeemFromByPartition THEN reverts with ClearingIsDisabled", async () => {
+      await asset.connect(signer_A).deactivateClearing();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN non-default partition WHEN clearingRedeemFromByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _WRONG_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN protected partitions without wildcard role WHEN clearingRedeemFromByPartition THEN reverts with PartitionsAreProtectedAndNoRole", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      await asset.connect(signer_A).protectPartitions();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "PartitionsAreProtectedAndNoRole");
+    });
+
+    it("GIVEN protected partitions with wildcard role WHEN clearingRedeemFromByPartition THEN succeeds", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      await asset.connect(signer_A).protectPartitions();
+      await asset.grantRole(ATS_ROLES.WILD_CARD_ROLE, signer_B.address);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT)).to.not.be
+        .reverted;
+    });
+
+    it("GIVEN a zero from address WHEN clearingRedeemFromByPartition THEN reverts with ZeroAddressNotAllowed", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: ADDRESS_ZERO,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+    });
+
+    it("GIVEN no allowance WHEN clearingRedeemFromByPartition THEN reverts with InsufficientAllowance", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "InsufficientAllowance");
+    });
+
+    it("GIVEN amount exceeds balance WHEN clearingRedeemFromByPartition THEN reverts with InsufficientBalance", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, 4 * _AMOUNT);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, 4 * _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "InsufficientBalance");
+    });
+
+    it("GIVEN a past expiration timestamp WHEN clearingRedeemFromByPartition THEN reverts with WrongExpirationTimestamp", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: BASE_TIMESTAMP - 1,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
+      ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+  });
+
+  // ─── clearingTransferByPartition ──────────────────────────────────────────
+
+  describe("clearingTransferByPartition", () => {
+    it("GIVEN a token holder WHEN clearingTransferByPartition THEN balance is locked and destination not credited yet", async () => {
+      const balanceA_before = await asset.balanceOf(signer_A.address);
+      const balanceB_before = await asset.balanceOf(signer_B.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+
+      await expect(asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address))
+        .to.emit(asset, "ClearedTransferByPartition")
+        .withArgs(
+          signer_A.address,
+          signer_A.address,
+          signer_B.address,
+          _DEFAULT_PARTITION,
+          1,
+          _AMOUNT,
+          EXPIRATION_TIMESTAMP,
+          EMPTY_HEX_BYTES,
+          EMPTY_HEX_BYTES,
+        );
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceA_before - BigInt(_AMOUNT));
+      expect(await asset.balanceOf(signer_B.address)).to.equal(balanceB_before);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+    });
+
+    it("GIVEN a paused token WHEN clearingTransferByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.connect(signer_D).pause();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN clearing deactivated WHEN clearingTransferByPartition THEN reverts with ClearingIsDisabled", async () => {
+      await asset.connect(signer_A).deactivateClearing();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN zero address destination WHEN clearingTransferByPartition THEN reverts with ZeroAddressNotAllowed", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, ADDRESS_ZERO),
+      ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+    });
+
+    it("GIVEN a recovered sender WHEN clearingTransferByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN a recovered destination WHEN clearingTransferByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN non-default partition WHEN clearingTransferByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperation = {
+        partition: _WRONG_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN protected partitions without wildcard role WHEN clearingTransferByPartition THEN reverts with PartitionsAreProtectedAndNoRole", async () => {
+      await asset.connect(signer_A).protectPartitions();
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "PartitionsAreProtectedAndNoRole");
+    });
+
+    it("GIVEN protected partitions with wildcard role WHEN clearingTransferByPartition THEN succeeds", async () => {
+      await asset.connect(signer_A).protectPartitions();
+      await asset.grantRole(ATS_ROLES.WILD_CARD_ROLE, signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address)).to
+        .not.be.reverted;
+    });
+
+    it("GIVEN amount exceeds balance WHEN clearingTransferByPartition THEN reverts with InsufficientBalance", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, 4 * _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "InsufficientBalance");
+    });
+
+    it("GIVEN a past expiration timestamp WHEN clearingTransferByPartition THEN reverts with WrongExpirationTimestamp", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: BASE_TIMESTAMP - 1,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+  });
+
+  // ─── clearingTransferFromByPartition ──────────────────────────────────────
+
+  describe("clearingTransferFromByPartition", () => {
+    it("GIVEN a caller with allowance WHEN clearingTransferFromByPartition THEN balance locked, destination not credited, allowance consumed", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      const balanceA_before = await asset.balanceOf(signer_A.address);
+      const balanceC_before = await asset.balanceOf(signer_C.address);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      )
+        .to.emit(asset, "ClearedTransferFromByPartition")
+        .withArgs(
+          signer_B.address,
+          signer_A.address,
+          signer_C.address,
+          _DEFAULT_PARTITION,
+          1,
+          _AMOUNT,
+          EXPIRATION_TIMESTAMP,
+          EMPTY_HEX_BYTES,
+          EMPTY_HEX_BYTES,
+        );
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceA_before - BigInt(_AMOUNT));
+      expect(await asset.balanceOf(signer_C.address)).to.equal(balanceC_before);
+      expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(0);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+    });
+
+    it("GIVEN a paused token WHEN clearingTransferFromByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.connect(signer_D).pause();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN clearing deactivated WHEN clearingTransferFromByPartition THEN reverts with ClearingIsDisabled", async () => {
+      await asset.connect(signer_A).deactivateClearing();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN a recovered sender WHEN clearingTransferFromByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN a recovered destination WHEN clearingTransferFromByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN a recovered from address WHEN clearingTransferFromByPartition THEN reverts with WalletRecovered", async () => {
+      await asset.grantRole(ATS_ROLES.AGENT_ROLE, signer_A.address);
+      await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+    });
+
+    it("GIVEN non-default partition WHEN clearingTransferFromByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _WRONG_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN protected partitions without wildcard role WHEN clearingTransferFromByPartition THEN reverts with PartitionsAreProtectedAndNoRole", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      await asset.connect(signer_A).protectPartitions();
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "PartitionsAreProtectedAndNoRole");
+    });
+
+    it("GIVEN protected partitions with wildcard role WHEN clearingTransferFromByPartition THEN succeeds", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      await asset.connect(signer_A).protectPartitions();
+      await asset.grantRole(ATS_ROLES.WILD_CARD_ROLE, signer_B.address);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.not.be.reverted;
+    });
+
+    it("GIVEN a zero from address WHEN clearingTransferFromByPartition THEN reverts with ZeroAddressNotAllowed", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: ADDRESS_ZERO,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+    });
+
+    it("GIVEN a zero destination WHEN clearingTransferFromByPartition THEN reverts with ZeroAddressNotAllowed", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, ADDRESS_ZERO),
+      ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+    });
+
+    it("GIVEN no allowance WHEN clearingTransferFromByPartition THEN reverts with InsufficientAllowance", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "InsufficientAllowance");
+    });
+
+    it("GIVEN amount exceeds balance WHEN clearingTransferFromByPartition THEN reverts with InsufficientBalance", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, 4 * _AMOUNT);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, 4 * _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "InsufficientBalance");
+    });
+
+    it("GIVEN a past expiration timestamp WHEN clearingTransferFromByPartition THEN reverts with WrongExpirationTimestamp", async () => {
+      await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: BASE_TIMESTAMP - 1,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+  });
+
+  // ─── approveClearingOperationByPartition ──────────────────────────────────
+
+  describe("approveClearingOperationByPartition", () => {
+    it("GIVEN a pending transfer clearing WHEN approveClearingOperationByPartition THEN balances updated and clearedAmount zeroed", async () => {
+      const balanceA_before = await asset.balanceOf(signer_A.address);
+      const balanceB_before = await asset.balanceOf(signer_B.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address);
+
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Transfer,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+
+      await expect(asset.connect(signer_A).approveClearingOperationByPartition(identifier))
+        .to.emit(asset, "ClearingOperationApproved")
+        .withArgs(signer_A.address, signer_A.address, _DEFAULT_PARTITION, 1, ClearingOperationType.Transfer, "0x");
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceA_before - BigInt(_AMOUNT));
+      expect(await asset.balanceOf(signer_B.address)).to.equal(balanceB_before + BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a pending redeem clearing WHEN approveClearingOperationByPartition THEN balance stays reduced and clearedAmount zeroed", async () => {
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+
+      await expect(asset.connect(signer_A).approveClearingOperationByPartition(identifier))
+        .to.emit(asset, "ClearingOperationApproved")
+        .withArgs(signer_A.address, signer_A.address, _DEFAULT_PARTITION, 1, ClearingOperationType.Redeem, "0x");
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a paused token WHEN approveClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.connect(signer_D).pause();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN no CLEARING_VALIDATOR_ROLE WHEN approveClearingOperationByPartition THEN reverts with AccountHasNoRole", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_B).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
+    });
+
+    it("GIVEN clearing deactivated WHEN approveClearingOperationByPartition THEN reverts with ClearingIsDisabled", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.connect(signer_A).deactivateClearing();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN non-default partition WHEN approveClearingOperationByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _WRONG_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN an expired clearing WHEN approveClearingOperationByPartition THEN reverts with ExpirationDateReached", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Transfer,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ExpirationDateReached");
+    });
+
+    it("GIVEN wrong clearingId WHEN approveClearingOperationByPartition THEN reverts with WrongClearingId", async () => {
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 9999,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "WrongClearingId");
+    });
+  });
+
+  // ─── cancelClearingOperationByPartition ───────────────────────────────────
+
+  describe("cancelClearingOperationByPartition", () => {
+    it("GIVEN a pending clearing WHEN cancelClearingOperationByPartition THEN balance restored and clearedAmount zeroed", async () => {
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+
+      await expect(asset.connect(signer_A).cancelClearingOperationByPartition(identifier))
+        .to.emit(asset, "ClearingOperationCanceled")
+        .withArgs(signer_A.address, signer_A.address, _DEFAULT_PARTITION, 1, ClearingOperationType.Redeem);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a paused token WHEN cancelClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.connect(signer_D).pause();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN no CLEARING_VALIDATOR_ROLE WHEN cancelClearingOperationByPartition THEN reverts with AccountHasNoRole", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_B).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
+    });
+
+    it("GIVEN clearing deactivated WHEN cancelClearingOperationByPartition THEN reverts with ClearingIsDisabled", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.connect(signer_A).deactivateClearing();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN non-default partition WHEN cancelClearingOperationByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _WRONG_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN wrong clearingId WHEN cancelClearingOperationByPartition THEN reverts with WrongClearingId", async () => {
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 9999,
+      };
+      await expect(
+        asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "WrongClearingId");
+    });
+
+    it("GIVEN an expired clearing WHEN cancelClearingOperationByPartition THEN reverts with ExpirationDateReached", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ExpirationDateReached");
+    });
+  });
+
+  // ─── reclaimClearingOperationByPartition ──────────────────────────────────
+
+  describe("reclaimClearingOperationByPartition", () => {
+    it("GIVEN an expired clearing WHEN reclaimClearingOperationByPartition THEN balance restored and clearedAmount zeroed", async () => {
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+
+      await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(identifier))
+        .to.emit(asset, "ClearingOperationReclaimed")
+        .withArgs(signer_A.address, signer_A.address, _DEFAULT_PARTITION, 1, ClearingOperationType.Redeem);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a paused token WHEN reclaimClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+      await asset.connect(signer_D).pause();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN clearing deactivated WHEN reclaimClearingOperationByPartition THEN reverts with ClearingIsDisabled", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+      await asset.connect(signer_A).deactivateClearing();
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ClearingIsDisabled");
+    });
+
+    it("GIVEN non-default partition WHEN reclaimClearingOperationByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _WRONG_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+    });
+
+    it("GIVEN a non-expired clearing WHEN reclaimClearingOperationByPartition THEN reverts with ExpirationDateNotReached", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ExpirationDateNotReached");
+    });
+
+    it("GIVEN wrong clearingId WHEN reclaimClearingOperationByPartition THEN reverts with WrongClearingId", async () => {
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 9999,
+      };
+      await expect(
+        asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "WrongClearingId");
+    });
+  });
+
+  // ─── Read functions ────────────────────────────────────────────────────────
+
+  describe("getClearingRedeemForByPartition", () => {
+    it("GIVEN a pending redeem clearing WHEN getClearingRedeemForByPartition THEN returns correct data", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+      const data = await asset.getClearingRedeemForByPartition(_DEFAULT_PARTITION, signer_A.address, 1);
+      expect(data.amount).to.equal(_AMOUNT);
+      expect(data.expirationTimestamp).to.equal(EXPIRATION_TIMESTAMP);
+      expect(data.operatorType).to.equal(ThirdPartyType.NULL);
+    });
+  });
+
+  describe("getClearingTransferForByPartition", () => {
+    it("GIVEN a pending transfer clearing WHEN getClearingTransferForByPartition THEN returns correct data", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address);
+
+      const data = await asset.getClearingTransferForByPartition(_DEFAULT_PARTITION, signer_A.address, 1);
+      expect(data.amount).to.equal(_AMOUNT);
+      expect(data.destination).to.equal(signer_B.address);
+      expect(data.expirationTimestamp).to.equal(EXPIRATION_TIMESTAMP);
+      expect(data.operatorType).to.equal(ThirdPartyType.NULL);
+    });
+  });
+
+  describe("getClearedAmountForByPartition", () => {
+    it("GIVEN a pending redeem clearing WHEN getClearedAmountForByPartition THEN returns locked amount", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+    });
+
+    it("GIVEN no pending clearings WHEN getClearedAmountForByPartition THEN returns zero", async () => {
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a cleared operation WHEN getClearedAmountForByPartition after approve THEN returns zero", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+      await asset.connect(signer_A).approveClearingOperationByPartition({
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      });
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+  });
+
+  describe("getClearingCountForByPartition", () => {
+    it("GIVEN two pending redeem clearings WHEN getClearingCountForByPartition THEN returns 2", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT / 2);
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT / 4);
+      expect(
+        await asset.getClearingCountForByPartition(_DEFAULT_PARTITION, signer_A.address, ClearingOperationType.Redeem),
+      ).to.equal(2);
+    });
+
+    it("GIVEN no clearings WHEN getClearingCountForByPartition THEN returns 0", async () => {
+      expect(
+        await asset.getClearingCountForByPartition(_DEFAULT_PARTITION, signer_A.address, ClearingOperationType.Redeem),
+      ).to.equal(0);
+    });
+  });
+
+  describe("getClearingsIdForByPartition", () => {
+    it("GIVEN multiple pending clearings WHEN getClearingsIdForByPartition with pagination THEN returns correct ids", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT / 4);
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT / 4);
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT / 4);
+
+      const page1 = await asset.getClearingsIdForByPartition(
+        _DEFAULT_PARTITION,
+        signer_A.address,
+        ClearingOperationType.Redeem,
+        0,
+        2,
+      );
+      expect(page1.length).to.equal(2);
+      expect(page1[0]).to.equal(1);
+      expect(page1[1]).to.equal(2);
+
+      const page2 = await asset.getClearingsIdForByPartition(
+        _DEFAULT_PARTITION,
+        signer_A.address,
+        ClearingOperationType.Redeem,
+        1,
+        2,
+      );
+      expect(page2.length).to.equal(1);
+      expect(page2[0]).to.equal(3);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new facet, `ClearingByPartitionFacet`, to the asset tokenization contracts, which consolidates all partition-scoped clearing operations into a dedicated module. As a result, 12 functions previously spread across multiple facets have been moved, and the relevant interfaces and configuration have been updated. This is a breaking change, as interface IDs for several clearing facets have changed.

**Major changes:**

**Partition-scoped clearing refactor:**
- Added the new `ClearingByPartitionFacet` contract and its implementation, which encapsulates 12 partition-scoped clearing functions that were previously distributed across `ClearingActionsFacet`, `ClearingRedeemFacet`, `ClearingTransferFacet`, and `ClearingReadFacet`. This provides a dedicated facet for partition-aware clearing operations. [[1]](diffhunk://#diff-4137b0f75ac85b4bf54e74847f42c990b88d7da2204818f26c97ba9b7f3ca30bR1-R308) [[2]](diffhunk://#diff-147a887378503efa6eaf7c48ef70b77a39792612dd49d2f4bb375406a5ee9a08R1-R51) [[3]](diffhunk://#diff-59e67dd80b4a9074af7026d5da450cdf63d0b69b09a7e52727ea773701797aeeR1-R141)
- Updated the `CONTRACT_NAMES` array in `Configuration.ts` to include `ClearingByPartitionFacet`, ensuring it is registered in contract deployments.
- Introduced a new resolver key constant, `_CLEARING_BY_PARTITION_RESOLVER_KEY`, for the new facet.

**Interface and contract integration:**
- Updated the `IAsset` interface to inherit from the new `IClearingByPartition` interface, ensuring the asset contract exposes the new partition-scoped clearing functionality. [[1]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R93) [[2]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R186)
- Defined the `IClearingByPartition` interface, specifying the 12 partition-scoped clearing functions and relevant data accessors.

**Breaking changes:**
- The interface IDs for `IClearingActions`, `IClearingRedeem`, `IClearingTransfer`, and `IClearingRead` have changed due to the removal of partition-scoped functions from these interfaces.

**Code cleanup:**
- Removed unnecessary imports and references to partition-scoped clearing logic from the original facets, reflecting the new modular structure.

**Changelog update:**
- Documented these changes in a new changeset, clearly noting the breaking nature of the refactor and the rationale for the new facet.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
