### PR TITLE
feat: hold at snapshot facet

### DIFF
--- a/.changeset/maf-hold-at-snapshot.md
+++ b/.changeset/maf-hold-at-snapshot.md
@@ -1,0 +1,30 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+# HoldAtSnapshot split
+
+Extract `heldBalanceOfAtSnapshot` from `SnapshotsFacet` into a dedicated
+`HoldAtSnapshotFacet` registered under `_HOLD_AT_SNAPSHOT_RESOLVER_KEY`.
+
+## Changes
+
+- Added `contracts/facets/holdAtSnapshot/IHoldAtSnapshot.sol`,
+  `HoldAtSnapshot.sol`, `HoldAtSnapshotFacet.sol`.
+- Added `_HOLD_AT_SNAPSHOT_RESOLVER_KEY` constant in `resolverKeys.sol`.
+- Removed `heldBalanceOfAtSnapshot` from `ISnapshots.sol`, `Snapshots.sol`,
+  and `SnapshotsFacet.sol` (11 → 10 selectors).
+- `IAsset` now inherits `IHoldAtSnapshot`.
+- Updated `Configuration.ts` and 7 `createConfiguration.ts` scripts
+  (equity, bond, bondFixedRate, bondKpiLinkedRate,
+  bondSustainabilityPerformanceTargetRate, loan, loanPortfolio) to register
+  `HoldAtSnapshotFacet`.
+- Added `test/contracts/integration/holdAtSnapshot/holdAtSnapshot.test.ts`
+  covering revert cases (SnapshotIdNull, SnapshotIdDoesNotExists), happy paths,
+  historical correctness across two snapshots, and multi-holder independence.
+- Removed `heldBalanceOfAtSnapshot` assertions from `snapshots.test.ts`.
+
+## Non-breaking
+
+The 4-byte selector of `heldBalanceOfAtSnapshot` is unchanged. Any call
+through `IAsset` continues to work without modification.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -105,6 +105,7 @@ export const CONTRACT_NAMES = [
   "CouponListingFacet",
   "CouponSecurityHoldersFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "CorporateActionsFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -534,6 +534,9 @@ bytes32 constant _BALANCE_TRACKER_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY = 0x1d00
 // keccak256('security.token.standard.clearingAtSnapshotByPartition.resolverKey');
 bytes32 constant _CLEARING_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY = 0x28a0e168340e454e3c0e6fbe7dccb80c91178f4e2ee50776e28bbc5c19063e88;
 
+// keccak256('security.token.standard.holdAtSnapshot.resolverKey');
+bytes32 constant _HOLD_AT_SNAPSHOT_RESOLVER_KEY = 0x799547b5a870e2f0d0e9664f133d288ad8cd2a1b267be8ae0085030adb2d858d;
+
 // Layer 2 Resolver Keys
 
 // keccak256('security.token.standard.equity.resolverKey');

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -77,6 +77,7 @@ import {
 } from "./balanceTrackerAtSnapshotByPartition/IBalanceTrackerAtSnapshotByPartition.sol";
 import { IClearingAtSnapshot } from "./clearingAtSnapshot/IClearingAtSnapshot.sol";
 import { IClearingAtSnapshotByPartition } from "./clearingAtSnapshotByPartition/IClearingAtSnapshotByPartition.sol";
+import { IHoldAtSnapshot } from "./holdAtSnapshot/IHoldAtSnapshot.sol";
 import { ICouponListing } from "./couponListing/ICouponListing.sol";
 import { ICouponSecurityHolders } from "./couponSecurityHolders/ICouponSecurityHolders.sol";
 import {
@@ -187,6 +188,7 @@ interface IAsset is
     IBalanceTrackerAtSnapshotByPartition,
     IClearingAtSnapshot,
     IClearingAtSnapshotByPartition,
+    IHoldAtSnapshot,
     IFixedRate,
     // Scheduled Tasks
     ICouponListing,

--- a/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshot.sol
+++ b/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshot.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IHoldAtSnapshot } from "./IHoldAtSnapshot.sol";
+import { SnapshotsStorageWrapper } from "../../domain/asset/SnapshotsStorageWrapper.sol";
+
+/**
+ * @title  HoldAtSnapshot
+ * @notice Abstract implementation of `IHoldAtSnapshot`.
+ * @dev    Delegates all storage reads to `SnapshotsStorageWrapper`. Intended to be
+ *         inherited solely by `HoldAtSnapshotFacet`.
+ * @author Asset Tokenization Studio Team
+ */
+abstract contract HoldAtSnapshot is IHoldAtSnapshot {
+    /// @inheritdoc IHoldAtSnapshot
+    function heldBalanceOfAtSnapshot(
+        uint256 _snapshotID,
+        address _tokenHolder
+    ) external view override returns (uint256 balance_) {
+        balance_ = SnapshotsStorageWrapper.heldBalanceOfAtSnapshot(_snapshotID, _tokenHolder);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshotFacet.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IHoldAtSnapshot } from "./IHoldAtSnapshot.sol";
+import { HoldAtSnapshot } from "./HoldAtSnapshot.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _HOLD_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title  HoldAtSnapshotFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes the held-balance-at-snapshot query via
+ *         `IHoldAtSnapshot`, registered under `_HOLD_AT_SNAPSHOT_RESOLVER_KEY`.
+ * @dev    Exposes one selector: `heldBalanceOfAtSnapshot`. Inherits read logic from
+ *         `HoldAtSnapshot` and satisfies `IStaticFunctionSelectors` for Diamond proxy
+ *         selector registration.
+ */
+contract HoldAtSnapshotFacet is HoldAtSnapshot, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _HOLD_AT_SNAPSHOT_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 1;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.heldBalanceOfAtSnapshot.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IHoldAtSnapshot).interfaceId;
+        }
+    }
+}

--- a/packages/ats/contracts/contracts/facets/holdAtSnapshot/IHoldAtSnapshot.sol
+++ b/packages/ats/contracts/contracts/facets/holdAtSnapshot/IHoldAtSnapshot.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/**
+ * @title  IHoldAtSnapshot
+ * @notice Interface for querying a token holder's held (escrowed) balance at the time of a
+ *         previously taken snapshot.
+ * @dev    Reads are delegated to `SnapshotsStorageWrapper` and depend on the snapshot index
+ *         recorded by `takeSnapshot`. The held amount is computed against the adjustment
+ *         factor active at the snapshot timestamp via
+ *         `HoldStorageWrapper.getHeldAmountForAdjustedAt`.
+ *         Reverts with `SnapshotIdNull` when `_snapshotID == 0` and with
+ *         `SnapshotIdDoesNotExists` for unknown identifiers.
+ * @author Asset Tokenization Studio Team
+ */
+interface IHoldAtSnapshot {
+    /**
+     * @notice Returns the held balance of a token holder at the time of a given snapshot.
+     * @dev    Sums all hold escrow amounts active at `_snapshotID`, adjusted for any
+     *         balance-adjustment factor recorded at that snapshot timestamp.
+     * @param _snapshotID  The snapshot identifier returned by a prior `takeSnapshot` call.
+     * @param _tokenHolder The address of the token holder.
+     * @return balance_ The held balance of `_tokenHolder` recorded at `_snapshotID`.
+     */
+    function heldBalanceOfAtSnapshot(
+        uint256 _snapshotID,
+        address _tokenHolder
+    ) external view returns (uint256 balance_);
+}

--- a/packages/ats/contracts/contracts/facets/layer_1/snapshot/ISnapshots.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/snapshot/ISnapshots.sol
@@ -63,11 +63,6 @@ interface ISnapshots {
         address _tokenHolder
     ) external view returns (uint256 balance_);
 
-    function heldBalanceOfAtSnapshot(
-        uint256 _snapshotID,
-        address _tokenHolder
-    ) external view returns (uint256 balance_);
-
     function heldBalanceOfAtSnapshotByPartition(
         bytes32 _partition,
         uint256 _snapshotID,

--- a/packages/ats/contracts/contracts/facets/layer_1/snapshot/Snapshots.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/snapshot/Snapshots.sol
@@ -73,14 +73,6 @@ abstract contract Snapshots is ISnapshots, Modifiers {
     }
 
     /// @inheritdoc ISnapshots
-    function heldBalanceOfAtSnapshot(
-        uint256 _snapshotID,
-        address _tokenHolder
-    ) external view returns (uint256 balance_) {
-        balance_ = SnapshotsStorageWrapper.heldBalanceOfAtSnapshot(_snapshotID, _tokenHolder);
-    }
-
-    /// @inheritdoc ISnapshots
     function heldBalanceOfAtSnapshotByPartition(
         bytes32 _partition,
         uint256 _snapshotID,

--- a/packages/ats/contracts/contracts/facets/layer_1/snapshot/SnapshotsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/snapshot/SnapshotsFacet.sol
@@ -24,14 +24,13 @@ contract SnapshotsFacet is Snapshots, IStaticFunctionSelectors {
 
     /// @inheritdoc IStaticFunctionSelectors
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 11;
+        uint256 selectorIndex = 10;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
             staticFunctionSelectors_[--selectorIndex] = this.getTotalTokenHoldersAtSnapshot.selector;
             staticFunctionSelectors_[--selectorIndex] = this.getTokenHoldersAtSnapshot.selector;
             staticFunctionSelectors_[--selectorIndex] = this.frozenBalanceOfAtSnapshotByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.heldBalanceOfAtSnapshotByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.heldBalanceOfAtSnapshot.selector;
             staticFunctionSelectors_[--selectorIndex] = this.lockedBalanceOfAtSnapshotByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.lockedBalanceOfAtSnapshot.selector;
             staticFunctionSelectors_[--selectorIndex] = this.partitionsOfAtSnapshot.selector;

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-04T14:40:00.426Z
- * Facets: 107
+ * Generated: 2026-05-04T14:59:04.448Z
+ * Facets: 108
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -88,6 +88,7 @@ import {
   FixedRateFacet__factory,
   FreezeAtSnapshotFacet__factory,
   FreezeFacet__factory,
+  HoldAtSnapshotFacet__factory,
   HoldByPartitionFacet__factory,
   HoldFacet__factory,
   HoldManagementFacet__factory,
@@ -9281,6 +9282,43 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new FreezeFacetTimeTravel__factory(signer),
   },
 
+  HoldAtSnapshotFacet: {
+    name: "HoldAtSnapshotFacet",
+    description:
+      "Diamond facet that exposes the held-balance-at-snapshot query via `IHoldAtSnapshot`, registered under `_HOLD_AT_SNAPSHOT_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_HOLD_AT_SNAPSHOT_RESOLVER_KEY",
+      value: "0x799547b5a870e2f0d0e9664f133d288ad8cd2a1b267be8ae0085030adb2d858d",
+    },
+    inheritance: ["HoldAtSnapshot", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "heldBalanceOfAtSnapshot",
+        signature: {
+          full: "function heldBalanceOfAtSnapshot(uint256 _snapshotID, address _tokenHolder) view returns (uint256 balance_)",
+          canonical: "heldBalanceOfAtSnapshot(uint256,address)",
+        },
+        selector: "0xb52e39aa",
+      },
+    ],
+    errors: [
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+    ],
+    factory: (signer) => new HoldAtSnapshotFacet__factory(signer),
+  },
+
   HoldByPartitionFacet: {
     name: "HoldByPartitionFacet",
     description:
@@ -13031,14 +13069,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x867126e1",
       },
       {
-        name: "heldBalanceOfAtSnapshot",
-        signature: {
-          full: "function heldBalanceOfAtSnapshot(uint256 _snapshotID, address _tokenHolder) view returns (uint256 balance_)",
-          canonical: "heldBalanceOfAtSnapshot(uint256,address)",
-        },
-        selector: "0xb52e39aa",
-      },
-      {
         name: "heldBalanceOfAtSnapshotByPartition",
         signature: {
           full: "function heldBalanceOfAtSnapshotByPartition(bytes32 _partition, uint256 _snapshotID, address _tokenHolder) view returns (uint256 balance_)",
@@ -14408,7 +14438,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 107 as const;
+export const TOTAL_FACETS = 108 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -48,6 +48,7 @@ const BOND_FACETS = [
   "KycFacet",
   "PauseFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "BalanceTrackerFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -45,6 +45,7 @@ const BOND_FIXED_RATE_FACETS = [
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "BalanceTrackerByPartitionFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -53,6 +53,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "BalanceTrackerByPartitionFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -53,6 +53,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "BalanceTrackerByPartitionFacet",

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -54,6 +54,7 @@ const EQUITY_FACETS = [
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "BalanceTrackerByPartitionFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -123,6 +123,7 @@ const LOAN_FACETS = [
 
   // Advanced Features
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "CorporateActionsFacet",

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -60,6 +60,7 @@ const LOANS_PORTFOLIO_FACETS = [
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "SnapshotsFacet",
+  "HoldAtSnapshotFacet",
   "FreezeAtSnapshotFacet",
   "CoreAtSnapshotFacet",
   "SsiManagementFacet",

--- a/packages/ats/contracts/test/contracts/integration/holdAtSnapshot/holdAtSnapshot.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/holdAtSnapshot/holdAtSnapshot.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { type ResolverProxy, type IAsset } from "@contract-types";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { ATS_ROLES, EMPTY_STRING, ZERO } from "@scripts";
+import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
+
+const _PARTITION_ID_1 = "0x0000000000000000000000000000000000000000000000000000000000000001";
+const _PARTITION_ID_2 = "0x0000000000000000000000000000000000000000000000000000000000000002";
+const EMPTY_VC_ID = EMPTY_STRING;
+const amount = 1000;
+
+describe("HoldAtSnapshot Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+
+  let asset: IAsset;
+
+  async function deployEquity() {
+    const base = await deployEquityTokenFixture({
+      equityDataParams: {
+        securityData: { isMultiPartition: true },
+      },
+    });
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target);
+
+    await executeRbac(asset, [
+      { role: ATS_ROLES.ISSUER_ROLE, members: [signer_B.address] },
+      { role: ATS_ROLES.KYC_ROLE, members: [signer_B.address] },
+      { role: ATS_ROLES.SNAPSHOT_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.SSI_MANAGER_ROLE, members: [signer_A.address] },
+    ]);
+
+    await asset.connect(signer_A).addIssuer(signer_B.address);
+    await asset.connect(signer_B).grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_B.address);
+    await asset.connect(signer_B).grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_B.address);
+    await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_B.address);
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployEquity);
+  });
+
+  describe("heldBalanceOfAtSnapshot", () => {
+    it("GIVEN no snapshot taken WHEN heldBalanceOfAtSnapshot at id 0 THEN reverts with SnapshotIdNull", async () => {
+      await expect(asset.heldBalanceOfAtSnapshot(0, signer_A.address)).to.be.revertedWithCustomError(
+        asset,
+        "SnapshotIdNull",
+      );
+    });
+
+    it("GIVEN no snapshot taken WHEN heldBalanceOfAtSnapshot at id 1 THEN reverts with SnapshotIdDoesNotExists", async () => {
+      await expect(asset.heldBalanceOfAtSnapshot(1, signer_A.address)).to.be.revertedWithCustomError(
+        asset,
+        "SnapshotIdDoesNotExists",
+      );
+    });
+
+    it("GIVEN a snapshot taken WHEN heldBalanceOfAtSnapshot for holder with no holds THEN returns zero", async () => {
+      await asset.connect(signer_B).issueByPartition({
+        partition: _PARTITION_ID_1,
+        tokenHolder: signer_A.address,
+        value: amount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).takeSnapshot();
+
+      const balance = await asset.heldBalanceOfAtSnapshot(1, signer_A.address);
+      expect(balance).to.equal(0);
+    });
+
+    it("GIVEN a snapshot taken after createHoldByPartition WHEN heldBalanceOfAtSnapshot THEN returns the exact held amount at that snapshot", async () => {
+      const heldAmount = 300;
+
+      await asset.connect(signer_B).issueByPartition({
+        partition: _PARTITION_ID_1,
+        tokenHolder: signer_A.address,
+        value: amount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).createHoldByPartition(_PARTITION_ID_1, {
+        amount: heldAmount,
+        expirationTimestamp: MAX_UINT256,
+        escrow: signer_B.address,
+        to: signer_C.address,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).takeSnapshot();
+
+      const balance = await asset.heldBalanceOfAtSnapshot(1, signer_A.address);
+      expect(balance).to.equal(heldAmount);
+    });
+
+    it("GIVEN two snapshots where held amount differs between them WHEN heldBalanceOfAtSnapshot at first snapshot THEN returns the value recorded at the first snapshot", async () => {
+      const heldAmountFirst = 100;
+      const heldAmountSecond = 250;
+
+      await asset.connect(signer_B).issueByPartition({
+        partition: _PARTITION_ID_1,
+        tokenHolder: signer_A.address,
+        value: amount,
+        data: "0x",
+      });
+
+      // snapshot 1: no holds yet
+      await asset.connect(signer_A).takeSnapshot();
+
+      await asset.connect(signer_A).createHoldByPartition(_PARTITION_ID_1, {
+        amount: heldAmountFirst,
+        expirationTimestamp: MAX_UINT256,
+        escrow: signer_B.address,
+        to: signer_C.address,
+        data: "0x",
+      });
+
+      // snapshot 2: first hold active
+      await asset.connect(signer_A).takeSnapshot();
+
+      await asset.connect(signer_A).createHoldByPartition(_PARTITION_ID_1, {
+        amount: heldAmountSecond,
+        expirationTimestamp: MAX_UINT256,
+        escrow: signer_B.address,
+        to: signer_C.address,
+        data: "0x",
+      });
+
+      const balanceAtSnapshot1 = await asset.heldBalanceOfAtSnapshot(1, signer_A.address);
+      const balanceAtSnapshot2 = await asset.heldBalanceOfAtSnapshot(2, signer_A.address);
+
+      expect(balanceAtSnapshot1).to.equal(0);
+      expect(balanceAtSnapshot2).to.equal(heldAmountFirst);
+    });
+
+    it("GIVEN two holders each with different held amounts at snapshot time WHEN heldBalanceOfAtSnapshot THEN returns each holder's individual held amount independently", async () => {
+      const heldAmountA = 200;
+      const heldAmountC = 450;
+
+      await asset.connect(signer_B).issueByPartition({
+        partition: _PARTITION_ID_1,
+        tokenHolder: signer_A.address,
+        value: amount,
+        data: "0x",
+      });
+      await asset.connect(signer_B).issueByPartition({
+        partition: _PARTITION_ID_2,
+        tokenHolder: signer_C.address,
+        value: amount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).createHoldByPartition(_PARTITION_ID_1, {
+        amount: heldAmountA,
+        expirationTimestamp: MAX_UINT256,
+        escrow: signer_B.address,
+        to: signer_C.address,
+        data: "0x",
+      });
+      await asset.connect(signer_C).createHoldByPartition(_PARTITION_ID_2, {
+        amount: heldAmountC,
+        expirationTimestamp: MAX_UINT256,
+        escrow: signer_B.address,
+        to: signer_A.address,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).takeSnapshot();
+
+      const balanceA = await asset.heldBalanceOfAtSnapshot(1, signer_A.address);
+      const balanceC = await asset.heldBalanceOfAtSnapshot(1, signer_C.address);
+
+      expect(balanceA).to.equal(heldAmountA);
+      expect(balanceC).to.equal(heldAmountC);
+    });
+  });
+});

--- a/packages/ats/contracts/test/contracts/integration/layer_1/snapshots/snapshots.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/snapshots/snapshots.test.ts
@@ -254,8 +254,6 @@ describe("Snapshots Tests", () => {
       signer_C.address,
     );
 
-    const snapshot_HeldBalance_Of_A_1 = await asset.heldBalanceOfAtSnapshot(1, signer_A.address);
-    const snapshot_HeldBalance_Of_C_1 = await asset.heldBalanceOfAtSnapshot(1, signer_C.address);
     const snapshot_HeldBalance_Of_A_1_Partition_1 = await asset.heldBalanceOfAtSnapshotByPartition(
       _PARTITION_ID_1,
       1,
@@ -335,8 +333,6 @@ describe("Snapshots Tests", () => {
       signer_C.address,
     );
 
-    const snapshot_HeldBalance_Of_A_2 = await asset.heldBalanceOfAtSnapshot(2, signer_A.address);
-    const snapshot_HeldBalance_Of_C_2 = await asset.heldBalanceOfAtSnapshot(2, signer_C.address);
     const snapshot_HeldBalance_Of_A_2_Partition_1 = await asset.heldBalanceOfAtSnapshotByPartition(
       _PARTITION_ID_1,
       2,
@@ -384,8 +380,6 @@ describe("Snapshots Tests", () => {
     expect(snapshot_LockedBalance_Of_A_1_Partition_2).to.equal(0);
     expect(snapshot_LockedBalance_Of_C_1_Partition_2).to.equal(0);
 
-    expect(snapshot_HeldBalance_Of_A_1).to.equal(0);
-    expect(snapshot_HeldBalance_Of_C_1).to.equal(0);
     expect(snapshot_HeldBalance_Of_A_1_Partition_1).to.equal(0);
     expect(snapshot_HeldBalance_Of_C_1_Partition_1).to.equal(0);
     expect(snapshot_HeldBalance_Of_A_1_Partition_2).to.equal(0);
@@ -430,8 +424,6 @@ describe("Snapshots Tests", () => {
     expect(snapshot_LockedBalance_Of_A_2_Partition_2).to.equal(lockedAmountOf_A_Partition_2);
     expect(snapshot_LockedBalance_Of_C_2_Partition_2).to.equal(0);
 
-    expect(snapshot_HeldBalance_Of_A_2).to.equal(heldAmountOf_A_Partition_1 + heldAmountOf_A_Partition_2);
-    expect(snapshot_HeldBalance_Of_C_2).to.equal(heldAmountOf_C_Partition_1);
     expect(snapshot_HeldBalance_Of_A_2_Partition_1).to.equal(heldAmountOf_A_Partition_1);
     expect(snapshot_HeldBalance_Of_C_2_Partition_1).to.equal(heldAmountOf_C_Partition_1);
     expect(snapshot_HeldBalance_Of_A_2_Partition_2).to.equal(heldAmountOf_A_Partition_2);


### PR DESCRIPTION
This pull request refactors the "held balance at snapshot" functionality in the asset tokenization contracts by extracting it from the general `SnapshotsFacet` into its own dedicated facet, `HoldAtSnapshotFacet`. This modularization improves code organization and maintainability, while preserving backward compatibility for existing interfaces and selectors. The change is accompanied by updates to configuration scripts and comprehensive new integration tests.

**Key changes:**

### HoldAtSnapshot Facet Extraction and Refactor

- Extracted the `heldBalanceOfAtSnapshot` logic from `SnapshotsFacet` and related contracts into a new set of files: `IHoldAtSnapshot.sol`, `HoldAtSnapshot.sol`, and `HoldAtSnapshotFacet.sol`, registering the new facet under the unique `_HOLD_AT_SNAPSHOT_RESOLVER_KEY` constant. This makes the held-balance-at-snapshot functionality independently upgradeable and easier to maintain. [[1]](diffhunk://#diff-a48f2e1ec3f17322ea876bd26d9449800cd2a885318ca523a2617812ed256fecR1-R22) [[2]](diffhunk://#diff-a314f7b681f404db99d803a90e33b0313b657e489c9b45894c103c0f206464c6R1-R41) [[3]](diffhunk://#diff-25acc22b0429451e5a05872bc3fe5bae918112f56901c01b2bb89b0759311c91R1-R29) [[4]](diffhunk://#diff-a6761447814cc412fd1b009f087d5b68cc0a5e3ad8ef1dd4e34fdd2e6b3b465dR537-R539)
- Updated the `IAsset` interface to inherit from the new `IHoldAtSnapshot` interface, ensuring that the top-level asset interface continues to expose the held balance at snapshot query. [[1]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R80) [[2]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R191)

### SnapshotsFacet and Selector Updates

- Removed `heldBalanceOfAtSnapshot` from `ISnapshots`, `Snapshots`, and `SnapshotsFacet`, reducing the number of selectors in `SnapshotsFacet` from 11 to 10. This makes the snapshot facet more focused and reduces its surface area. [[1]](diffhunk://#diff-3c63028c146e3895d235aa9fd3ec6a3afc6c8ebb2c183078560214c554592cdbL66-L70) [[2]](diffhunk://#diff-e74ab850f2960d6336b08259dd9bea227c1df58c503c4ffe22bd68eb243d85dcL75-L82) [[3]](diffhunk://#diff-c9b3dd953ca94676288e6120a629bbf164a42d85cbf482f71eb3abcde906ef3bL27-L34)

### Configuration and Deployment Script Updates

- Updated `Configuration.ts` and all relevant domain configuration scripts (equity, bond, bondFixedRate, bondKpiLinkedRate, bondSustainabilityPerformanceTargetRate, loan, loanPortfolio) to register the new `HoldAtSnapshotFacet`, ensuring it is deployed and available in all product variants. [[1]](diffhunk://#diff-409dd60ab11b542fadbe019ebe0bae2d62b9a88197c5df9c72dbf6139790278bR108) [[2]](diffhunk://#diff-d31ee2f421823c23b554f15e2b40af208cca35fa7b27905fa5d54d6c48d1d06eR57) [[3]](diffhunk://#diff-a720a90e2027c51c86c52a8b0a2c5f1f55b10a397357c77f3b78e8e5414bd2c5R51) [[4]](diffhunk://#diff-340f40bde9e011844c32605590792d04e8a08c309f2dd013580aaaf0422862beR48) [[5]](diffhunk://#diff-be815552a2fcc781130fb3b3076ffadbe135f6b2346fba9a91c36461ce03703eR56) [[6]](diffhunk://#diff-07d24066b881af524d31b71601198e8e15abd4b8d151b0ffd700c81292d687aeR56) [[7]](diffhunk://#diff-2c85f3ee7a2c03e0b4a796d6e735fe1cfd5f5aaa1e4e4ccf0f9c1f0b3250df08R126) [[8]](diffhunk://#diff-e333092a268307cc17506ff1435c7caf6512ac6a460d0ad8bbfea1b87fd481baR63)

### Testing Improvements

- Added a new integration test suite (`holdAtSnapshot.test.ts`) that thoroughly tests the new facet, covering revert cases, correct balance reporting, historical correctness across multiple snapshots, and independence between holders.
- Removed now-obsolete assertions for `heldBalanceOfAtSnapshot` from the original snapshot integration tests.

### Documentation and Changelog

- Added a detailed changeset describing the migration, non-breaking nature, and technical details of the selector and interface changes.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
