### PR TITLE
fix(contracts): hiero-solo facet registration race (BBND-1703)

### DIFF
--- a/.changeset/fix-hiero-solo-facet-registration.md
+++ b/.changeset/fix-hiero-solo-facet-registration.md
@@ -1,0 +1,11 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix BBND-1703: Hiero Solo deployment failure during facet registration.
+
+The `deploySystemWithNewBlr` workflow's "Step 4/12: Registering facets in BLR" step was racing on the Hedera Solo JSON-RPC relay. It fired one parallel `eth_call` per facet (≈101 concurrent reads of `getStaticResolverKey()`) via `Promise.all`, which Hardhat's in-process provider absorbs but the Hedera relay rejects/rate-limits. The deterministic resolver keys are already available offline via `getFacetDefinition()` from `@scripts/domain`, so the registration phase now reads them synchronously from the registry instead of fanning out RPC calls.
+
+Two related fixes ride along:
+- The `error()` / `warn()` / `debug()` loggers were silently dropping their `data` argument in text mode, masking the real exception body in CI logs (`❌ Deployment failed:` with no details). Text mode now also prints `Error.name` / `message` / `stack` and ethers-specific fields (`reason`, `shortMessage`, `code`, `data`).
+- `registerFacets()` had an off-by-one in its batch loop (`length / FACET_REGISTRATION_BATCH_SIZE` without `Math.ceil` plus `i <= iterations`) that would have sent an empty final transaction whenever the facet count was an exact multiple of the batch size. Hardened with `Math.ceil`, strict `<`, and a defensive empty-slice guard.

--- a/packages/ats/contracts/scripts/infrastructure/operations/registerFacets.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/registerFacets.ts
@@ -214,16 +214,22 @@ export async function registerFacets(
       businessLogicName: facet.name,
     }));
 
-    const iterations = businessLogics.length / FACET_REGISTRATION_BATCH_SIZE;
+    const iterations = Math.ceil(businessLogics.length / FACET_REGISTRATION_BATCH_SIZE);
     const transactionHashes = [];
     const blockNumbers = [];
     const transactionGas = [];
 
-    for (let i = 0; i <= iterations; i++) {
+    for (let i = 0; i < iterations; i++) {
       const businessLogicsSlice = businessLogics.slice(
         i * FACET_REGISTRATION_BATCH_SIZE,
         (i + 1) * FACET_REGISTRATION_BATCH_SIZE,
       );
+
+      // Skip empty slices (defensive guard)
+      if (businessLogicsSlice.length === 0) {
+        continue;
+      }
+
       const tx = await blr.registerBusinessLogics(businessLogicsSlice, {
         gasLimit: GAS_LIMIT.high,
         ...hederaGasOverrides(),

--- a/packages/ats/contracts/scripts/infrastructure/utils/logging.ts
+++ b/packages/ats/contracts/scripts/infrastructure/utils/logging.ts
@@ -165,6 +165,29 @@ export function debug(message: string, data?: unknown): void {
   const output = config.json ? formatJson("DEBUG", message, data) : formatMessage("DEBUG", message, Colors.Gray);
 
   console.log(output);
+
+  // Log data in text mode (JSON mode already includes it via formatJson)
+  if (!config.json && data !== undefined) {
+    if (data instanceof Error) {
+      const errorOutput = [data.name, data.message].filter(Boolean).join(": ");
+      console.log(errorOutput);
+      if (data.stack) {
+        console.log(data.stack);
+      }
+    } else {
+      try {
+        const jsonStr = JSON.stringify(data, (_key, value) => {
+          if (typeof value === "bigint") {
+            return value.toString();
+          }
+          return value;
+        });
+        console.log(jsonStr);
+      } catch {
+        console.log(String(data));
+      }
+    }
+  }
 }
 
 /**
@@ -203,6 +226,29 @@ export function warn(message: string, data?: unknown): void {
   const output = config.json ? formatJson("WARN", message, data) : formatMessage("WARN", message, Colors.Yellow);
 
   console.warn(output);
+
+  // Log data in text mode (JSON mode already includes it via formatJson)
+  if (!config.json && data !== undefined) {
+    if (data instanceof Error) {
+      const errorOutput = [data.name, data.message].filter(Boolean).join(": ");
+      console.warn(errorOutput);
+      if (data.stack) {
+        console.warn(data.stack);
+      }
+    } else {
+      try {
+        const jsonStr = JSON.stringify(data, (_key, value) => {
+          if (typeof value === "bigint") {
+            return value.toString();
+          }
+          return value;
+        });
+        console.warn(jsonStr);
+      } catch {
+        console.warn(String(data));
+      }
+    }
+  }
 }
 
 /**
@@ -222,6 +268,43 @@ export function error(message: string, data?: unknown): void {
   const output = config.json ? formatJson("ERROR", message, data) : formatMessage("ERROR", message, Colors.Red);
 
   console.error(output);
+
+  // Log data in text mode (JSON mode already includes it via formatJson)
+  if (!config.json && data !== undefined) {
+    if (data instanceof Error) {
+      const errorOutput = [data.name, data.message].filter(Boolean).join(": ");
+      console.error(errorOutput);
+      if (data.stack) {
+        console.error(data.stack);
+      }
+      // Also try ethers-specific error fields
+      const ethersError = data as unknown as Record<string, unknown>;
+      if (ethersError.reason) {
+        console.error(`Reason: ${ethersError.reason}`);
+      }
+      if (ethersError.shortMessage) {
+        console.error(`Short: ${ethersError.shortMessage}`);
+      }
+      if (ethersError.code) {
+        console.error(`Code: ${ethersError.code}`);
+      }
+      if (ethersError.data) {
+        console.error(`Data: ${ethersError.data}`);
+      }
+    } else {
+      try {
+        const jsonStr = JSON.stringify(data, (_key, value) => {
+          if (typeof value === "bigint") {
+            return value.toString();
+          }
+          return value;
+        });
+        console.error(jsonStr);
+      } catch {
+        console.error(String(data));
+      }
+    }
+  }
 }
 
 /**

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
@@ -57,6 +57,7 @@ import {
   createLoansPortfolioConfiguration,
   deployOrchestratorLibraries,
   hasOrchestratorLibraryAddresses,
+  getFacetDefinition,
 } from "@scripts/domain";
 import {
   BusinessLogicResolver__factory,
@@ -461,31 +462,26 @@ export async function deploySystemWithNewBlr(
     } else {
       info(`\n📝 Step 4/${totalSteps}: Registering facets in BLR...`);
 
-      // Prepare facets with resolver keys from registry
-      const facetsToRegister = await Promise.all(
-        Array.from(facetsResult.deployed.entries()).map(async ([facetName, deploymentResult]) => {
-          if (!deploymentResult.address) {
-            throw new Error(`No address for facet: ${facetName}`);
-          }
+      // Prepare facets with resolver keys from offline registry (avoids 101 parallel eth_call)
+      const facetsToRegister = Array.from(facetsResult.deployed.entries()).map(([facetName, deploymentResult]) => {
+        if (!deploymentResult.address) {
+          throw new Error(`No address for facet: ${facetName}`);
+        }
 
-          // Strip "TimeTravel" suffix to get canonical name
-          const baseName = facetName.replace(/TimeTravel$/, "");
-          // deploymentResult.address
-          const staticSelector = IStaticFunctionSelectors__factory.connect(deploymentResult.address, signer);
-          const resolverKey = await staticSelector.getStaticResolverKey();
-          // Look up resolver key from registry
+        // Strip "TimeTravel" suffix to get canonical name
+        const baseName = facetName.replace(/TimeTravel$/, "");
+        const facetDef = getFacetDefinition(baseName);
 
-          if (!resolverKey) {
-            throw new Error(`Facet ${baseName} not found in registry or missing resolver key`);
-          }
+        if (!facetDef?.resolverKey?.value) {
+          throw new Error(`Facet ${baseName} not found in registry or missing resolver key`);
+        }
 
-          return {
-            name: facetName,
-            address: deploymentResult.address,
-            resolverKey: resolverKey,
-          };
-        }),
-      );
+        return {
+          name: facetName,
+          address: deploymentResult.address,
+          resolverKey: facetDef.resolverKey.value,
+        };
+      });
 
       const registerResult = await registerFacets(blrContract, {
         facets: facetsToRegister,


### PR DESCRIPTION
## Summary

Hiero Solo JSON-RPC relay rate-limits concurrent `eth_call` operations. The registration script was sending 101 parallel calls to fetch resolver keys from each facet contract, causing requests to queue and timeout. Solution: replace on-chain lookups with offline registry reads.

## Why This Matters

- **Root cause**: 101 concurrent eth_call → rate-limit queue → timeout
- **Fix**: Use deterministic atsRegistry.getFacetDefinition() (already generated at build time)
- **Hardhat**: Tolerates parallel calls; Solo does not
- **Data integrity**: Resolver keys are immutable, so offline lookup is safe

## Verification

- ✅ Local Hardhat: all facets register in parallel, test suite green
- ✅ Code review: logging + batch-loop defensive guards added
- 🔄 CI Solo job (`102-flow-ats-deployment-test.yaml`): will confirm timeout is gone

## Additional Fixes

- `error()/warn()/debug()` now print data argument in text mode (was silently dropped)
- `registerFacets()` batch loop hardened: defensive empty-slice guard to prevent sending empty final tx

**Related ticket**: [BBND-1703](https://iobuilders.atlassian.net/browse/BBND-1703)