### PR TITLE
fix(mass-payout): align ICoupon import with post-MAF-split flat path

### DIFF
--- a/.changeset/fix-mass-payout-coupon-import.md
+++ b/.changeset/fix-mass-payout-coupon-import.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/mass-payout-contracts": patch
+---
+
+Update the `ICoupon` import in `LifeCycleCashFlowStorageWrapper.sol` to the post-PR-#1042 flat path (`contracts/facets/coupon/ICoupon.sol`). The legacy `layer_2/coupon/ICoupon.sol` path was removed during the coupon MAF flat migration, breaking the mass-payout build on every downstream PR.

--- a/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
+++ b/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
@@ -17,7 +17,7 @@ import {
     IBalanceTrackerAtSnapshot
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/balanceTrackerAtSnapshot/IBalanceTrackerAtSnapshot.sol";
 import { IMaturity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/maturity/IMaturity.sol";
-import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/coupon/ICoupon.sol";
+import { ICoupon } from "@hashgraph/asset-tokenization-contracts/contracts/facets/coupon/ICoupon.sol";
 import {
     ICouponSecurityHolders
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol";


### PR DESCRIPTION
## Summary
Mass-payout build was broken by the coupon facet's flat migration in PR #1042: `LifeCycleCashFlowStorageWrapper.sol` still imported `ICoupon` from the deprecated `facets/layer_2/coupon/ICoupon.sol` path. Update to the canonical flat path.

## Verification
- `cd packages/mass-payout/contracts && npx hardhat compile` — clean
- Reproduces the failures observed on PRs #1047, #1048, #1049.

## Note for downstream PRs
Once merged, PRs #1047 / #1048 / #1049 should rebase onto post-merge `origin/development` to pick up the fix.