### PR TITLE
feat: coupon security holders facet

### DIFF
--- a/.changeset/maf-coupon-security-holders-facet.md
+++ b/.changeset/maf-coupon-security-holders-facet.md
@@ -1,0 +1,20 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+# CouponSecurityHoldersFacet split
+
+Extract coupon security-holder queries from `CouponFacet` into a dedicated `CouponSecurityHoldersFacet` registered under `_COUPON_SECURITY_HOLDERS_RESOLVER_KEY`.
+
+## Changes
+
+- Added `contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol`, `CouponSecurityHolders.sol`, `CouponSecurityHoldersFacet.sol`.
+- Added `_COUPON_SECURITY_HOLDERS_RESOLVER_KEY` constant in `resolverKeys.sol`.
+- Removed `getCouponHolders`, `getCouponsFor`, `getTotalCouponHolders` from `Coupon.sol`, `ICoupon.sol`, and `CouponFacetBase.sol` (9 → 6 selectors).
+- `IAsset` now inherits `ICouponSecurityHolders` alongside `ICoupon`.
+- Updated `Configuration.ts` and 5 `createConfiguration.ts` scripts (bond, bondFixedRate, bondKpiLinkedRate, bondSustainabilityPerformanceTargetRate, loan) to register `CouponSecurityHoldersFacet`.
+- Added `test/contracts/integration/couponSecurityHolders/couponSecurityHolders.test.ts` covering snapshot holders, pre-record-date empty results, pagination, and error cases.
+
+## Non-breaking
+
+The 4-byte selectors of all three functions are unchanged. Any call to `asset.getCouponHolders(...)`, `asset.getCouponsFor(...)`, or `asset.getTotalCouponHolders(...)` through `IAsset` continues to work without modification.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -103,6 +103,7 @@ export const CONTRACT_NAMES = [
   "ScheduledBalanceAdjustmentsFacet",
   "ScheduledCrossOrderedTasksFacet",
   "CouponListingFacet",
+  "CouponSecurityHoldersFacet",
   "SnapshotsFacet",
   "CoreAtSnapshotFacet",
   "CorporateActionsFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -599,6 +599,9 @@ bytes32 constant _COUPON_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY = 0
 // keccak256("security.token.standard.couponListing.resolverKey");
 bytes32 constant _COUPON_LISTING_RESOLVER_KEY = 0x09830f922c6bb4e736cc4cc426ceec0888c8b95b2cc21b67f16dab889ad4c47e;
 
+// keccak256("security.token.standard.coupon.securityHolders.resolverKey");
+bytes32 constant _COUPON_SECURITY_HOLDERS_RESOLVER_KEY = 0x2dbf6db0e4dddb14cd72f1a882c1520fdbd592db82b5f3d2562ace6c9eb5cc23;
+
 // keccak256('security.token.standard.scheduled.tasks.resolverKey');
 bytes32 constant _SCHEDULED_TASKS_RESOLVER_KEY = 0xa4934195ab83f1497ce5fc99b68d0f41694716bcfba5f232aa6c8e0d4d504f08;
 

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -77,6 +77,7 @@ import {
 import { IClearingAtSnapshot } from "./clearingAtSnapshot/IClearingAtSnapshot.sol";
 import { IClearingAtSnapshotByPartition } from "./clearingAtSnapshotByPartition/IClearingAtSnapshotByPartition.sol";
 import { ICouponListing } from "./couponListing/ICouponListing.sol";
+import { ICouponSecurityHolders } from "./couponSecurityHolders/ICouponSecurityHolders.sol";
 import {
     IScheduledBalanceAdjustments
 } from "./layer_2/scheduledTask/scheduledBalanceAdjustment/IScheduledBalanceAdjustments.sol";
@@ -169,6 +170,7 @@ interface IAsset is
     ITransferAndLock,
     // Corporate Actions
     ICoupon,
+    ICouponSecurityHolders,
     IDividend,
     // Additional Layer 1
     IBalanceTracker,

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
@@ -42,11 +42,11 @@ abstract contract CouponSecurityHolders is ICouponSecurityHolders, Modifiers {
         onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
         returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory holders_)
     {
-        address[] memory holders = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
-        holders_ = holders;
-        couponFor_ = new ICouponTypes.CouponFor[](holders.length);
-        for (uint256 i; i < holders.length; ) {
-            couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders[i]);
+        holders_ = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
+        uint256 length = holders_.length;
+        couponFor_ = new ICouponTypes.CouponFor[](length);
+        for (uint256 i; i < length; ) {
+            couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders_[i]);
             unchecked {
                 ++i;
             }

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ICouponSecurityHolders } from "./ICouponSecurityHolders.sol";
+import { ICouponTypes } from "../layer_2/coupon/ICouponTypes.sol";
+import { COUPON_CORPORATE_ACTION_TYPE } from "../../constants/values.sol";
+import { CouponStorageWrapper } from "../../domain/asset/coupon/CouponStorageWrapper.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+
+/**
+ * @title CouponSecurityHolders
+ * @notice Abstract implementation of `ICouponSecurityHolders`.
+ * @dev All functions are guarded by `onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, …)`
+ *      and delegate storage reads to `CouponStorageWrapper`.
+ * @author Asset Tokenization Studio Team
+ */
+abstract contract CouponSecurityHolders is ICouponSecurityHolders, Modifiers {
+    /// @inheritdoc ICouponSecurityHolders
+    function getCouponHolders(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (address[] memory holders_)
+    {
+        holders_ = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
+    }
+
+    /// @inheritdoc ICouponSecurityHolders
+    function getCouponsFor(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    )
+        external
+        view
+        override
+        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
+        returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory accounts_)
+    {
+        address[] memory holders = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
+        accounts_ = holders;
+        couponFor_ = new ICouponTypes.CouponFor[](holders.length);
+        for (uint256 i; i < holders.length; ) {
+            couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @inheritdoc ICouponSecurityHolders
+    function getTotalCouponHolders(
+        uint256 _couponID
+    ) external view override onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1) returns (uint256) {
+        return CouponStorageWrapper.getTotalCouponHolders(_couponID);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHolders.sol
@@ -40,10 +40,10 @@ abstract contract CouponSecurityHolders is ICouponSecurityHolders, Modifiers {
         view
         override
         onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory accounts_)
+        returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory holders_)
     {
         address[] memory holders = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
-        accounts_ = holders;
+        holders_ = holders;
         couponFor_ = new ICouponTypes.CouponFor[](holders.length);
         for (uint256 i; i < holders.length; ) {
             couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders[i]);

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHoldersFacet.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHoldersFacet.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ICouponSecurityHolders } from "./ICouponSecurityHolders.sol";
+import { CouponSecurityHolders } from "./CouponSecurityHolders.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _COUPON_SECURITY_HOLDERS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title CouponSecurityHoldersFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes coupon security-holder queries via
+ *         `ICouponSecurityHolders`, registered under
+ *         `_COUPON_SECURITY_HOLDERS_RESOLVER_KEY`.
+ * @dev Consolidates holder-enumeration methods previously part of `CouponFacet`:
+ *      `getCouponHolders`, `getCouponsFor`, `getTotalCouponHolders`.
+ *      Must be registered alongside any `Coupon*Facet` variant in all token
+ *      configurations that include coupon functionality.
+ *      Exposes 3 selectors and declares `ICouponSecurityHolders` as its interface ID.
+ */
+contract CouponSecurityHoldersFacet is CouponSecurityHolders, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _COUPON_SECURITY_HOLDERS_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 3;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.getTotalCouponHolders.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getCouponsFor.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getCouponHolders.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(ICouponSecurityHolders).interfaceId;
+        }
+    }
+}

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol
@@ -33,18 +33,18 @@ interface ICouponSecurityHolders is ICouponTypes {
      * @notice Returns coupon information for every holder of a given coupon, paginated.
      * @dev Internally resolves the holder page then retrieves per-holder coupon details.
      *      The two returned arrays share the same index: `couponFor_[i]` corresponds
-     *      to `accounts_[i]`.
+     *      to `holders_[i]`.
      * @param _couponID    Identifier of the target coupon (1-based index).
      * @param _pageIndex   Zero-based page number for pagination.
      * @param _pageLength  Maximum number of records to return per page.
      * @return couponFor_  Per-holder coupon details for the requested page.
-     * @return accounts_   Holder addresses corresponding to each entry in `couponFor_`.
+     * @return holders_   Holder addresses corresponding to each entry in `couponFor_`.
      */
     function getCouponsFor(
         uint256 _couponID,
         uint256 _pageIndex,
         uint256 _pageLength
-    ) external view returns (CouponFor[] memory couponFor_, address[] memory accounts_);
+    ) external view returns (CouponFor[] memory couponFor_, address[] memory holders_);
 
     /**
      * @notice Returns the total number of security holders eligible for a coupon.

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ICouponTypes } from "../layer_2/coupon/ICouponTypes.sol";
+
+/**
+ * @title ICouponSecurityHolders
+ * @notice Interface for querying the set of security holders associated with a coupon.
+ * @dev Functions revert with `WrongIndexForAction` (via `onlyMatchingActionType`) when
+ *      `_couponID` does not resolve to an existing coupon corporate action.
+ *      Holder data is sourced from the snapshot taken at the coupon record date when
+ *      available; otherwise the current token-holder enumeration is used.
+ * @author Asset Tokenization Studio Team
+ */
+interface ICouponSecurityHolders is ICouponTypes {
+    /**
+     * @notice Returns a paginated list of token holders eligible for a coupon.
+     * @dev Holders are resolved from the snapshot at the coupon record date when one
+     *      exists; falls back to the live holder list if no snapshot has been taken.
+     *      Returns an empty array if the record date has not yet been reached.
+     * @param _couponID    Identifier of the target coupon (1-based index).
+     * @param _pageIndex   Zero-based page number for pagination.
+     * @param _pageLength  Maximum number of addresses to return per page.
+     * @return holders_    Ordered array of holder addresses for the requested page.
+     */
+    function getCouponHolders(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (address[] memory holders_);
+
+    /**
+     * @notice Returns coupon information for every holder of a given coupon, paginated.
+     * @dev Internally resolves the holder page then retrieves per-holder coupon details.
+     *      The two returned arrays share the same index: `couponFor_[i]` corresponds
+     *      to `accounts_[i]`.
+     * @param _couponID    Identifier of the target coupon (1-based index).
+     * @param _pageIndex   Zero-based page number for pagination.
+     * @param _pageLength  Maximum number of records to return per page.
+     * @return couponFor_  Per-holder coupon details for the requested page.
+     * @return accounts_   Holder addresses corresponding to each entry in `couponFor_`.
+     */
+    function getCouponsFor(
+        uint256 _couponID,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (CouponFor[] memory couponFor_, address[] memory accounts_);
+
+    /**
+     * @notice Returns the total number of security holders eligible for a coupon.
+     * @dev Count is taken from the snapshot at the coupon record date when one exists;
+     *      falls back to the live total if no snapshot has been taken.
+     *      Returns zero if the record date has not yet been reached.
+     * @param _couponID  Identifier of the target coupon (1-based index).
+     * @return           Total number of eligible holders.
+     */
+    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256);
+}

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/Coupon.sol
@@ -65,28 +65,6 @@ abstract contract Coupon is ICoupon, Modifiers {
         couponFor_ = CouponStorageWrapper.getCouponFor(_couponID, _account);
     }
 
-    function getCouponsFor(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (ICouponTypes.CouponFor[] memory couponFor_, address[] memory accounts_)
-    {
-        address[] memory holders = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
-        accounts_ = holders;
-        couponFor_ = new ICouponTypes.CouponFor[](holders.length);
-        for (uint256 i; i < holders.length; ) {
-            couponFor_[i] = CouponStorageWrapper.getCouponFor(_couponID, holders[i]);
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
     function getCouponAmountFor(
         uint256 _couponID,
         address _account
@@ -102,26 +80,6 @@ abstract contract Coupon is ICoupon, Modifiers {
 
     function getCouponCount() external view override returns (uint256 couponCount_) {
         couponCount_ = CouponStorageWrapper.getCouponCount();
-    }
-
-    function getCouponHolders(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    )
-        external
-        view
-        override
-        onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1)
-        returns (address[] memory holders_)
-    {
-        holders_ = CouponStorageWrapper.getCouponHolders(_couponID, _pageIndex, _pageLength);
-    }
-
-    function getTotalCouponHolders(
-        uint256 _couponID
-    ) external view override onlyMatchingActionType(COUPON_CORPORATE_ACTION_TYPE, _couponID - 1) returns (uint256) {
-        return CouponStorageWrapper.getTotalCouponHolders(_couponID);
     }
 
     function _prepareCoupon(

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/CouponFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/CouponFacetBase.sol
@@ -7,14 +7,11 @@ import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticF
 
 abstract contract CouponFacetBase is Coupon, IStaticFunctionSelectors {
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 9;
+        uint256 selectorIndex = 6;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalCouponHolders.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponHolders.selector;
             staticFunctionSelectors_[--selectorIndex] = this.getCouponCount.selector;
             staticFunctionSelectors_[--selectorIndex] = this.getCouponAmountFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponsFor.selector;
             staticFunctionSelectors_[--selectorIndex] = this.getCouponFor.selector;
             staticFunctionSelectors_[--selectorIndex] = this.getCoupon.selector;
             staticFunctionSelectors_[--selectorIndex] = this.cancelCoupon.selector;

--- a/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/coupon/ICoupon.sol
@@ -63,18 +63,6 @@ interface ICoupon is ICouponTypes {
     /// @return couponFor_ Coupon information for the specified account
     function getCouponFor(uint256 _couponID, address _account) external view returns (CouponFor memory couponFor_);
 
-    /// @notice Retrieves coupon information for a specific coupon ID
-    /// @param _couponID The ID of the coupon
-    /// @param _pageIndex The page index for pagination
-    /// @param _pageLength The number of records per page
-    /// @return couponFor_ List of coupon information for accounts corresponding to the coupon ID
-    /// @return accounts_ List of account addresses corresponding to the coupon information
-    function getCouponsFor(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (CouponFor[] memory couponFor_, address[] memory accounts_);
-
     /// @notice Retrieves coupon amount numerator and denominator for a specific account and coupon ID
     /// @param _couponID The ID of the coupon
     /// @param _account The account address
@@ -87,21 +75,4 @@ interface ICoupon is ICouponTypes {
     /// @notice Retrieves the total number of coupons set for the security
     /// @return couponCount_ The total count of coupons
     function getCouponCount() external view returns (uint256 couponCount_);
-
-    /// @notice Retrieves a paginated list of coupon holders for a specific coupon ID
-    /// @param _couponID The ID of the coupon
-    /// @param _pageIndex The page index for pagination
-    /// @param _pageLength The number of holders per page
-    /// @return holders_ Array of holder addresses
-    function getCouponHolders(
-        uint256 _couponID,
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (address[] memory holders_);
-
-    /// @notice Retrieves the total number of coupon holders for a specific coupon ID
-    /// @dev It is the list of token holders at the snapshot taken at the record date
-    /// @param _couponID The ID of the coupon
-    /// @return The total number of coupon holders
-    function getTotalCouponHolders(uint256 _couponID) external view returns (uint256);
 }

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-04-30T14:27:45.533Z
- * Facets: 102
+ * Generated: 2026-05-04T08:13:36.619Z
+ * Facets: 103
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -67,6 +67,7 @@ import {
   CouponFixedRateFacet__factory,
   CouponKpiLinkedRateFacet__factory,
   CouponListingFacet__factory,
+  CouponSecurityHoldersFacet__factory,
   CouponSustainabilityPerformanceTargetRateFacet__factory,
   DiamondFacet__factory,
   DividendFacet__factory,
@@ -5902,30 +5903,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xbba7b56d",
       },
       {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsFor",
-        signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
-          canonical: "getCouponsFor(uint256,uint256,uint256)",
-        },
-        selector: "0x7327ad90",
-      },
-      {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "setCoupon",
         signature: {
           full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
@@ -6104,30 +6081,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "getCouponFor(uint256,address)",
         },
         selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsFor",
-        signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
-          canonical: "getCouponsFor(uint256,uint256,uint256)",
-        },
-        selector: "0x7327ad90",
-      },
-      {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
       },
       {
         name: "setCoupon",
@@ -6317,30 +6270,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xbba7b56d",
       },
       {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsFor",
-        signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
-          canonical: "getCouponsFor(uint256,uint256,uint256)",
-        },
-        selector: "0x7327ad90",
-      },
-      {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
-      },
-      {
         name: "setCoupon",
         signature: {
           full: "function setCoupon((uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) _newCoupon) returns (uint256 couponID_)",
@@ -6527,6 +6456,101 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     factory: (signer) => new CouponListingFacet__factory(signer),
   },
 
+  CouponSecurityHoldersFacet: {
+    name: "CouponSecurityHoldersFacet",
+    description:
+      "Diamond facet that exposes coupon security-holder queries via `ICouponSecurityHolders`, registered under `_COUPON_SECURITY_HOLDERS_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_COUPON_SECURITY_HOLDERS_RESOLVER_KEY",
+      value: "0x2dbf6db0e4dddb14cd72f1a882c1520fdbd592db82b5f3d2562ace6c9eb5cc23",
+    },
+    inheritance: ["CouponSecurityHolders", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "getCouponHolders",
+        signature: {
+          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
+          canonical: "getCouponHolders(uint256,uint256,uint256)",
+        },
+        selector: "0xa92e8371",
+      },
+      {
+        name: "getCouponsFor",
+        signature: {
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          canonical: "getCouponsFor(uint256,uint256,uint256)",
+        },
+        selector: "0x7327ad90",
+      },
+      {
+        name: "getTotalCouponHolders",
+        signature: {
+          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
+          canonical: "getTotalCouponHolders(uint256)",
+        },
+        selector: "0xec116ae3",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "CouponNotFound",
+        signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
+        selector: "0x69a80e75",
+      },
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongImpactDataValues",
+        signature: {
+          full: "error WrongImpactDataValues((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData)",
+          canonical: "WrongImpactDataValues((uint256,uint256,uint256,uint8,uint256))",
+        },
+        selector: "0xa60b6cba",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+      {
+        name: "WrongInterestRateValues",
+        signature: {
+          full: "error WrongInterestRateValues((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate)",
+          canonical: "WrongInterestRateValues((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
+        },
+        selector: "0x570cf0d3",
+      },
+    ],
+    factory: (signer) => new CouponSecurityHoldersFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
+
   CouponSustainabilityPerformanceTargetRateFacet: {
     name: "CouponSustainabilityPerformanceTargetRateFacet",
     resolverKey: {
@@ -6574,30 +6598,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "getCouponFor(uint256,address)",
         },
         selector: "0xbba7b56d",
-      },
-      {
-        name: "getCouponHolders",
-        signature: {
-          full: "function getCouponHolders(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
-          canonical: "getCouponHolders(uint256,uint256,uint256)",
-        },
-        selector: "0xa92e8371",
-      },
-      {
-        name: "getCouponsFor",
-        signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
-          canonical: "getCouponsFor(uint256,uint256,uint256)",
-        },
-        selector: "0x7327ad90",
-      },
-      {
-        name: "getTotalCouponHolders",
-        signature: {
-          full: "function getTotalCouponHolders(uint256 _couponID) view returns (uint256)",
-          canonical: "getTotalCouponHolders(uint256)",
-        },
-        selector: "0xec116ae3",
       },
       {
         name: "setCoupon",
@@ -14292,7 +14292,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 102 as const;
+export const TOTAL_FACETS = 103 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-04T08:13:36.619Z
+ * Generated: 2026-05-04T10:09:29.455Z
  * Facets: 103
  * Infrastructure: 2
  *
@@ -6477,7 +6477,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       {
         name: "getCouponsFor",
         signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] accounts_)",
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] holders_)",
           canonical: "getCouponsFor(uint256,uint256,uint256)",
         },
         selector: "0x7327ad90",

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -112,6 +112,7 @@ const BOND_FACETS = [
   // Advanced Features
   "AdjustBalancesFacet",
   "CouponFacet",
+  "CouponSecurityHoldersFacet",
   "LockFacet",
   "NominalValueFacet",
   "ProceedRecipientsFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -115,6 +115,8 @@ const BOND_FIXED_RATE_FACETS = [
   "CouponListingFacet",
   "SsiManagementFacet",
 
+  "CouponSecurityHoldersFacet",
+
   // Interest Rate (rate-specific)
   "CouponFixedRateFacet",
   "FixedRateFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -113,6 +113,8 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   "SsiManagementFacet",
   "TransferAndLockFacet",
 
+  "CouponSecurityHoldersFacet",
+
   // Interest Rate (rate-specific - keep variant names)
   "CouponKpiLinkedRateFacet",
   "KpiLinkedRateFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -113,6 +113,8 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   "SsiManagementFacet",
   "TransferAndLockFacet",
 
+  "CouponSecurityHoldersFacet",
+
   // Interest Rate (rate-specific - keep variant names)
   "CouponSustainabilityPerformanceTargetRateFacet",
   "SustainabilityPerformanceTargetRateFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -38,6 +38,7 @@ const LOAN_FACETS = [
   // Loan Functionality
   "LoanFacet",
   "CouponFacet",
+  "CouponSecurityHoldersFacet",
   "CouponListingFacet",
   "NominalValueFacet",
   "AmortizationFacet",

--- a/packages/ats/contracts/test/contracts/integration/couponSecurityHolders/couponSecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/couponSecurityHolders/couponSecurityHolders.test.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { ResolverProxy, type IAsset } from "@contract-types";
+import { DEFAULT_PARTITION, ATS_ROLES, TIME_PERIODS_S, ZERO, EMPTY_STRING } from "@scripts";
+import { getDltTimestamp, executeRbac } from "@test";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { deployBondTokenFixture } from "@test";
+import { MAX_UINT256 } from "@test";
+
+const numberOfCoupons = 50;
+const frequency = TIME_PERIODS_S.DAY;
+let startingDate = 0;
+let maturityDate = 0;
+
+let couponRecordDateInSeconds = 0;
+let couponExecutionDateInSeconds = 0;
+const couponRate = 50;
+const couponRateDecimals = 1;
+const couponPeriod = TIME_PERIODS_S.WEEK;
+let couponFixingDateInSeconds = 0;
+let couponEndDateInSeconds = 0;
+let couponStartDateInSeconds = 0;
+const EMPTY_VC_ID = EMPTY_STRING;
+const couponRateStatus = 1;
+
+describe("CouponSecurityHolders Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+
+  let asset: IAsset;
+
+  async function deploySecurityFixture() {
+    const base = await deployBondTokenFixture({
+      bondDataParams: {
+        bondDetails: {
+          startingDate: startingDate,
+          maturityDate: maturityDate,
+        },
+      },
+    });
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target);
+    await executeRbac(asset, [
+      {
+        role: ATS_ROLES.PAUSER_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES.KYC_ROLE,
+        members: [signer_B.address],
+      },
+      {
+        role: ATS_ROLES.SSI_MANAGER_ROLE,
+        members: [signer_A.address],
+      },
+      {
+        role: ATS_ROLES.AGENT_ROLE,
+        members: [signer_A.address],
+      },
+    ]);
+
+    await asset.connect(signer_A).addIssuer(signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+  }
+
+  before(async () => {
+    const currentTimestamp = await getDltTimestamp();
+    startingDate = currentTimestamp + TIME_PERIODS_S.DAY;
+    maturityDate = startingDate + numberOfCoupons * frequency;
+  });
+
+  beforeEach(async () => {
+    const currentTimestamp = await getDltTimestamp();
+    couponRecordDateInSeconds = currentTimestamp + 400;
+    couponExecutionDateInSeconds = currentTimestamp + 1200;
+    couponFixingDateInSeconds = currentTimestamp + 1200;
+    couponEndDateInSeconds = couponFixingDateInSeconds - 1;
+    couponStartDateInSeconds = couponEndDateInSeconds - couponPeriod;
+    await loadFixture(deploySecurityFixture);
+  });
+
+  it("GIVEN a coupon with snapshot WHEN getCouponHolders is called THEN returns token holders from snapshot", async () => {
+    const TotalAmount = 1000;
+    await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A.address);
+    await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+
+    await asset.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: TotalAmount,
+      data: "0x",
+    });
+
+    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
+    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await asset.connect(signer_A).setCoupon(couponData);
+
+    await asset.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+
+    // Trigger scheduled tasks by performing an action
+    await asset.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_B.address,
+      value: 500,
+      data: "0x",
+    });
+
+    const coupon = (await asset.getCoupon(1)).registeredCoupon_;
+    const couponTotalHolders = await asset.getTotalCouponHolders(1);
+    const couponHolders = await asset.getCouponHolders(1, 0, couponTotalHolders);
+
+    expect(coupon.snapshotId).to.be.greaterThan(0); // Snapshot should have been taken
+    expect(couponTotalHolders).to.equal(1);
+    expect([...couponHolders]).to.have.members([signer_A.address]);
+  });
+
+  it("GIVEN no existing coupon WHEN holder view methods called with invalid ID THEN transaction fails with WrongIndexForAction", async () => {
+    await expect(asset.getTotalCouponHolders(999)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
+    await expect(asset.getCouponHolders(999, 0, 10)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
+    await expect(asset.getCouponsFor(999, 0, 10)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
+  });
+
+  it("GIVEN a coupon before record date WHEN getTotalCouponHolders THEN returns zero", async () => {
+    await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A.address);
+    await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_A.address);
+
+    await asset.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: 1000,
+      data: "0x",
+    });
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await asset.connect(signer_A).setCoupon(couponData);
+
+    const totalHolders = await asset.getTotalCouponHolders(1);
+    const holders = await asset.getCouponHolders(1, 0, 10);
+    const [couponsFor, accounts] = await asset.getCouponsFor(1, 0, 10);
+
+    expect(totalHolders).to.equal(0);
+    expect(holders.length).to.equal(0);
+    expect(couponsFor.length).to.equal(0);
+    expect(accounts.length).to.equal(0);
+  });
+
+  it("GIVEN a coupon after record date with holders WHEN getCouponsFor THEN returns correct data for each holder", async () => {
+    await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A.address);
+    await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_A.address);
+    await asset.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+
+    await asset.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: 500,
+      data: "0x",
+    });
+
+    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
+    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
+
+    const couponData = {
+      recordDate: couponRecordDateInSeconds.toString(),
+      executionDate: couponExecutionDateInSeconds.toString(),
+      rate: couponRate,
+      rateDecimals: couponRateDecimals,
+      startDate: couponStartDateInSeconds.toString(),
+      endDate: couponEndDateInSeconds.toString(),
+      fixingDate: couponFixingDateInSeconds.toString(),
+      rateStatus: couponRateStatus,
+    };
+
+    await asset.connect(signer_A).setCoupon(couponData);
+    await asset.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+
+    // Trigger snapshot via a transfer
+    await asset.connect(signer_A).issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_B.address,
+      value: 100,
+      data: "0x",
+    });
+
+    const totalHolders = await asset.getTotalCouponHolders(1);
+    const [couponsFor, accounts] = await asset.getCouponsFor(1, 0, totalHolders);
+
+    expect(totalHolders).to.be.greaterThan(0);
+    expect(couponsFor.length).to.equal(Number(totalHolders));
+    expect(accounts.length).to.equal(Number(totalHolders));
+    expect(couponsFor[0].recordDateReached).to.be.true;
+    expect(accounts).to.include(signer_A.address);
+  });
+});

--- a/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
@@ -682,54 +682,6 @@ describe("Coupon Tests", () => {
     await expect(asset.connect(signer_C).cancelCoupon(999)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
   });
 
-  it("GIVEN a coupon with snapshot WHEN getCouponHolders is called THEN returns token holders from snapshot", async () => {
-    const TotalAmount = 1000;
-    await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A.address);
-    await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_A.address);
-    await asset.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
-
-    await asset.connect(signer_A).issueByPartition({
-      partition: DEFAULT_PARTITION,
-      tokenHolder: signer_A.address,
-      value: TotalAmount,
-      data: "0x",
-    });
-
-    couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;
-    couponExecutionDateInSeconds = (await getDltTimestamp()) + 2000;
-
-    const couponData = {
-      recordDate: couponRecordDateInSeconds.toString(),
-      executionDate: couponExecutionDateInSeconds.toString(),
-      rate: couponRate,
-      rateDecimals: couponRateDecimals,
-      startDate: couponStartDateInSeconds.toString(),
-      endDate: couponEndDateInSeconds.toString(),
-      fixingDate: couponFixingDateInSeconds.toString(),
-      rateStatus: couponRateStatus,
-    };
-
-    await asset.connect(signer_A).setCoupon(couponData);
-
-    await asset.changeSystemTimestamp(couponRecordDateInSeconds + 1);
-
-    // Trigger scheduled tasks by performing an action
-    await asset.connect(signer_A).issueByPartition({
-      partition: DEFAULT_PARTITION,
-      tokenHolder: signer_B.address,
-      value: 500,
-      data: "0x",
-    });
-
-    const coupon = (await asset.getCoupon(1)).registeredCoupon_;
-    const couponTotalHolders = await asset.getTotalCouponHolders(1);
-    const couponHolders = await asset.getCouponHolders(1, 0, couponTotalHolders);
-
-    expect(coupon.snapshotId).to.be.greaterThan(0); // Snapshot should have been taken
-    expect(couponTotalHolders).to.equal(1);
-    expect([...couponHolders]).to.have.members([signer_A.address]);
-  });
-
   it("GIVEN a coupon without snapshot WHEN getCouponFor is called after record date THEN uses current balance", async () => {
     const TotalAmount = 1000;
     await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A.address);
@@ -808,10 +760,6 @@ describe("Coupon Tests", () => {
       asset,
       "WrongIndexForAction",
     );
-    await expect(asset.getTotalCouponHolders(999)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
-    await expect(asset.getCouponHolders(999, 0, 10)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
-
-    await expect(asset.getCouponsFor(999, 0, 10)).to.be.revertedWithCustomError(asset, "WrongIndexForAction");
   });
 
   it("GIVEN invalid startDate > endDate WHEN setCoupon THEN transaction fails with WrongDates", async () => {

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -501,7 +501,7 @@ export class RPCQueryAdapter {
       );
     });
 
-    return { coupons, accounts: [...result.accounts_] };
+    return { coupons, accounts: [...result.holders_] };
   }
 
   async getCouponAmountFor(address: EvmAddress, target: EvmAddress, coupon: number): Promise<CouponAmountFor> {

--- a/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
+++ b/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
@@ -18,8 +18,10 @@ import {
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/balanceTrackerAtSnapshot/IBalanceTrackerAtSnapshot.sol";
 import { IBond } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBond.sol";
 import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
+import {
+    ICouponSecurityHolders
+} from "@hashgraph/asset-tokenization-contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol";
 import { IBondRead } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondRead.sol";
-import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
 import { IEquity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/equity/IEquity.sol";
 import { IDividend } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/dividend/IDividend.sol";
 import { ISecurity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/security/ISecurity.sol";
@@ -733,7 +735,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
         if (_assetType == ILifeCycleCashFlow.AssetType.Equity) {
             return IDividend(_asset).getDividendHolders(_distributionID, _pageIndex, _pageLength);
         } else {
-            return ICoupon(_asset).getCouponHolders(_distributionID, _pageIndex, _pageLength);
+            return ICouponSecurityHolders(_asset).getCouponHolders(_distributionID, _pageIndex, _pageLength);
         }
     }
 


### PR DESCRIPTION
This pull request refactors the coupon-related facets by extracting all coupon security-holder query logic from the general `CouponFacet` into a dedicated `CouponSecurityHoldersFacet`. This separation clarifies responsibilities, improves maintainability, and ensures all coupon-holder enumeration methods are grouped under a single, clearly registered facet. The change is non-breaking: all existing selectors and interfaces remain compatible, and calls through `IAsset` are unaffected. The update also includes new tests and configuration changes to support the new facet.

**Facet extraction and interface changes:**

* Introduced new files: `ICouponSecurityHolders.sol`, `CouponSecurityHolders.sol`, and `CouponSecurityHoldersFacet.sol` to encapsulate coupon holder queries in their own facet and interface. [[1]](diffhunk://#diff-d74535555e34deb4df86b39411b78748036b02b78bae4c8ac2e87c86cecb08a2R1-R20) [[2]](diffhunk://#diff-b42a1083e9403f1c7ed73ffb46f16291e5d838fc4d8343aaa453ff99cb93e91dR1-R58) [[3]](diffhunk://#diff-473b055c71c738dc7b2c2b4789656c3cbbd9f12661eb2a8533bf615a9bffb251R1-R62) [[4]](diffhunk://#diff-ec7a9802bf86ba64d7e0aade902471e096037a8b52ea4af0ec30176887b00b6dR1-R46)
* Removed `getCouponHolders`, `getCouponsFor`, and `getTotalCouponHolders` from `Coupon.sol`, `ICoupon.sol`, and `CouponFacetBase.sol`, reducing the number of selectors in `CouponFacetBase` from 9 to 6. [[1]](diffhunk://#diff-d74535555e34deb4df86b39411b78748036b02b78bae4c8ac2e87c86cecb08a2R1-R20) [[2]](diffhunk://#diff-77a24c2ff1e99d9db4b5b9723b9b3279b5fffa406087ce3e405d3160ab7a089fL68-L89) [[3]](diffhunk://#diff-77a24c2ff1e99d9db4b5b9723b9b3279b5fffa406087ce3e405d3160ab7a089fL107-L126) [[4]](diffhunk://#diff-86f97b4d03af48a6ca40caf84d0c612abf4ffdf45d60e4eeaa8e24afe698e2c2L66-L77) [[5]](diffhunk://#diff-86f97b4d03af48a6ca40caf84d0c612abf4ffdf45d60e4eeaa8e24afe698e2c2L90-L106) [[6]](diffhunk://#diff-ed7bbf3bdfbf6a27a96290fa5d39d11b4720194d8ddde5ca1c580aced789364aL10-L17)
* Updated the `IAsset` interface to inherit from `ICouponSecurityHolders` in addition to `ICoupon`, ensuring all coupon holder queries are available through `IAsset`. [[1]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R80) [[2]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R173)

**Constants and configuration:**

* Added the `_COUPON_SECURITY_HOLDERS_RESOLVER_KEY` constant for facet registration and updated `Configuration.ts` and related scripts to register the new facet. [[1]](diffhunk://#diff-a6761447814cc412fd1b009f087d5b68cc0a5e3ad8ef1dd4e34fdd2e6b3b465dR602-R604) [[2]](diffhunk://#diff-409dd60ab11b542fadbe019ebe0bae2d62b9a88197c5df9c72dbf6139790278bR106)
* Updated the facet registry and deployment scripts to include `CouponSecurityHoldersFacet` and its factory. [[1]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L13-R14) [[2]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R70)

**Testing and documentation:**

* Added a new integration test `couponSecurityHolders.test.ts` covering the new facet’s behavior, including snapshots, pagination, and error cases.
* Updated the changeset documentation to describe the migration, emphasizing that the change is non-breaking and selectors are unchanged.

**Registry and selector cleanup:**

* Removed old coupon-holder selectors from the facet registry to reflect their migration to the new facet. [[1]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L5904-L5927) [[2]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L6108-L6131)

This refactor isolates coupon security-holder logic for better modularity while maintaining backward compatibility and improving test coverage.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
