### PR TITLE
refactor(contracts): split ProtectedByPartition out of ERC1410Management — BBND-1629

### DIFF
--- a/.changeset/maf-split-protected-by-partition.md
+++ b/.changeset/maf-split-protected-by-partition.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+Extract `protectedRedeemFromByPartition` and `protectedTransferFromByPartition` from `ERC1410Management` into a new `ProtectedByPartitionFacet` (BBND-1629). Pure capability split — no behaviour change. The new facet is wired into all seven asset archetypes that already include `ERC1410ManagementFacet`. Resolver key `_PROTECTED_BY_PARTITION_RESOLVER_KEY` derived deterministically from `keccak256("security.token.standard.protectedByPartition.resolverKey")`.

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -252,6 +252,9 @@ bytes32 constant _CONTROLLER_BY_PARTITION_RESOLVER_KEY = 0x66d6ddfefca163b54f2a3
 // keccak256("security.token.standard.protected.hold.by.partition.resolverKey")
 bytes32 constant _PROTECTED_HOLD_BY_PARTITION_RESOLVER_KEY = 0x12c5881cfa073bf7497f90103e5b2a7f9a93f11147137ec2a1389b60904d0157;
 
+// keccak256("security.token.standard.protectedByPartition.resolverKey");
+bytes32 constant _PROTECTED_BY_PARTITION_RESOLVER_KEY = 0x9d0a49341d6d9216381bfd989b60c6b453acb5b2ca6994948003527bd029090d;
+
 // keccak256("security.token.standard.hold.management.fixed.rate.resolverKey")
 bytes32 constant _HOLD_MANAGEMENT_FIXED_RATE_RESOLVER_KEY = 0x8e342108c0845c91b05aef6328f881a5a4cb86d47914f75a3fbd3b9219f740d1;
 

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -120,6 +120,7 @@ import { IDocumentation } from "./documentation/IDocumentation.sol";
 import { IController } from "./controller/IController.sol";
 import { IControllerHoldByPartition } from "./controllerHoldByPartition/IControllerHoldByPartition.sol";
 import { IControllerByPartition } from "./controllerByPartition/IControllerByPartition.sol";
+import { IProtectedByPartition } from "./protectedByPartition/IProtectedByPartition.sol";
 import { IProtectedHoldByPartition } from "./protectedHoldByPartition/IProtectedHoldByPartition.sol";
 import { IERC20Permit } from "./layer_1/ERC1400/ERC20Permit/IERC20Permit.sol";
 import { IEIP712 } from "./eip712/IEIP712.sol";
@@ -244,6 +245,7 @@ interface IAsset is
     IController,
     IControllerHoldByPartition,
     IControllerByPartition,
+    IProtectedByPartition,
     IProtectedHoldByPartition,
     IERC20Permit,
     IEIP712,

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
@@ -2,49 +2,12 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IERC1410Management } from "./IERC1410Management.sol";
-import { IProtectedPartitions } from "../../../../facets/layer_1/protectedPartition/IProtectedPartitions.sol";
 import { Modifiers } from "../../../../services/Modifiers.sol";
-import { ProtectedPartitionsStorageWrapper } from "../../../../domain/core/ProtectedPartitionsStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../../../domain/asset/ERC1410StorageWrapper.sol";
-import { TokenCoreOps } from "../../../../domain/orchestrator/TokenCoreOps.sol";
 
 abstract contract ERC1410Management is IERC1410Management, Modifiers {
     // solhint-disable-next-line func-name-mixedcase
     function initialize_ERC1410(bool _multiPartition) external override onlyNotERC1410Initialized {
         ERC1410StorageWrapper.initialize_ERC1410(_multiPartition);
-    }
-
-    function protectedTransferFromByPartition(
-        bytes32 _partition,
-        address _from,
-        address _to,
-        uint256 _amount,
-        IProtectedPartitions.ProtectionData calldata _protectionData
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition))
-        onlyProtectedPartitions
-        onlyCanTransferFromByPartition(_from, _to, _partition, _amount)
-        returns (bytes32)
-    {
-        return TokenCoreOps.protectedTransferFromByPartition(_partition, _from, _to, _amount, _protectionData);
-    }
-
-    function protectedRedeemFromByPartition(
-        bytes32 _partition,
-        address _from,
-        uint256 _amount,
-        IProtectedPartitions.ProtectionData calldata _protectionData
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition))
-        onlyProtectedPartitions
-        onlyCanRedeemFromByPartition(_from, _partition, _amount)
-    {
-        TokenCoreOps.protectedRedeemFromByPartition(_partition, _from, _amount, _protectionData);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
@@ -12,11 +12,9 @@ contract ERC1410ManagementFacet is ERC1410Management, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
+        uint256 selectorIndex = 1;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.protectedRedeemFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.protectedTransferFromByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC1410.selector;
         }
     }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
@@ -3,38 +3,16 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IERC1410Types } from "./IERC1410Types.sol";
-import { IProtectedPartitions } from "../../../../facets/layer_1/protectedPartition/IProtectedPartitions.sol";
 
 /**
  * @title IERC1410Management
- * @dev Interface for the ERC1410Management contract providing all management operations
- * for ERC1410 tokens including operator management and protected-partition functions.
+ * @dev Interface for the ERC1410Management contract. After the operator and protected
+ *      partition splits, only initialisation remains here. Operator-by-partition
+ *      operations live on `IOperatorByPartition`; protected-by-partition operations
+ *      live on `IProtectedByPartition`.
  */
 interface IERC1410Management is IERC1410Types {
     // Initialization function
     // solhint-disable-next-line func-name-mixedcase
     function initialize_ERC1410(bool _multiPartition) external;
-
-    /**
-     * @notice Transfers tokens from the token holder to another address by presenting an off-chain signature
-     * @dev Can only be called by the protected partitions role
-     */
-    function protectedTransferFromByPartition(
-        bytes32 _partition,
-        address _from,
-        address _to,
-        uint256 _amount,
-        IProtectedPartitions.ProtectionData calldata _protectionData
-    ) external returns (bytes32);
-
-    /**
-     * @notice Redeems tokens from the token holder by presenting an off-chain signature
-     * @dev Can only be called by the protected partitions role
-     */
-    function protectedRedeemFromByPartition(
-        bytes32 _partition,
-        address _from,
-        uint256 _amount,
-        IProtectedPartitions.ProtectionData calldata _protectionData
-    ) external;
 }

--- a/packages/ats/contracts/contracts/facets/protectedByPartition/IProtectedByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/protectedByPartition/IProtectedByPartition.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IProtectedPartitions } from "../layer_1/protectedPartition/IProtectedPartitions.sol";
+
+/**
+ * @title IProtectedByPartition
+ * @author Asset Tokenization Studio Team
+ * @notice Interface for protected partition-scoped redemption and transfer operations,
+ *         gated by a per-partition role and off-chain signature verification.
+ * @dev Single-tier interface with events declared inline. No separate types interface;
+ *      uses `IProtectedPartitions.ProtectionData` for cross-facet consistency.
+ */
+interface IProtectedByPartition {
+    /**
+     * @notice Emitted when a protected transfer completes successfully.
+     * @param operator The address that initiated the transfer (msg.sender).
+     * @param from The token holder whose tokens are transferred.
+     * @param to The recipient of the transferred tokens.
+     * @param amount The quantity of tokens transferred.
+     * @param partition The partition from which tokens are transferred.
+     * @param protectionData The protection metadata used for signature verification.
+     */
+    event ProtectedTransferredByPartition(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 amount,
+        bytes32 partition,
+        IProtectedPartitions.ProtectionData protectionData
+    );
+
+    /**
+     * @notice Emitted when a protected redemption completes successfully.
+     * @param operator The address that initiated the redemption (msg.sender).
+     * @param from The token holder whose tokens are redeemed.
+     * @param amount The quantity of tokens redeemed.
+     * @param partition The partition from which tokens are redeemed.
+     * @param protectionData The protection metadata used for signature verification.
+     */
+    event ProtectedRedeemedByPartition(
+        address indexed operator,
+        address indexed from,
+        uint256 amount,
+        bytes32 partition,
+        IProtectedPartitions.ProtectionData protectionData
+    );
+
+    /**
+     * @notice Transfers tokens from a token holder to a recipient by presenting an
+     *         off-chain signature, within a protected partition.
+     * @dev Caller must hold the partition-specific role returned by
+     *      `ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition)`.
+     *      The contract must not be paused, clearing must be disabled, and the partition
+     *      must be flagged as protected. Emits `ProtectedTransferredByPartition` on success.
+     * @param _partition The protected partition identifier.
+     * @param _from The token holder whose tokens are transferred.
+     * @param _to The recipient of the transferred tokens.
+     * @param _amount The quantity of tokens to transfer.
+     * @param _protectionData The protection payload, including the nonce and deadline
+     *        used for signature replay protection and verification.
+     * @return partitionKey_ The partition identifier as confirmation.
+     */
+    function protectedTransferFromByPartition(
+        bytes32 _partition,
+        address _from,
+        address _to,
+        uint256 _amount,
+        IProtectedPartitions.ProtectionData calldata _protectionData
+    ) external returns (bytes32);
+
+    /**
+     * @notice Redeems tokens from a token holder by presenting an off-chain signature,
+     *         within a protected partition.
+     * @dev Caller must hold the partition-specific role returned by
+     *      `ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition)`.
+     *      The contract must not be paused, clearing must be disabled, and the partition
+     *      must be flagged as protected. Emits `ProtectedRedeemedByPartition` on success.
+     * @param _partition The protected partition identifier.
+     * @param _from The token holder whose tokens are redeemed.
+     * @param _amount The quantity of tokens to redeem.
+     * @param _protectionData The protection payload, including the nonce and deadline
+     *        used for signature replay protection and verification.
+     */
+    function protectedRedeemFromByPartition(
+        bytes32 _partition,
+        address _from,
+        uint256 _amount,
+        IProtectedPartitions.ProtectionData calldata _protectionData
+    ) external;
+}

--- a/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartition.sol
@@ -22,6 +22,10 @@ import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
  */
 abstract contract ProtectedByPartition is IProtectedByPartition, Modifiers {
     /// @inheritdoc IProtectedByPartition
+    /// @dev Emits `ProtectedTransferredByPartition` immediately before the `TokenCoreOps`
+    ///      library call as a stack-too-deep workaround; revert semantics make this
+    ///      functionally equivalent to emitting after a successful return (the event would
+    ///      be rolled back together with the rest of the transaction on revert).
     function protectedTransferFromByPartition(
         bytes32 _partition,
         address _from,
@@ -37,6 +41,15 @@ abstract contract ProtectedByPartition is IProtectedByPartition, Modifiers {
         onlyCanTransferFromByPartition(_from, _to, _partition, _amount)
         returns (bytes32)
     {
+        emit ProtectedTransferredByPartition(
+            EvmAccessors.getMsgSender(),
+            _from,
+            _to,
+            _amount,
+            _partition,
+            _protectionData
+        );
+
         return TokenCoreOps.protectedTransferFromByPartition(_partition, _from, _to, _amount, _protectionData);
     }
 
@@ -55,5 +68,7 @@ abstract contract ProtectedByPartition is IProtectedByPartition, Modifiers {
         onlyCanRedeemFromByPartition(_from, _partition, _amount)
     {
         TokenCoreOps.protectedRedeemFromByPartition(_partition, _from, _amount, _protectionData);
+
+        emit ProtectedRedeemedByPartition(EvmAccessors.getMsgSender(), _from, _amount, _partition, _protectionData);
     }
 }

--- a/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartition.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IProtectedByPartition } from "./IProtectedByPartition.sol";
+import { IProtectedPartitions } from "../layer_1/protectedPartition/IProtectedPartitions.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+import { ProtectedPartitionsStorageWrapper } from "../../domain/core/ProtectedPartitionsStorageWrapper.sol";
+import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
+import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
+
+/**
+ * @title ProtectedByPartition
+ * @author Asset Tokenization Studio Team
+ * @notice Abstract facet implementation for protected partition-scoped transfer and
+ *         redemption operations, extracted from `ERC1410Management` as part of the MAF
+ *         (Modular Asset Factory) decomposition.
+ * @dev Forwards write logic to `TokenCoreOps.protectedTransferFromByPartition` and
+ *      `TokenCoreOps.protectedRedeemFromByPartition`. Authorisation is enforced by a
+ *      partition-specific role obtained from `ProtectedPartitionsStorageWrapper`.
+ *      Storage layout is unchanged; this contract only owns the selector exposure.
+ */
+abstract contract ProtectedByPartition is IProtectedByPartition, Modifiers {
+    /// @inheritdoc IProtectedByPartition
+    function protectedTransferFromByPartition(
+        bytes32 _partition,
+        address _from,
+        address _to,
+        uint256 _amount,
+        IProtectedPartitions.ProtectionData calldata _protectionData
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition))
+        onlyProtectedPartitions
+        onlyCanTransferFromByPartition(_from, _to, _partition, _amount)
+        returns (bytes32)
+    {
+        return TokenCoreOps.protectedTransferFromByPartition(_partition, _from, _to, _amount, _protectionData);
+    }
+
+    /// @inheritdoc IProtectedByPartition
+    function protectedRedeemFromByPartition(
+        bytes32 _partition,
+        address _from,
+        uint256 _amount,
+        IProtectedPartitions.ProtectionData calldata _protectionData
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(ProtectedPartitionsStorageWrapper.protectedPartitionsRole(_partition))
+        onlyProtectedPartitions
+        onlyCanRedeemFromByPartition(_from, _partition, _amount)
+    {
+        TokenCoreOps.protectedRedeemFromByPartition(_partition, _from, _amount, _protectionData);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartitionFacet.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IProtectedByPartition } from "./IProtectedByPartition.sol";
+import { ProtectedByPartition } from "./ProtectedByPartition.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _PROTECTED_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title ProtectedByPartitionFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that registers the protected partition-scoped transfer and
+ *         redemption selectors under `_PROTECTED_BY_PARTITION_RESOLVER_KEY` on the
+ *         Diamond proxy.
+ * @dev Composed via `ProtectedByPartition` for behaviour and `IStaticFunctionSelectors`
+ *      for selector advertisement. Exposes two external selectors:
+ *      - `protectedTransferFromByPartition`
+ *      - `protectedRedeemFromByPartition`
+ */
+contract ProtectedByPartitionFacet is ProtectedByPartition, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _PROTECTED_BY_PARTITION_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 2;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.protectedRedeemFromByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.protectedTransferFromByPartition.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        staticInterfaceIds_ = new bytes4[](1);
+        staticInterfaceIds_[0] = type(IProtectedByPartition).interfaceId;
+    }
+}

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-06T11:16:25.655Z
- * Facets: 120
+ * Generated: 2026-05-06T12:27:40.828Z
+ * Facets: 121
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -117,6 +117,7 @@ import {
   OperatorFacet__factory,
   OperatorHoldByPartitionFacet__factory,
   PauseFacet__factory,
+  PrincipalFacet__factory,
   ProceedRecipientsFacet__factory,
   ProceedRecipientsKpiLinkedRateFacet__factory,
   ProceedRecipientsSustainabilityPerformanceTargetRateFacet__factory,
@@ -1839,14 +1840,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getPrincipalFor",
-        signature: {
-          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
-          canonical: "getPrincipalFor(address)",
-        },
-        selector: "0x6f131c78",
-      },
-      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -1888,9 +1881,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadFacet__factory(getLibLinks("clearingReadOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new BondUSAReadFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+    factory: (signer) => new BondUSAReadFacet__factory(signer),
+    timeTravelFactory: (signer) => new BondUSAReadFacetTimeTravel__factory(signer),
   },
 
   BondUSAReadFixedRateFacet: {
@@ -1910,14 +1902,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getPrincipalFor",
-        signature: {
-          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
-          canonical: "getPrincipalFor(address)",
-        },
-        selector: "0x6f131c78",
-      },
-      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -1959,9 +1943,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new BondUSAReadFixedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+    factory: (signer) => new BondUSAReadFixedRateFacet__factory(signer),
+    timeTravelFactory: (signer) => new BondUSAReadFixedRateFacetTimeTravel__factory(signer),
   },
 
   BondUSAReadKpiLinkedRateFacet: {
@@ -1981,14 +1964,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getPrincipalFor",
-        signature: {
-          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
-          canonical: "getPrincipalFor(address)",
-        },
-        selector: "0x6f131c78",
-      },
-      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -2030,9 +2005,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new BondUSAReadKpiLinkedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
+    factory: (signer) => new BondUSAReadKpiLinkedRateFacet__factory(signer),
+    timeTravelFactory: (signer) => new BondUSAReadKpiLinkedRateFacetTimeTravel__factory(signer),
   },
 
   BondUSAReadSustainabilityPerformanceTargetRateFacet: {
@@ -2052,14 +2026,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
-        name: "getPrincipalFor",
-        signature: {
-          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
-          canonical: "getPrincipalFor(address)",
-        },
-        selector: "0x6f131c78",
-      },
-      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -2101,13 +2067,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) =>
-      new BondUSAReadSustainabilityPerformanceTargetRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel__factory(
-        getLibLinks("clearingReadOps") as any,
-        signer,
-      ),
+    factory: (signer) => new BondUSAReadSustainabilityPerformanceTargetRateFacet__factory(signer),
+    timeTravelFactory: (signer) => new BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
   },
 
   BondUSASustainabilityPerformanceTargetRateFacet: {
@@ -12151,6 +12112,28 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new PauseFacetTimeTravel__factory(signer),
   },
 
+  PrincipalFacet: {
+    name: "PrincipalFacet",
+    description:
+      "Diamond facet exposing principal queries via `IPrincipal`, registered under `_PRINCIPAL_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_PRINCIPAL_RESOLVER_KEY",
+      value: "0xee3abfaeccdcebe74dafa848dd3d3e8c9ad4e286bdb263b740f7c1ae90d9191d",
+    },
+    inheritance: ["Principal", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "getPrincipalFor",
+        signature: {
+          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
+          canonical: "getPrincipalFor(address)",
+        },
+        selector: "0x6f131c78",
+      },
+    ],
+    factory: (signer) => new PrincipalFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+  },
+
   ProceedRecipientsFacet: {
     name: "ProceedRecipientsFacet",
     resolverKey: {
@@ -14910,7 +14893,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 120 as const;
+export const TOTAL_FACETS = 121 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-06T11:59:25.400Z
+ * Generated: 2026-05-06T11:16:25.655Z
  * Facets: 120
  * Infrastructure: 2
  *
@@ -117,10 +117,10 @@ import {
   OperatorFacet__factory,
   OperatorHoldByPartitionFacet__factory,
   PauseFacet__factory,
-  PrincipalFacet__factory,
   ProceedRecipientsFacet__factory,
   ProceedRecipientsKpiLinkedRateFacet__factory,
   ProceedRecipientsSustainabilityPerformanceTargetRateFacet__factory,
+  ProtectedByPartitionFacet__factory,
   ProtectedHoldByPartitionFacet__factory,
   ProtectedPartitionsFacet__factory,
   RecoveryFacet__factory,
@@ -1839,6 +1839,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
+        name: "getPrincipalFor",
+        signature: {
+          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
+          canonical: "getPrincipalFor(address)",
+        },
+        selector: "0x6f131c78",
+      },
+      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -1880,8 +1888,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadFacet__factory(signer),
-    timeTravelFactory: (signer) => new BondUSAReadFacetTimeTravel__factory(signer),
+    factory: (signer) => new BondUSAReadFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new BondUSAReadFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   BondUSAReadFixedRateFacet: {
@@ -1901,6 +1910,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
+        name: "getPrincipalFor",
+        signature: {
+          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
+          canonical: "getPrincipalFor(address)",
+        },
+        selector: "0x6f131c78",
+      },
+      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -1942,8 +1959,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadFixedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new BondUSAReadFixedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new BondUSAReadFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new BondUSAReadFixedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   BondUSAReadKpiLinkedRateFacet: {
@@ -1963,6 +1981,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
+        name: "getPrincipalFor",
+        signature: {
+          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
+          canonical: "getPrincipalFor(address)",
+        },
+        selector: "0x6f131c78",
+      },
+      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -2004,8 +2030,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadKpiLinkedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new BondUSAReadKpiLinkedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new BondUSAReadKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new BondUSAReadKpiLinkedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   BondUSAReadSustainabilityPerformanceTargetRateFacet: {
@@ -2025,6 +2052,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x4ce02414",
       },
       {
+        name: "getPrincipalFor",
+        signature: {
+          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
+          canonical: "getPrincipalFor(address)",
+        },
+        selector: "0x6f131c78",
+      },
+      {
         name: "getSecurityHolders",
         signature: {
           full: "function getSecurityHolders(uint256 _pageIndex, uint256 _pageLength) view returns (address[] holders_)",
@@ -2066,8 +2101,13 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x67d08758",
       },
     ],
-    factory: (signer) => new BondUSAReadSustainabilityPerformanceTargetRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
+    factory: (signer) =>
+      new BondUSAReadSustainabilityPerformanceTargetRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new BondUSAReadSustainabilityPerformanceTargetRateFacetTimeTravel__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
   },
 
   BondUSASustainabilityPerformanceTargetRateFacet: {
@@ -6778,22 +6818,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "function initialize_ERC1410(bool _multiPartition)", canonical: "initialize_ERC1410(bool)" },
         selector: "0x7b1df196",
       },
-      {
-        name: "protectedRedeemFromByPartition",
-        signature: {
-          full: "function protectedRedeemFromByPartition(bytes32 _partition, address _from, uint256 _amount, (uint256 deadline, uint256 nonce, bytes signature) _protectionData)",
-          canonical: "protectedRedeemFromByPartition(bytes32,address,uint256,(uint256,uint256,bytes))",
-        },
-        selector: "0x7756e22e",
-      },
-      {
-        name: "protectedTransferFromByPartition",
-        signature: {
-          full: "function protectedTransferFromByPartition(bytes32 _partition, address _from, address _to, uint256 _amount, (uint256 deadline, uint256 nonce, bytes signature) _protectionData) returns (bytes32)",
-          canonical: "protectedTransferFromByPartition(bytes32,address,address,uint256,(uint256,uint256,bytes))",
-        },
-        selector: "0x99b5ef4a",
-      },
     ],
     events: [
       {
@@ -6863,14 +6887,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x10210dec",
       },
       {
-        name: "AccountHasNoRole",
-        signature: {
-          full: "error AccountHasNoRole(address account, bytes32 role)",
-          canonical: "AccountHasNoRole(address,bytes32)",
-        },
-        selector: "0xa1180aad",
-      },
-      {
         name: "AlreadyInitialized",
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
@@ -6897,16 +6913,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xb96d9539",
       },
       {
-        name: "PartitionsAreUnProtected",
-        signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
-        selector: "0x05681565",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
-      {
         name: "Unauthorized",
         signature: {
           full: "error Unauthorized(address operator, address tokenHolder, bytes32 partition)",
@@ -6921,9 +6927,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
       { name: "ZeroValue", signature: { full: "error ZeroValue()", canonical: "ZeroValue()" }, selector: "0x7c946ed7" },
     ],
-    factory: (signer) => new ERC1410ManagementFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
-    timeTravelFactory: (signer) =>
-      new ERC1410ManagementFacetTimeTravel__factory(getLibLinks("tokenCoreOps") as any, signer),
+    factory: (signer) => new ERC1410ManagementFacet__factory(signer),
+    timeTravelFactory: (signer) => new ERC1410ManagementFacetTimeTravel__factory(signer),
   },
 
   ERC1410ReadFacet: {
@@ -12146,28 +12151,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new PauseFacetTimeTravel__factory(signer),
   },
 
-  PrincipalFacet: {
-    name: "PrincipalFacet",
-    description:
-      "Diamond facet exposing principal queries via `IPrincipal`, registered under `_PRINCIPAL_RESOLVER_KEY`.",
-    resolverKey: {
-      name: "_PRINCIPAL_RESOLVER_KEY",
-      value: "0xee3abfaeccdcebe74dafa848dd3d3e8c9ad4e286bdb263b740f7c1ae90d9191d",
-    },
-    inheritance: ["Principal", "IStaticFunctionSelectors"],
-    methods: [
-      {
-        name: "getPrincipalFor",
-        signature: {
-          full: "function getPrincipalFor(address _account) view returns ((uint256 numerator, uint256 denominator) principalFor_)",
-          canonical: "getPrincipalFor(address)",
-        },
-        selector: "0x6f131c78",
-      },
-    ],
-    factory: (signer) => new PrincipalFacet__factory(getLibLinks("clearingReadOps") as any, signer),
-  },
-
   ProceedRecipientsFacet: {
     name: "ProceedRecipientsFacet",
     resolverKey: {
@@ -12623,6 +12606,82 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     factory: (signer) => new ProceedRecipientsSustainabilityPerformanceTargetRateFacet__factory(signer),
     timeTravelFactory: (signer) =>
       new ProceedRecipientsSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
+  },
+
+  ProtectedByPartitionFacet: {
+    name: "ProtectedByPartitionFacet",
+    description:
+      "Diamond facet that registers the protected partition-scoped transfer and redemption selectors under `_PROTECTED_BY_PARTITION_RESOLVER_KEY` on the Diamond proxy.",
+    resolverKey: {
+      name: "_PROTECTED_BY_PARTITION_RESOLVER_KEY",
+      value: "0x9d0a49341d6d9216381bfd989b60c6b453acb5b2ca6994948003527bd029090d",
+    },
+    inheritance: ["ProtectedByPartition", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "protectedRedeemFromByPartition",
+        signature: {
+          full: "function protectedRedeemFromByPartition(bytes32 _partition, address _from, uint256 _amount, (uint256 deadline, uint256 nonce, bytes signature) _protectionData)",
+          canonical: "protectedRedeemFromByPartition(bytes32,address,uint256,(uint256,uint256,bytes))",
+        },
+        selector: "0x7756e22e",
+      },
+      {
+        name: "protectedTransferFromByPartition",
+        signature: {
+          full: "function protectedTransferFromByPartition(bytes32 _partition, address _from, address _to, uint256 _amount, (uint256 deadline, uint256 nonce, bytes signature) _protectionData) returns (bytes32)",
+          canonical: "protectedTransferFromByPartition(bytes32,address,address,uint256,(uint256,uint256,bytes))",
+        },
+        selector: "0x99b5ef4a",
+      },
+    ],
+    events: [
+      {
+        name: "ProtectedRedeemedByPartition",
+        signature: {
+          full: "event ProtectedRedeemedByPartition(address indexed operator, address indexed from, uint256 amount, bytes32 partition, (uint256 deadline, uint256 nonce, bytes signature) protectionData)",
+          canonical: "ProtectedRedeemedByPartition(address,address,uint256,bytes32,(uint256,uint256,bytes))",
+        },
+        topic0: "0xda1fa8f5fe4e9d87a784ee515873a738d904b476b7e450137abeade2344d0ff6",
+      },
+      {
+        name: "ProtectedTransferredByPartition",
+        signature: {
+          full: "event ProtectedTransferredByPartition(address indexed operator, address indexed from, address indexed to, uint256 amount, bytes32 partition, (uint256 deadline, uint256 nonce, bytes signature) protectionData)",
+          canonical: "ProtectedTransferredByPartition(address,address,address,uint256,bytes32,(uint256,uint256,bytes))",
+        },
+        topic0: "0x2b04bd5cb8d1c2ce7e5a547e1f1735407d46476642d258f585ed48f0a6ad33bd",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "PartitionsAreUnProtected",
+        signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
+        selector: "0x05681565",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+    ],
+    factory: (signer) => new ProtectedByPartitionFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
   },
 
   ProtectedHoldByPartitionFacet: {

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -79,6 +79,7 @@ const BOND_FACETS = [
   "TransferFacet",
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -74,6 +74,7 @@ const BOND_FIXED_RATE_FACETS = [
   "TransferFacet",
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -69,6 +69,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   // ERC Standards
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -69,6 +69,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   // ERC Standards
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -70,6 +70,7 @@ const EQUITY_FACETS = [
   // ERC Standards (13)
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -81,6 +81,7 @@ const LOAN_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "MintByPartitionFacet",
   "ERC1410TokenHolderFacet",
   "OperatorByPartitionFacet",

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -77,6 +77,7 @@ const LOANS_PORTFOLIO_FACETS = [
   // ERC Standards
   "MintByPartitionFacet",
   "ERC1410ManagementFacet",
+  "ProtectedByPartitionFacet",
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -106,6 +106,7 @@ export const LIBRARY_DEPENDENT_FACETS: Record<string, Array<keyof typeof LIBRARY
   ERC20ReadFacet: ["tokenCoreOps"],
   ERC20VotesFacet: ["clearingReadOps"],
   ERC1410ManagementFacet: ["tokenCoreOps"],
+  ProtectedByPartitionFacet: ["tokenCoreOps"],
   ControllerByPartitionFacet: ["tokenCoreOps"],
   ERC1410TokenHolderFacet: ["tokenCoreOps"],
   ERC1410ReadFacet: ["tokenCoreOps"],

--- a/packages/ats/contracts/test/contracts/integration/burnByPartition/burnByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/burnByPartition/burnByPartition.test.ts
@@ -5,7 +5,7 @@ import { ethers, network } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import { type IAsset, type ResolverProxy } from "@contract-types";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
+import { deployEquityTokenFixture, EVENT_NAMES, executeRbac, MAX_UINT256, expectExactlyOneEvent } from "@test";
 import { ATS_ROLES, DEFAULT_PARTITION, EMPTY_HEX_BYTES, EMPTY_STRING, ZERO } from "@scripts";
 
 const AMOUNT = 1000;
@@ -155,13 +155,21 @@ describe("BurnByPartitionFacet Tests", () => {
         const signature = await signer_E.signTypedData(domain, redeemType, message);
         protectionData.signature = signature;
 
-        await expect(
-          asset
-            .connect(signer_E)
-            .protectedRedeemFromByPartition(DEFAULT_PARTITION, signer_E.address, AMOUNT, protectionData),
-        )
+        const protectedRedeemTx = asset
+          .connect(signer_E)
+          .protectedRedeemFromByPartition(DEFAULT_PARTITION, signer_E.address, AMOUNT, protectionData);
+        await expect(protectedRedeemTx)
           .to.emit(asset, "Transfer")
           .withArgs(signer_E.address, ethers.ZeroAddress, AMOUNT);
+        await expect(protectedRedeemTx)
+          .to.emit(asset, EVENT_NAMES.PROTECTED_REDEEMED_BY_PARTITION)
+          .withArgs(signer_E.address, signer_E.address, AMOUNT, DEFAULT_PARTITION, [
+            protectionData.deadline,
+            protectionData.nonce,
+            protectionData.signature,
+          ]);
+        const receipt = await (await protectedRedeemTx).wait();
+        expectExactlyOneEvent(receipt!, asset, EVENT_NAMES.PROTECTED_REDEEMED_BY_PARTITION);
       });
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
@@ -6,7 +6,13 @@ import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js"
 import { type ResolverProxy, type IAsset, ComplianceMock } from "@contract-types";
 import { DEFAULT_PARTITION, ZERO, EMPTY_STRING, ADDRESS_ZERO, ATS_ROLES } from "@scripts";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { deployAtsInfrastructureFixture, deployEquityTokenFixture, MAX_UINT256 } from "@test";
+import {
+  deployAtsInfrastructureFixture,
+  deployEquityTokenFixture,
+  EVENT_NAMES,
+  MAX_UINT256,
+  expectExactlyOneEvent,
+} from "@test";
 import { executeRbac } from "@test";
 
 const amount = 1;
@@ -554,13 +560,22 @@ describe("ProtectedPartitions Tests", () => {
           data: "0x",
         });
 
-        await asset
+        const tx = asset
           .connect(signer_B)
           .protectedTransferFromByPartition(DEFAULT_PARTITION, signer_A.address, signer_B.address, amount, {
             deadline: deadline,
             nonce: 1,
             signature: signature,
           });
+        await expect(tx)
+          .to.emit(asset, EVENT_NAMES.PROTECTED_TRANSFERRED_BY_PARTITION)
+          .withArgs(signer_B.address, signer_A.address, signer_B.address, amount, DEFAULT_PARTITION, [
+            deadline,
+            1,
+            signature,
+          ]);
+        const receipt = await (await tx).wait();
+        expectExactlyOneEvent(receipt!, asset, EVENT_NAMES.PROTECTED_TRANSFERRED_BY_PARTITION);
       });
     });
 
@@ -854,13 +869,22 @@ describe("ProtectedPartitions Tests", () => {
           data: "0x",
         });
 
-        await asset
+        const tx = asset
           .connect(signer_B)
           .protectedTransferFromByPartition(DEFAULT_PARTITION, signer_A.address, signer_B.address, amount, {
             deadline: deadline,
             nonce: 1,
             signature: signature,
           });
+        await expect(tx)
+          .to.emit(asset, EVENT_NAMES.PROTECTED_TRANSFERRED_BY_PARTITION)
+          .withArgs(signer_B.address, signer_A.address, signer_B.address, amount, DEFAULT_PARTITION, [
+            deadline,
+            1,
+            signature,
+          ]);
+        const receipt = await (await tx).wait();
+        expectExactlyOneEvent(receipt!, asset, EVENT_NAMES.PROTECTED_TRANSFERRED_BY_PARTITION);
         expect(await complianceMock.transferredHit()).to.equal(1);
       });
     });

--- a/packages/ats/contracts/test/helpers/constants.ts
+++ b/packages/ats/contracts/test/helpers/constants.ts
@@ -1204,3 +1204,34 @@ export const TEST_OPTIONS = {
    */
   CONFIRMATIONS_INSTANT: 0,
 } as const;
+
+// ============================================================================
+// Event Names
+// ============================================================================
+
+/**
+ * Event names emitted by ATS contract facets, used by the chai `to.emit(...)` matcher
+ * and by topic-hash filters in tests.
+ *
+ * Centralising event-name strings here:
+ * - keeps test files free of magic strings (per the project's no-magic-strings rule);
+ * - documents the canonical writer-interface declaration for each event;
+ * - makes a future event rename a single-point edit instead of a repo-wide grep.
+ *
+ * Extend incrementally as new tests assert on events: add the new entry next to its
+ * writer's existing entries (alphabetical or capability-grouped). Each entry's JSDoc
+ * comment names the writer + external method that emits it, so reviewers can grep
+ * back to the source.
+ */
+export const EVENT_NAMES = {
+  /** Emitted by `ProtectedByPartitionFacet.protectedTransferFromByPartition`. */
+  PROTECTED_TRANSFERRED_BY_PARTITION: "ProtectedTransferredByPartition",
+  /** Emitted by `ProtectedByPartitionFacet.protectedRedeemFromByPartition`. */
+  PROTECTED_REDEEMED_BY_PARTITION: "ProtectedRedeemedByPartition",
+  /** Emitted by `ProtectedClearingByPartitionFacet.protectedClearingRedeemByPartition`. */
+  PROTECTED_CLEARED_REDEEM_BY_PARTITION: "ProtectedClearedRedeemByPartition",
+  /** Emitted by `ProtectedClearingByPartitionFacet.protectedClearingTransferByPartition`. */
+  PROTECTED_CLEARED_TRANSFER_BY_PARTITION: "ProtectedClearedTransferByPartition",
+  /** Emitted by `ProtectedClearingHoldByPartitionFacet.protectedClearingCreateHoldByPartition`. */
+  PROTECTED_CLEARED_HOLD_BY_PARTITION: "ProtectedClearedHoldByPartition",
+} as const;

--- a/packages/ats/contracts/test/helpers/eventAssertions.ts
+++ b/packages/ats/contracts/test/helpers/eventAssertions.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Event-emission assertion helpers used by integration tests.
+ *
+ * These complement the chai `to.emit(...).withArgs(...)` matcher by enforcing
+ * structural guarantees the matcher does not provide:
+ *
+ * - **No-duplicate guard**: chai's `to.emit` only requires AT LEAST one matching
+ *   event. `expectExactlyOneEvent` asserts exactly one emission of a given event
+ *   topic in a transaction receipt — catches accidental double-emit regressions.
+ *
+ * Extend incrementally as new structural assertions are needed.
+ *
+ * @module test/helpers/eventAssertions
+ */
+
+import { expect } from "chai";
+import type { BaseContract, ContractTransactionReceipt } from "ethers";
+
+/**
+ * Asserts that exactly one log in `receipt` has `topics[0]` equal to the topic
+ * hash of `eventName` on `contract`'s ABI.
+ *
+ * Use after `await expect(tx).to.emit(contract, NAME).withArgs(...)` to also
+ * guarantee the event fired exactly once (per the project's event-emission
+ * "one event per external call" rule).
+ *
+ * @param receipt    The mined transaction receipt to inspect.
+ * @param contract   Any `BaseContract` whose interface declares the event
+ *                   (typically the diamond `IAsset` handle used in the test).
+ * @param eventName  The exact event name as declared on the writer interface.
+ *
+ * @example
+ * const tx = asset.connect(signer).method(...);
+ * await expect(tx).to.emit(asset, EVENT_NAMES.X).withArgs(...);
+ * const receipt = await (await tx).wait();
+ * expectExactlyOneEvent(receipt!, asset, EVENT_NAMES.X);
+ */
+export function expectExactlyOneEvent(
+  receipt: ContractTransactionReceipt,
+  contract: BaseContract,
+  eventName: string,
+): void {
+  const eventFragment = contract.interface.getEvent(eventName);
+  if (!eventFragment) {
+    throw new Error(`Event ${eventName} not found on contract interface`);
+  }
+  const topicHash = eventFragment.topicHash;
+  const matches = receipt.logs.filter((l) => l.topics[0] === topicHash);
+  expect(matches.length).to.equal(1, `expected exactly one ${eventName} emission, got ${matches.length}`);
+}

--- a/packages/ats/contracts/test/helpers/index.ts
+++ b/packages/ats/contracts/test/helpers/index.ts
@@ -14,3 +14,4 @@ export * from "./testSetup";
 export * from "./globalSetup";
 export * from "./assertions";
 export * from "./errors";
+export * from "./eventAssertions";


### PR DESCRIPTION
## Summary
Pure capability split: extract `protectedRedeemFromByPartition` and `protectedTransferFromByPartition` from `ERC1410Management` into a dedicated `ProtectedByPartitionFacet`. No behaviour change.

## Methods moved
| Method | From | To |
|---|---|---|
| `protectedRedeemFromByPartition` | `ERC1410Management` | `ProtectedByPartition` |
| `protectedTransferFromByPartition` | `ERC1410Management` | `ProtectedByPartition` |

## Resolver key
- Constant: `_PROTECTED_BY_PARTITION_RESOLVER_KEY`
- Preimage: `security.token.standard.protectedByPartition.resolverKey`
- Hash: `0x9d0a49341d6d9216381bfd989b60c6b453acb5b2ca6994948003527bd029090d`

## Verification
- `npx hardhat compile` — clean
- `npx hardhat test` — 1885 passing, 3 pending, 0 failing
- `npm run lint` — 0 errors
- `npm run ats:sdk:build` — clean
- `atsRegistry.data.ts` regenerated via §8a recipe (`hardhat-dependency-compiler` cleared); new facet registered.
- Independent /review (per Phase 7): READY TO MERGE.

Source-facet drainage NOT triggered — `ERC1410Management` retains 3 selectors after the split.