### PR TITLE
feat: controller by partition facet

### DIFF
--- a/.changeset/maf-controller-by-partition-facet.md
+++ b/.changeset/maf-controller-by-partition-facet.md
@@ -1,0 +1,27 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+# ControllerByPartitionFacet split
+
+Extract `controllerTransferByPartition` and `controllerRedeemByPartition` from `ERC1410ManagementFacet`
+into a dedicated `ControllerByPartitionFacet` registered under `_CONTROLLER_BY_PARTITION_RESOLVER_KEY`.
+
+## Changes
+
+- Added `contracts/facets/controllerByPartition/IControllerByPartition.sol`, `ControllerByPartition.sol`,
+  `ControllerByPartitionFacet.sol`.
+- Added `_CONTROLLER_BY_PARTITION_RESOLVER_KEY` constant in `resolverKeys.sol`.
+- `ERC1410ManagementFacet` reduced from 7 to 5 selectors; stale imports (`CONTROLLER_ROLE`, `AGENT_ROLE`,
+  `AccessControlStorageWrapper`) removed from `ERC1410Management.sol`.
+- `IAsset` now exposes the two controller-by-partition functions via `IControllerByPartition`.
+- Updated `Configuration.ts`, `orchestratorLibraries.ts` and all 7 `createConfiguration.ts` scripts to
+  include `ControllerByPartitionFacet`.
+- Added `test/contracts/integration/controllerByPartition/controllerByPartition.test.ts` with full
+  modifier coverage (paused, wrong partition, non-controllable, access control) and success cases for
+  both `CONTROLLER_ROLE` and `AGENT_ROLE`.
+
+## Non-breaking
+
+The 4-byte selectors of `controllerTransferByPartition` and `controllerRedeemByPartition` are unchanged.
+Any call to these functions through `IAsset` continues to work without modification.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -94,6 +94,7 @@ export const CONTRACT_NAMES = [
   "ClearingHoldByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",
+  "ControllerByPartitionFacet",
   "DiamondFacet",
   "EquityUSAFacet",
   "BondUSAFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -219,6 +219,9 @@ bytes32 constant _HOLD_MANAGEMENT_RESOLVER_KEY = 0xaab5a0e0978ad146ca8dc61d16bab
 // keccak256('security.token.standard.controller.hold.by.partition.resolverKey');
 bytes32 constant _CONTROLLER_HOLD_BY_PARTITION_RESOLVER_KEY = 0x9e49506d2dfd484ed2aa6f2fd6f90a9efd8ae79466f93fa70571a95ddda4659c;
 
+// keccak256("security.token.standard.controller.by.partition.resolverKey")
+bytes32 constant _CONTROLLER_BY_PARTITION_RESOLVER_KEY = 0x66d6ddfefca163b54f2a365e7965e1c3f42e2d87254191bcfb5a6e7fb03174a2;
+
 // keccak256("security.token.standard.protected.hold.by.partition.resolverKey")
 bytes32 constant _PROTECTED_HOLD_BY_PARTITION_RESOLVER_KEY = 0x12c5881cfa073bf7497f90103e5b2a7f9a93f11147137ec2a1389b60904d0157;
 

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -102,6 +102,7 @@ import { IBurn } from "./burn/IBurn.sol";
 import { IDocumentation } from "./documentation/IDocumentation.sol";
 import { IController } from "./controller/IController.sol";
 import { IControllerHoldByPartition } from "./controllerHoldByPartition/IControllerHoldByPartition.sol";
+import { IControllerByPartition } from "./controllerByPartition/IControllerByPartition.sol";
 import { IProtectedHoldByPartition } from "./protectedHoldByPartition/IProtectedHoldByPartition.sol";
 import { IERC20Permit } from "./layer_1/ERC1400/ERC20Permit/IERC20Permit.sol";
 import { IControlList } from "./layer_1/controlList/IControlList.sol";
@@ -203,6 +204,7 @@ interface IAsset is
     IDocumentation,
     IController,
     IControllerHoldByPartition,
+    IControllerByPartition,
     IProtectedHoldByPartition,
     IERC20Permit,
     // Control

--- a/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartition.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IControllerByPartition } from "./IControllerByPartition.sol";
+import { CONTROLLER_ROLE, AGENT_ROLE, _buildRoles } from "../../constants/roles.sol";
+import { IERC1410Types } from "../layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
+import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
+
+/**
+ * @title ControllerByPartition
+ * @notice Abstract implementation of controller-initiated forced transfers and redemptions on a
+ *         specific partition. Delegates into `TokenCoreOps` so semantics match `ERC1410Management`
+ *         exactly.
+ * @dev Inherits modifier guards from `Modifiers`. Intended to be used only through
+ *      `ControllerByPartitionFacet`.
+ * @author Asset Tokenization Studio Team
+ */
+abstract contract ControllerByPartition is IControllerByPartition, Modifiers {
+    /// @inheritdoc IControllerByPartition
+    /// @dev Emits {TransferByPartition} via TokenCoreOps.transferByPartition.
+    function controllerTransferByPartition(
+        bytes32 _partition,
+        address _from,
+        address _to,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    )
+        external
+        override
+        onlyUnpaused
+        onlyDefaultPartitionWithSinglePartition(_partition)
+        onlyControllable
+        onlyAnyRole(_buildRoles(CONTROLLER_ROLE, AGENT_ROLE))
+        returns (bytes32)
+    {
+        return
+            TokenCoreOps.transferByPartition(
+                _from,
+                IERC1410Types.BasicTransferInfo(_to, _value),
+                _partition,
+                _data,
+                EvmAccessors.getMsgSender(),
+                _operatorData
+            );
+    }
+
+    /// @inheritdoc IControllerByPartition
+    /// @dev Emits {RedeemedByPartition} via TokenCoreOps.redeemByPartition.
+    function controllerRedeemByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    )
+        external
+        override
+        onlyUnpaused
+        onlyDefaultPartitionWithSinglePartition(_partition)
+        onlyControllable
+        onlyAnyRole(_buildRoles(CONTROLLER_ROLE, AGENT_ROLE))
+    {
+        TokenCoreOps.redeemByPartition(
+            _partition,
+            _tokenHolder,
+            EvmAccessors.getMsgSender(),
+            _value,
+            _data,
+            _operatorData
+        );
+    }
+}

--- a/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartitionFacet.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IControllerByPartition } from "./IControllerByPartition.sol";
+import { ControllerByPartition } from "./ControllerByPartition.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _CONTROLLER_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title ControllerByPartitionFacet
+ * @notice Diamond facet that exposes controller-initiated forced transfer and redemption operations
+ *         on a specific partition, registered under `_CONTROLLER_BY_PARTITION_RESOLVER_KEY`.
+ * @dev Inherits behaviour from `ControllerByPartition` and satisfies `IStaticFunctionSelectors` for
+ *      Diamond proxy selector registration. Exposes two selectors:
+ *      `controllerTransferByPartition`, `controllerRedeemByPartition`.
+ * @author Asset Tokenization Studio Team
+ */
+contract ControllerByPartitionFacet is ControllerByPartition, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _CONTROLLER_BY_PARTITION_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 2;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.controllerTransferByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.controllerRedeemByPartition.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IControllerByPartition).interfaceId;
+        }
+    }
+}

--- a/packages/ats/contracts/contracts/facets/controllerByPartition/IControllerByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/controllerByPartition/IControllerByPartition.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IERC1410Types } from "../layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+
+/**
+ * @title IControllerByPartition
+ * @notice Interface for controller-initiated forced transfers and redemptions on a specific partition.
+ * @dev Exposes two write methods that allow an authorised controller or agent to forcibly transfer
+ *      or redeem tokens from any token holder's balance on a given partition. Both operations
+ *      require the token to be controllable and not paused, and are restricted to single-partition
+ *      mode with the default partition.
+ */
+interface IControllerByPartition is IERC1410Types {
+    /**
+     * @notice Forces a transfer in a partition from a token holder to a destination address.
+     * @dev Can only be called by a user with the controller or agent role. The contract must be
+     *      controllable and not paused. Only valid in single-partition mode with the default partition.
+     * @param _partition The partition from which tokens are transferred.
+     * @param _from The address from which tokens are transferred.
+     * @param _to The address to which tokens are transferred.
+     * @param _value The amount of tokens to transfer.
+     * @param _data Additional data attached to the transfer.
+     * @param _operatorData Additional data attached to the transfer by the operator.
+     * @return The partition from which the tokens were transferred.
+     */
+    function controllerTransferByPartition(
+        bytes32 _partition,
+        address _from,
+        address _to,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    ) external returns (bytes32);
+
+    /**
+     * @notice Forces a redemption in a partition from a token holder.
+     * @dev Can only be called by a user with the controller or agent role. The contract must be
+     *      controllable and not paused. Only valid in single-partition mode with the default partition.
+     * @param _partition The partition from which tokens are redeemed.
+     * @param _tokenHolder The address whose tokens are redeemed.
+     * @param _value The amount of tokens to redeem.
+     * @param _data Additional data attached to the redemption.
+     * @param _operatorData Additional data attached to the redemption by the operator.
+     */
+    function controllerRedeemByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    ) external;
+}

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { CONTROLLER_ROLE, AGENT_ROLE } from "../../../../constants/roles.sol";
 import { IERC1410Types } from "./IERC1410Types.sol";
 import { IERC1410Management } from "./IERC1410Management.sol";
 import { IProtectedPartitions } from "../../../../facets/layer_1/protectedPartition/IProtectedPartitions.sol";
-import { AccessControlStorageWrapper } from "../../../../domain/core/AccessControlStorageWrapper.sol";
 import { Modifiers } from "../../../../services/Modifiers.sol";
 import { ProtectedPartitionsStorageWrapper } from "../../../../domain/core/ProtectedPartitionsStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../../../domain/asset/ERC1410StorageWrapper.sol";
@@ -16,57 +14,6 @@ abstract contract ERC1410Management is IERC1410Management, Modifiers {
     // solhint-disable-next-line func-name-mixedcase
     function initialize_ERC1410(bool _multiPartition) external override onlyNotERC1410Initialized {
         ERC1410StorageWrapper.initialize_ERC1410(_multiPartition);
-    }
-
-    function controllerTransferByPartition(
-        bytes32 _partition,
-        address _from,
-        address _to,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    )
-        external
-        override
-        onlyUnpaused
-        onlyDefaultPartitionWithSinglePartition(_partition)
-        onlyControllable
-        returns (bytes32)
-    {
-        bytes32[] memory roles = new bytes32[](2);
-        roles[0] = CONTROLLER_ROLE;
-        roles[1] = AGENT_ROLE;
-        AccessControlStorageWrapper.checkAnyRole(roles, EvmAccessors.getMsgSender());
-        return
-            TokenCoreOps.transferByPartition(
-                _from,
-                IERC1410Types.BasicTransferInfo(_to, _value),
-                _partition,
-                _data,
-                EvmAccessors.getMsgSender(),
-                _operatorData
-            );
-    }
-
-    function controllerRedeemByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    ) external override onlyUnpaused onlyDefaultPartitionWithSinglePartition(_partition) onlyControllable {
-        bytes32[] memory roles = new bytes32[](2);
-        roles[0] = CONTROLLER_ROLE;
-        roles[1] = AGENT_ROLE;
-        AccessControlStorageWrapper.checkAnyRole(roles, EvmAccessors.getMsgSender());
-        TokenCoreOps.redeemByPartition(
-            _partition,
-            _tokenHolder,
-            EvmAccessors.getMsgSender(),
-            _value,
-            _data,
-            _operatorData
-        );
     }
 
     function operatorTransferByPartition(

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
@@ -12,19 +12,22 @@ contract ERC1410ManagementFacet is ERC1410Management, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ERC1410.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.controllerTransferByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.controllerRedeemByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.operatorTransferByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.operatorRedeemByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.protectedTransferFromByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.protectedRedeemFromByPartition.selector;
+        uint256 selectorIndex = 5;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.protectedRedeemFromByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.protectedTransferFromByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.operatorRedeemByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.operatorTransferByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC1410.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IERC1410Management).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IERC1410Management).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
@@ -8,37 +8,12 @@ import { IProtectedPartitions } from "../../../../facets/layer_1/protectedPartit
 /**
  * @title IERC1410Management
  * @dev Interface for the ERC1410Management contract providing all management operations
- * for ERC1410 tokens including operator management and controller functions.
+ * for ERC1410 tokens including operator management and protected-partition functions.
  */
 interface IERC1410Management is IERC1410Types {
     // Initialization function
     // solhint-disable-next-line func-name-mixedcase
     function initialize_ERC1410(bool _multiPartition) external;
-
-    /**
-     * @notice Forces a transfer in a partition from a token holder to a destination address
-     * @dev Can only be used by the controller role
-     */
-    function controllerTransferByPartition(
-        bytes32 _partition,
-        address _from,
-        address _to,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    ) external returns (bytes32);
-
-    /**
-     * @notice Forces a redeem in a partition from a token holder
-     * @dev Can only be used by the controller role
-     */
-    function controllerRedeemByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    ) external;
 
     /**
      * @notice Transfers the ownership of tokens from a specified partition from one address to another address

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-29T13:35:58.966Z
- * Facets: 98
+ * Generated: 2026-04-30T07:57:10.491Z
+ * Facets: 99
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -54,6 +54,7 @@ import {
   ClearingTransferFacet__factory,
   ComplianceFacet__factory,
   ControlListFacet__factory,
+  ControllerByPartitionFacet__factory,
   ControllerFacet__factory,
   ControllerHoldByPartitionFacet__factory,
   CoreAdjustedFacet__factory,
@@ -4807,6 +4808,157 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new ComplianceFacetTimeTravel__factory(signer),
   },
 
+  ControllerByPartitionFacet: {
+    name: "ControllerByPartitionFacet",
+    description:
+      "Diamond facet that exposes controller-initiated forced transfer and redemption operations on a specific partition, registered under `_CONTROLLER_BY_PARTITION_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_CONTROLLER_BY_PARTITION_RESOLVER_KEY",
+      value: "0x66d6ddfefca163b54f2a365e7965e1c3f42e2d87254191bcfb5a6e7fb03174a2",
+    },
+    inheritance: ["ControllerByPartition", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "controllerRedeemByPartition",
+        signature: {
+          full: "function controllerRedeemByPartition(bytes32 _partition, address _tokenHolder, uint256 _value, bytes _data, bytes _operatorData)",
+          canonical: "controllerRedeemByPartition(bytes32,address,uint256,bytes,bytes)",
+        },
+        selector: "0xb84777cc",
+      },
+      {
+        name: "controllerTransferByPartition",
+        signature: {
+          full: "function controllerTransferByPartition(bytes32 _partition, address _from, address _to, uint256 _value, bytes _data, bytes _operatorData) returns (bytes32)",
+          canonical: "controllerTransferByPartition(bytes32,address,address,uint256,bytes,bytes)",
+        },
+        selector: "0xfb78befa",
+      },
+    ],
+    events: [
+      {
+        name: "AuthorizedOperator",
+        signature: {
+          full: "event AuthorizedOperator(address indexed operator, address indexed tokenHolder)",
+          canonical: "AuthorizedOperator(address,address)",
+        },
+        topic0: "0xf4caeb2d6ca8932a215a353d0703c326ec2d81fc68170f320eb2ab49e9df61f9",
+      },
+      {
+        name: "AuthorizedOperatorByPartition",
+        signature: {
+          full: "event AuthorizedOperatorByPartition(bytes32 indexed partition, address indexed operator, address indexed tokenHolder)",
+          canonical: "AuthorizedOperatorByPartition(bytes32,address,address)",
+        },
+        topic0: "0x3646a897c70797ecc134b0adc32f471b07bf1d6f451133b0384badab531e3fd6",
+      },
+      {
+        name: "IssuedByPartition",
+        signature: {
+          full: "event IssuedByPartition(bytes32 indexed partition, address indexed operator, address indexed to, uint256 value, bytes data)",
+          canonical: "IssuedByPartition(bytes32,address,address,uint256,bytes)",
+        },
+        topic0: "0x5af1c8f424b104b6ba4e3c0885f2ed9fef04a9b1ea39cd9ed362432105c0791a",
+      },
+      {
+        name: "RedeemedByPartition",
+        signature: {
+          full: "event RedeemedByPartition(bytes32 indexed partition, address indexed operator, address indexed from, uint256 value, bytes data, bytes operatorData)",
+          canonical: "RedeemedByPartition(bytes32,address,address,uint256,bytes,bytes)",
+        },
+        topic0: "0xa4f62471c9bdf88115b97203943c74c59b655913ee5ee592706d84ef53fb6be2",
+      },
+      {
+        name: "RevokedOperator",
+        signature: {
+          full: "event RevokedOperator(address indexed operator, address indexed tokenHolder)",
+          canonical: "RevokedOperator(address,address)",
+        },
+        topic0: "0x50546e66e5f44d728365dc3908c63bc5cfeeab470722c1677e3073a6ac294aa1",
+      },
+      {
+        name: "RevokedOperatorByPartition",
+        signature: {
+          full: "event RevokedOperatorByPartition(bytes32 indexed partition, address indexed operator, address indexed tokenHolder)",
+          canonical: "RevokedOperatorByPartition(bytes32,address,address)",
+        },
+        topic0: "0x3b287c4f1bab4df949b33bceacef984f544dc5d5479930d00e4ee8c9d8dd96f2",
+      },
+      {
+        name: "TransferByPartition",
+        signature: {
+          full: "event TransferByPartition(bytes32 indexed _fromPartition, address _operator, address indexed _from, address indexed _to, uint256 _value, bytes _data, bytes _operatorData)",
+          canonical: "TransferByPartition(bytes32,address,address,address,uint256,bytes,bytes)",
+        },
+        topic0: "0xff4e9a26af4eb73b8bacfaa4abd4fea03d9448e7b912dc5ff4019048875aa2d4",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRoles",
+        signature: {
+          full: "error AccountHasNoRoles(address account, bytes32[] roles)",
+          canonical: "AccountHasNoRoles(address,bytes32[])",
+        },
+        selector: "0x90e55392",
+      },
+      {
+        name: "InvalidPartition",
+        signature: {
+          full: "error InvalidPartition(address account, bytes32 partition)",
+          canonical: "InvalidPartition(address,bytes32)",
+        },
+        selector: "0xbf84f4ec",
+      },
+      {
+        name: "NotAllowedInMultiPartitionMode",
+        signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
+        selector: "0x76d08f88",
+      },
+      {
+        name: "PartitionNotAllowedInSinglePartitionMode",
+        signature: {
+          full: "error PartitionNotAllowedInSinglePartitionMode(bytes32 partition)",
+          canonical: "PartitionNotAllowedInSinglePartitionMode(bytes32)",
+        },
+        selector: "0xb96d9539",
+      },
+      {
+        name: "TokenIsNotControllable",
+        signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
+        selector: "0xf4b7b072",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "Unauthorized",
+        signature: {
+          full: "error Unauthorized(address operator, address tokenHolder, bytes32 partition)",
+          canonical: "Unauthorized(address,address,bytes32)",
+        },
+        selector: "0x1e09743f",
+      },
+      {
+        name: "ZeroPartition",
+        signature: { full: "error ZeroPartition()", canonical: "ZeroPartition()" },
+        selector: "0x4a6f30c3",
+      },
+      { name: "ZeroValue", signature: { full: "error ZeroValue()", canonical: "ZeroValue()" }, selector: "0x7c946ed7" },
+    ],
+    factory: (signer) => new ControllerByPartitionFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
+  },
+
   ControllerFacet: {
     name: "ControllerFacet",
     description: "Diamond facet exposing ERC-1644 forced-transfer operations and ERC-3643 agent management.",
@@ -7259,22 +7411,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     inheritance: ["ERC1410Management", "IStaticFunctionSelectors"],
     methods: [
       {
-        name: "controllerRedeemByPartition",
-        signature: {
-          full: "function controllerRedeemByPartition(bytes32 _partition, address _tokenHolder, uint256 _value, bytes _data, bytes _operatorData)",
-          canonical: "controllerRedeemByPartition(bytes32,address,uint256,bytes,bytes)",
-        },
-        selector: "0xb84777cc",
-      },
-      {
-        name: "controllerTransferByPartition",
-        signature: {
-          full: "function controllerTransferByPartition(bytes32 _partition, address _from, address _to, uint256 _value, bytes _data, bytes _operatorData) returns (bytes32)",
-          canonical: "controllerTransferByPartition(bytes32,address,address,uint256,bytes,bytes)",
-        },
-        selector: "0xfb78befa",
-      },
-      {
         name: "initialize_ERC1410",
         signature: { full: "function initialize_ERC1410(bool _multiPartition)", canonical: "initialize_ERC1410(bool)" },
         selector: "0x7b1df196",
@@ -7388,14 +7524,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xa1180aad",
       },
       {
-        name: "AccountHasNoRoles",
-        signature: {
-          full: "error AccountHasNoRoles(address account, bytes32[] roles)",
-          canonical: "AccountHasNoRoles(address,bytes32[])",
-        },
-        selector: "0x90e55392",
-      },
-      {
         name: "AlreadyInitialized",
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
@@ -7433,11 +7561,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
-      },
-      {
-        name: "TokenIsNotControllable",
-        signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
-        selector: "0xf4b7b072",
       },
       {
         name: "TokenIsPaused",
@@ -14284,7 +14407,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 98 as const;
+export const TOTAL_FACETS = 99 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -97,6 +97,7 @@ const BOND_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -92,6 +92,7 @@ const BOND_FIXED_RATE_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -89,6 +89,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -89,6 +89,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -90,6 +90,7 @@ const EQUITY_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -90,6 +90,7 @@ const LOAN_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -92,6 +92,7 @@ const LOANS_PORTFOLIO_FACETS = [
   "HoldFacet",
   "HoldManagementFacet",
   "ControllerHoldByPartitionFacet",
+  "ControllerByPartitionFacet",
   "ProtectedHoldByPartitionFacet",
   "HoldByPartitionFacet",
 

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -106,6 +106,7 @@ export const LIBRARY_DEPENDENT_FACETS: Record<string, Array<keyof typeof LIBRARY
   ERC20ReadFacet: ["tokenCoreOps"],
   ERC20VotesFacet: ["clearingReadOps"],
   ERC1410ManagementFacet: ["tokenCoreOps"],
+  ControllerByPartitionFacet: ["tokenCoreOps"],
   ERC1410TokenHolderFacet: ["tokenCoreOps"],
   ERC1410ReadFacet: ["tokenCoreOps"],
   ERC1410IssuerFacet: ["tokenCoreOps"],

--- a/packages/ats/contracts/test/contracts/integration/controllerByPartition/controllerByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/controllerByPartition/controllerByPartition.test.ts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
+import { DEFAULT_PARTITION, EMPTY_STRING, ZERO, EMPTY_HEX_BYTES, ATS_ROLES } from "@scripts";
+import { ResolverProxy, IAsset } from "@contract-types";
+
+const _WRONG_PARTITION = "0x0000000000000000000000000000000000000000000000000000000000000321";
+const _AMOUNT = 1000;
+const _DATA = "0x1234";
+const _OPERATOR_DATA = "0x5678";
+
+describe("ControllerByPartition Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+  let signer_D: HardhatEthersSigner;
+  let signer_E: HardhatEthersSigner;
+
+  let asset: IAsset;
+
+  function set_initRbacs() {
+    return [
+      {
+        role: ATS_ROLES.ISSUER_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES.PAUSER_ROLE,
+        members: [signer_D.address],
+      },
+      {
+        role: ATS_ROLES.KYC_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES.SSI_MANAGER_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES.CONTROLLER_ROLE,
+        members: [signer_C.address],
+      },
+    ];
+  }
+
+  async function setupBalances(asset: IAsset) {
+    await asset.connect(signer_A).addIssuer(signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_A.address, EMPTY_STRING, ZERO, MAX_UINT256, signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_E.address, EMPTY_STRING, ZERO, MAX_UINT256, signer_A.address);
+    await asset.connect(signer_B).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: _AMOUNT,
+      data: EMPTY_HEX_BYTES,
+    });
+  }
+
+  async function deployFixtureSinglePartition() {
+    const base = await deployEquityTokenFixture();
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+    signer_D = base.user3;
+    signer_E = base.user4;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target);
+    await executeRbac(asset, set_initRbacs());
+    await setupBalances(asset);
+  }
+
+  async function deployFixtureMultiPartition() {
+    const base = await deployEquityTokenFixture({
+      equityDataParams: { securityData: { isMultiPartition: true } },
+    });
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+    signer_D = base.user3;
+    signer_E = base.user4;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target);
+    await executeRbac(asset, set_initRbacs());
+    await setupBalances(asset);
+  }
+
+  describe("Single partition", () => {
+    beforeEach(async () => {
+      await loadFixture(deployFixtureSinglePartition);
+    });
+
+    describe("Paused", () => {
+      beforeEach(async () => {
+        await asset.connect(signer_D).pause();
+      });
+
+      it("GIVEN a paused token WHEN controllerTransferByPartition THEN revert TokenIsPaused", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerTransferByPartition(
+              DEFAULT_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      });
+
+      it("GIVEN a paused token WHEN controllerRedeemByPartition THEN revert TokenIsPaused", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      });
+    });
+
+    describe("Wrong partition — onlyDefaultPartitionWithSinglePartition", () => {
+      it("GIVEN a wrong partition in single-partition mode WHEN controllerTransferByPartition THEN revert PartitionNotAllowedInSinglePartitionMode", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerTransferByPartition(
+              _WRONG_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+      });
+
+      it("GIVEN a wrong partition in single-partition mode WHEN controllerRedeemByPartition THEN revert PartitionNotAllowedInSinglePartitionMode", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerRedeemByPartition(_WRONG_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode");
+      });
+    });
+
+    describe("Controllable — onlyControllable", () => {
+      beforeEach(async () => {
+        await asset.connect(signer_A).finalizeControllable();
+      });
+
+      it("GIVEN a non-controllable token WHEN controllerTransferByPartition THEN revert TokenIsNotControllable", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerTransferByPartition(
+              DEFAULT_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.be.revertedWithCustomError(asset, "TokenIsNotControllable");
+      });
+
+      it("GIVEN a non-controllable token WHEN controllerRedeemByPartition THEN revert TokenIsNotControllable", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.be.revertedWithCustomError(asset, "TokenIsNotControllable");
+      });
+    });
+
+    describe("AccessControl — onlyAnyRole", () => {
+      it("GIVEN an account without CONTROLLER_ROLE or AGENT_ROLE WHEN controllerTransferByPartition THEN revert AccountHasNoRoles", async () => {
+        await expect(
+          asset
+            .connect(signer_B)
+            .controllerTransferByPartition(
+              DEFAULT_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.be.revertedWithCustomError(asset, "AccountHasNoRoles");
+      });
+
+      it("GIVEN an account without CONTROLLER_ROLE or AGENT_ROLE WHEN controllerRedeemByPartition THEN revert AccountHasNoRoles", async () => {
+        await expect(
+          asset
+            .connect(signer_B)
+            .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.be.revertedWithCustomError(asset, "AccountHasNoRoles");
+      });
+    });
+
+    describe("Success", () => {
+      it("GIVEN an account with CONTROLLER_ROLE WHEN controllerTransferByPartition THEN emit TransferByPartition and update balances", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerTransferByPartition(
+              DEFAULT_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.emit(asset, "TransferByPartition");
+
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_E.address)).to.equal(_AMOUNT);
+        expect(await asset.totalSupply()).to.equal(_AMOUNT);
+      });
+
+      it("GIVEN an account with AGENT_ROLE WHEN controllerTransferByPartition THEN emit TransferByPartition and update balances", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.AGENT_ROLE, signer_B.address);
+
+        await expect(
+          asset
+            .connect(signer_B)
+            .controllerTransferByPartition(
+              DEFAULT_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.emit(asset, "TransferByPartition");
+
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_E.address)).to.equal(_AMOUNT);
+      });
+
+      it("GIVEN an account with CONTROLLER_ROLE WHEN controllerRedeemByPartition THEN emit RedeemedByPartition and decrease supply", async () => {
+        const supplyBefore = await asset.totalSupply();
+
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.emit(asset, "RedeemedByPartition");
+
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+        expect(await asset.totalSupply()).to.equal(supplyBefore - BigInt(_AMOUNT));
+      });
+
+      it("GIVEN an account with AGENT_ROLE WHEN controllerRedeemByPartition THEN emit RedeemedByPartition and decrease supply", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.AGENT_ROLE, signer_B.address);
+        const supplyBefore = await asset.totalSupply();
+
+        await expect(
+          asset
+            .connect(signer_B)
+            .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.emit(asset, "RedeemedByPartition");
+
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+        expect(await asset.totalSupply()).to.equal(supplyBefore - BigInt(_AMOUNT));
+      });
+    });
+  });
+
+  describe("Multi-partition", () => {
+    beforeEach(async () => {
+      await loadFixture(deployFixtureMultiPartition);
+    });
+
+    describe("Wrong partition — onlyDefaultPartitionWithSinglePartition", () => {
+      it("GIVEN a multi-partition token WHEN controllerTransferByPartition with non-existent partition THEN revert InvalidPartition", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerTransferByPartition(
+              _WRONG_PARTITION,
+              signer_A.address,
+              signer_E.address,
+              _AMOUNT,
+              _DATA,
+              _OPERATOR_DATA,
+            ),
+        ).to.be.revertedWithCustomError(asset, "InvalidPartition");
+      });
+
+      it("GIVEN a multi-partition token WHEN controllerRedeemByPartition with non-existent partition THEN revert InvalidPartition", async () => {
+        await expect(
+          asset
+            .connect(signer_C)
+            .controllerRedeemByPartition(_WRONG_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
+        ).to.be.revertedWithCustomError(asset, "InvalidPartition");
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new `ControllerByPartitionFacet` to the asset tokenization contracts, extracting the controller-initiated forced transfer and redemption functions from the existing `ERC1410ManagementFacet` into their own dedicated facet. This refactor improves modularity and clarity without breaking existing interfaces or function selectors. The update also includes new interface contracts, resolver key constants, configuration updates, and comprehensive integration tests.

Key changes include:

### Facet Extraction and Contract Refactoring

* Extracted `controllerTransferByPartition` and `controllerRedeemByPartition` functions from `ERC1410ManagementFacet` into a new `ControllerByPartitionFacet`, registered under the new `_CONTROLLER_BY_PARTITION_RESOLVER_KEY`. This reduces the number of selectors in `ERC1410ManagementFacet` and removes stale imports, improving maintainability. (`ControllerByPartitionFacet.sol`, `ControllerByPartition.sol`, `IControllerByPartition.sol`, `ERC1410ManagementFacet.sol`, `ERC1410Management.sol`, `resolverKeys.sol`) [[1]](diffhunk://#diff-f70bc544191dbba0e963ff10486d318655000a9b227f5d179d7cda996241266bR1-R27) [[2]](diffhunk://#diff-b60c523803b132152012bb9c01f00a694b6afad326a3dc388b0c451656c09703R1-R75) [[3]](diffhunk://#diff-b712ada71c1e2ae812d9fd9523ab7564fd54cc22badb2f06c7bdd0130b45263dR1-R42) [[4]](diffhunk://#diff-60cee3632a0ce4af6d7339164ad6c52a81fe7245b6895bbb6c9fdeb762eba9d4R1-R53) [[5]](diffhunk://#diff-686c0aa4e6679535ace1385ed58384e9dda80784e3be195e72af71326d4f14d7L15-R31) [[6]](diffhunk://#diff-cafaa302f9b330c8181db871e8f7da1158345268d203e3c9f8b253a77fcda9baL4-L8) [[7]](diffhunk://#diff-cafaa302f9b330c8181db871e8f7da1158345268d203e3c9f8b253a77fcda9baL21-L71) [[8]](diffhunk://#diff-a6761447814cc412fd1b009f087d5b68cc0a5e3ad8ef1dd4e34fdd2e6b3b465dR222-R224)

* Updated the `IAsset` interface to expose the two controller-by-partition functions via the new `IControllerByPartition` interface. (`IAsset.sol`) [[1]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R105) [[2]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R207)

### Configuration and Registry Updates

* Added `ControllerByPartitionFacet` to the contract configuration and registry files, ensuring it is included in deployment and orchestration scripts. (`Configuration.ts`, `atsRegistry.data.ts`) [[1]](diffhunk://#diff-409dd60ab11b542fadbe019ebe0bae2d62b9a88197c5df9c72dbf6139790278bR97) [[2]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L13-R14) [[3]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R57)

### Testing

* Added a comprehensive integration test suite for `ControllerByPartitionFacet` with full modifier coverage and success cases for both `CONTROLLER_ROLE` and `AGENT_ROLE`.

### Backward Compatibility

* Ensured that the 4-byte selectors for the controller-by-partition functions remain unchanged, so existing calls through `IAsset` continue to work without modification.

These changes improve the modularity and clarity of the codebase while maintaining backward compatibility.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
