### PR TITLE
feat: operator by partition facet

### DIFF
--- a/.changeset/maf-operator-by-partition-facet.md
+++ b/.changeset/maf-operator-by-partition-facet.md
@@ -1,0 +1,31 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+# OperatorByPartition split
+
+Extract per-partition operator functions from `ERC1410TokenHolder`, `ERC1410Read`, and
+`ERC1410Management` into a dedicated `OperatorByPartitionFacet` registered under
+`_OPERATOR_BY_PARTITION_RESOLVER_KEY`.
+
+## Changes
+
+- Added `contracts/facets/operatorByPartition/IOperatorByPartition.sol`,
+  `OperatorByPartition.sol`, `OperatorByPartitionFacet.sol`.
+- Added `_OPERATOR_BY_PARTITION_RESOLVER_KEY` constant in `resolverKeys.sol`.
+- Removed `authorizeOperatorByPartition` and `revokeOperatorByPartition` from
+  `ERC1410TokenHolder.sol` and `IERC1410TokenHolder.sol` (3 → 1 selectors).
+- Removed `isOperatorForPartition` from `ERC1410Read.sol` and `IERC1410Read.sol`
+  (3 → 2 selectors).
+- Removed `operatorTransferByPartition` and `operatorRedeemByPartition` from
+  `ERC1410Management.sol` and `IERC1410Management.sol` (5 → 3 selectors).
+- `IERC1410` now inherits `IOperatorByPartition`.
+- Updated `Configuration.ts` and 7 `createConfiguration.ts` scripts to register
+  `OperatorByPartitionFacet`.
+- Added `test/contracts/integration/operatorByPartition/operatorByPartition.test.ts`
+  covering authorise, revoke, query, operator-transfer, and operator-redeem scenarios.
+
+## Non-breaking
+
+The 4-byte selectors of all five functions are unchanged. Any call through `IAsset` or
+`IERC1410` continues to work without modification.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -89,6 +89,7 @@ export const CONTRACT_NAMES = [
   "ERC1410ManagementFacet",
   "MintByPartitionFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnFacet",
   "BurnByPartitionFacet",
   "ClearingByPartitionFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -159,6 +159,9 @@ bytes32 constant _ERC1410_MANAGEMENT_KPI_LINKED_RATE_RESOLVER_KEY = 0x831449a00c
 // keccak256("security.token.standard.erc1410.management.SustainabilityPerformanceTarget.rate.resolverKey");
 bytes32 constant _ERC1410_MANAGEMENT_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY = 0x6768fcc73686ddd306656061b0e415208ded041927d9935de3747583559d0c5e;
 
+// keccak256("security.token.standard.operatorByPartition.resolverKey");
+bytes32 constant _OPERATOR_BY_PARTITION_RESOLVER_KEY = 0x2809aea79e9555a03702a2bc4909c1ec379fa84126c71610671545c2d5e96957;
+
 // keccak256("security.token.standard.operator.resolverKey");
 bytes32 constant _OPERATOR_RESOLVER_KEY = 0x51edd1c99284e90fe906b4688cd46c5a665145ae32ebfd2df614ca0cd610e325;
 

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -124,6 +124,7 @@ import { IBatchMint } from "./batchMint/IBatchMint.sol";
 import { IBatchTransfer } from "./batchTransfer/IBatchTransfer.sol";
 import { IMetadata } from "./metadata/IMetadata.sol";
 import { IDeactivate } from "./deactivate/IDeactivate.sol";
+import { IOperatorByPartition } from "./operatorByPartition/IOperatorByPartition.sol";
 
 // solhint-disable no-empty-blocks
 /**
@@ -244,5 +245,6 @@ interface IAsset is
     IBatchMint,
     IBatchTransfer,
     IMetadata,
-    IDeactivate
+    IDeactivate,
+    IOperatorByPartition
 {}

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Management.sol
@@ -1,63 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { IERC1410Types } from "./IERC1410Types.sol";
 import { IERC1410Management } from "./IERC1410Management.sol";
 import { IProtectedPartitions } from "../../../../facets/layer_1/protectedPartition/IProtectedPartitions.sol";
 import { Modifiers } from "../../../../services/Modifiers.sol";
 import { ProtectedPartitionsStorageWrapper } from "../../../../domain/core/ProtectedPartitionsStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../../../domain/asset/ERC1410StorageWrapper.sol";
 import { TokenCoreOps } from "../../../../domain/orchestrator/TokenCoreOps.sol";
-import { EvmAccessors } from "../../../../infrastructure/utils/EvmAccessors.sol";
 
 abstract contract ERC1410Management is IERC1410Management, Modifiers {
     // solhint-disable-next-line func-name-mixedcase
     function initialize_ERC1410(bool _multiPartition) external override onlyNotERC1410Initialized {
         ERC1410StorageWrapper.initialize_ERC1410(_multiPartition);
-    }
-
-    function operatorTransferByPartition(
-        IERC1410Types.OperatorTransferData calldata _operatorTransferData
-    )
-        external
-        override
-        notZeroAddress(_operatorTransferData.to)
-        onlyDefaultPartitionWithSinglePartition(_operatorTransferData.partition)
-        onlyUnProtectedPartitionsOrWildCardRole
-        onlyCanTransferFromByPartition(
-            _operatorTransferData.from,
-            _operatorTransferData.to,
-            _operatorTransferData.partition,
-            _operatorTransferData.value
-        )
-        onlyOperator(_operatorTransferData.partition, _operatorTransferData.from)
-        returns (bytes32)
-    {
-        return TokenCoreOps.operatorTransferByPartition(_operatorTransferData);
-    }
-
-    function operatorRedeemByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    )
-        external
-        override
-        onlyDefaultPartitionWithSinglePartition(_partition)
-        onlyUnProtectedPartitionsOrWildCardRole
-        onlyCanRedeemFromByPartition(_tokenHolder, _partition, _value)
-        onlyOperator(_partition, _tokenHolder)
-    {
-        TokenCoreOps.redeemByPartition(
-            _partition,
-            _tokenHolder,
-            EvmAccessors.getMsgSender(),
-            _value,
-            _data,
-            _operatorData
-        );
     }
 
     function protectedTransferFromByPartition(

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
@@ -12,13 +12,11 @@ contract ERC1410ManagementFacet is ERC1410Management, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
+        uint256 selectorIndex = 3;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
             staticFunctionSelectors_[--selectorIndex] = this.protectedRedeemFromByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.protectedTransferFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.operatorRedeemByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.operatorTransferByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC1410.selector;
         }
     }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Read.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410Read.sol
@@ -13,12 +13,4 @@ abstract contract ERC1410Read is IERC1410Read, Modifiers {
     function isMultiPartition() external view returns (bool) {
         return ERC1410StorageWrapper.isMultiPartition();
     }
-
-    function isOperatorForPartition(
-        bytes32 _partition,
-        address _operator,
-        address _tokenHolder
-    ) public view returns (bool) {
-        return ERC1410StorageWrapper.isOperatorForPartition(_partition, _operator, _tokenHolder);
-    }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ReadFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ReadFacet.sol
@@ -12,10 +12,9 @@ contract ERC1410ReadFacet is ERC1410Read, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
+        uint256 selectorIndex = 2;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.isOperatorForPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.isMultiPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.partitionsOf.selector;
         }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410TokenHolder.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410TokenHolder.sol
@@ -5,7 +5,6 @@ import { IERC1410Types } from "./IERC1410Types.sol";
 import { IERC1410TokenHolder } from "./IERC1410TokenHolder.sol";
 
 import { Modifiers } from "../../../../services/Modifiers.sol";
-import { ERC1410StorageWrapper } from "../../../../domain/asset/ERC1410StorageWrapper.sol";
 import { TokenCoreOps } from "../../../../domain/orchestrator/TokenCoreOps.sol";
 import { EvmAccessors } from "../../../../infrastructure/utils/EvmAccessors.sol";
 
@@ -36,32 +35,5 @@ abstract contract ERC1410TokenHolder is IERC1410TokenHolder, Modifiers {
                 address(0),
                 ""
             );
-    }
-
-    function authorizeOperatorByPartition(
-        bytes32 _partition,
-        address _operator
-    )
-        external
-        override
-        onlyUnpaused
-        onlyDefaultPartitionWithSinglePartition(_partition)
-        onlyCompliant(EvmAccessors.getMsgSender(), _operator, false)
-    {
-        ERC1410StorageWrapper.authorizeOperatorByPartition(_partition, _operator);
-    }
-
-    function revokeOperatorByPartition(
-        bytes32 _partition,
-        address _operator
-    )
-        external
-        override
-        onlyUnpaused
-        onlyDefaultPartitionWithSinglePartition(_partition)
-        onlyIdentifiedAddresses(EvmAccessors.getMsgSender(), _operator)
-        onlyCompliant(EvmAccessors.getMsgSender(), _operator, false)
-    {
-        ERC1410StorageWrapper.revokeOperatorByPartition(_partition, _operator);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410TokenHolderFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410TokenHolderFacet.sol
@@ -12,11 +12,9 @@ contract ERC1410TokenHolderFacet is ERC1410TokenHolder, IStaticFunctionSelectors
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
+        uint256 selectorIndex = 1;
         staticFunctionSelectors_ = new bytes4[](selectorIndex);
         unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.revokeOperatorByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.authorizeOperatorByPartition.selector;
             staticFunctionSelectors_[--selectorIndex] = this.transferByPartition.selector;
         }
     }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Management.sol
@@ -16,31 +16,6 @@ interface IERC1410Management is IERC1410Types {
     function initialize_ERC1410(bool _multiPartition) external;
 
     /**
-     * @notice Transfers the ownership of tokens from a specified partition from one address to another address
-     * @param _operatorTransferData contains all the information about the operator transfer
-     */
-    function operatorTransferByPartition(
-        OperatorTransferData calldata _operatorTransferData
-    ) external returns (bytes32);
-
-    /**
-     * @notice Decreases totalSupply and the corresponding amount of the specified partition of tokenHolder
-     * @dev This function can only be called by the authorised operator.
-     * @param _partition The partition to allocate the decrease in balance.
-     * @param _tokenHolder The token holder whose balance should be decreased
-     * @param _value The amount by which to decrease the balance
-     * @param _data Additional data attached to the burning of tokens
-     * @param _operatorData Additional data attached to the transfer of tokens by the operator
-     */
-    function operatorRedeemByPartition(
-        bytes32 _partition,
-        address _tokenHolder,
-        uint256 _value,
-        bytes calldata _data,
-        bytes calldata _operatorData
-    ) external;
-
-    /**
      * @notice Transfers tokens from the token holder to another address by presenting an off-chain signature
      * @dev Can only be called by the protected partitions role
      */

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Read.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Read.sol
@@ -22,17 +22,4 @@ interface IERC1410Read is IERC1410Types {
      *  false : the token contains only one partition, the default one
      */
     function isMultiPartition() external view returns (bool);
-
-    /**
-     * @notice Determines whether `_operator` is an operator for a specified partition of `_tokenHolder`
-     * @param _partition The partition to check
-     * @param _operator The operator to check
-     * @param _tokenHolder The token holder to check
-     * @return Whether the `_operator` is an operator for a specified partition of `_tokenHolder`
-     */
-    function isOperatorForPartition(
-        bytes32 _partition,
-        address _operator,
-        address _tokenHolder
-    ) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410TokenHolder.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410TokenHolder.sol
@@ -21,18 +21,4 @@ interface IERC1410TokenHolder is IERC1410Types {
         BasicTransferInfo calldata _basicTransferInfo,
         bytes memory _data
     ) external returns (bytes32);
-
-    /**
-     * @notice Authorises an operator for a given partition of `msg.sender`
-     * @param _partition The partition to which the operator is authorised
-     * @param _operator An address which is being authorised
-     */
-    function authorizeOperatorByPartition(bytes32 _partition, address _operator) external;
-
-    /**
-     * @notice Revokes authorisation of an operator previously given for a specified partition of `msg.sender`
-     * @param _partition The partition to which the operator is de-authorised
-     * @param _operator An address which is being de-authorised
-     */
-    function revokeOperatorByPartition(bytes32 _partition, address _operator) external;
 }

--- a/packages/ats/contracts/contracts/facets/operatorByPartition/IOperatorByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/operatorByPartition/IOperatorByPartition.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IERC1410Types } from "../layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+
+/**
+ * @title  IOperatorByPartition
+ * @notice Interface for per-partition operator management: authorise, revoke, and query
+ *         operators scoped to individual token partitions, and execute operator-initiated
+ *         transfers and redemptions on those partitions.
+ * @dev    All storage reads and writes delegate to `ERC1410StorageWrapper`. Events
+ *         (`AuthorizedOperatorByPartition`, `RevokedOperatorByPartition`,
+ *         `TransferByPartition`, `RedeemedByPartition`) are inherited from `IERC1410Types`
+ *         and emitted by the storage wrapper or `TokenCoreOps` respectively.
+ * @author Asset Tokenization Studio Team
+ */
+interface IOperatorByPartition is IERC1410Types {
+    /**
+     * @notice Authorises an operator to manage a specific partition of `msg.sender`'s tokens.
+     * @dev    The token must not be paused. Both `msg.sender` and `_operator` must pass
+     *         compliance checks. Reverts when the partition is incompatible with the token's
+     *         partition mode (single-partition tokens only accept the default partition).
+     *         Emits {AuthorizedOperatorByPartition} via
+     *         `ERC1410StorageWrapper.authorizeOperatorByPartition`.
+     * @param _partition  The partition the operator is authorised for.
+     * @param _operator   The address being authorised as operator.
+     */
+    function authorizeOperatorByPartition(bytes32 _partition, address _operator) external;
+
+    /**
+     * @notice Revokes a previously authorised operator from a specific partition of
+     *         `msg.sender`'s tokens.
+     * @dev    The token must not be paused. `msg.sender` and `_operator` must be identified
+     *         addresses and both must pass compliance checks. Reverts when the partition is
+     *         incompatible with the token's partition mode.
+     *         Emits {RevokedOperatorByPartition} via
+     *         `ERC1410StorageWrapper.revokeOperatorByPartition`.
+     * @param _partition  The partition from which the operator is de-authorised.
+     * @param _operator   The address being de-authorised.
+     */
+    function revokeOperatorByPartition(bytes32 _partition, address _operator) external;
+
+    /**
+     * @notice Transfers tokens on behalf of a token holder from a specified partition to
+     *         another address.
+     * @dev    The caller must be an authorised operator for `_operatorTransferData.partition`
+     *         of `_operatorTransferData.from`. Enforces partition-mode rules,
+     *         unprotected-partition restrictions, and transfer-eligibility checks.
+     *         Emits {TransferByPartition} via `TokenCoreOps.operatorTransferByPartition`.
+     * @param _operatorTransferData  Struct containing partition, from, to, value, data, and
+     *                               operatorData.
+     * @return The partition to which the transferred tokens were allocated for the recipient.
+     */
+    function operatorTransferByPartition(
+        OperatorTransferData calldata _operatorTransferData
+    ) external returns (bytes32);
+
+    /**
+     * @notice Decreases the total supply and the partition balance of a token holder on
+     *         behalf of an authorised operator.
+     * @dev    The caller must be an authorised operator for `_partition` of `_tokenHolder`.
+     *         Enforces partition-mode rules, unprotected-partition restrictions, and
+     *         redemption-eligibility checks.
+     *         Emits {RedeemedByPartition} via `TokenCoreOps.redeemByPartition`.
+     * @param _partition      The partition from which tokens are redeemed.
+     * @param _tokenHolder    The address whose tokens are redeemed.
+     * @param _value          The number of tokens to redeem.
+     * @param _data           Additional data attached to the redemption (passed to hooks).
+     * @param _operatorData   Additional data attached by the operator.
+     */
+    function operatorRedeemByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    ) external;
+
+    /**
+     * @notice Returns whether `_operator` is an authorised operator for a specific partition
+     *         of `_tokenHolder`.
+     * @dev    Returns `true` if `_operator` has been authorised for all partitions of
+     *         `_tokenHolder` (via `authorizeOperator`) OR has explicit per-partition approval
+     *         (via `authorizeOperatorByPartition`). Read-only; no access control applied.
+     * @param _partition    The partition to query.
+     * @param _operator     The operator address to check.
+     * @param _tokenHolder  The token holder whose partition is being queried.
+     * @return bool `true` if `_operator` is authorised for `_partition` of `_tokenHolder`.
+     */
+    function isOperatorForPartition(
+        bytes32 _partition,
+        address _operator,
+        address _tokenHolder
+    ) external view returns (bool);
+}

--- a/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartition.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IERC1410Types } from "../layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+import { IOperatorByPartition } from "./IOperatorByPartition.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
+import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
+
+/**
+ * @title  OperatorByPartition
+ * @notice Abstract implementation of `IOperatorByPartition`.
+ * @dev    Storage reads and writes delegate to `ERC1410StorageWrapper`. Token-lifecycle
+ *         operations (operator transfer and redemption) are orchestrated via `TokenCoreOps`.
+ *         Intended to be inherited solely by `OperatorByPartitionFacet`.
+ * @author Asset Tokenization Studio Team
+ */
+abstract contract OperatorByPartition is IOperatorByPartition, Modifiers {
+    /// @inheritdoc IOperatorByPartition
+    /// @dev Emits {AuthorizedOperatorByPartition} via
+    ///      ERC1410StorageWrapper.authorizeOperatorByPartition.
+    function authorizeOperatorByPartition(
+        bytes32 _partition,
+        address _operator
+    )
+        external
+        override
+        onlyUnpaused
+        onlyDefaultPartitionWithSinglePartition(_partition)
+        onlyCompliant(EvmAccessors.getMsgSender(), _operator, false)
+    {
+        ERC1410StorageWrapper.authorizeOperatorByPartition(_partition, _operator);
+    }
+
+    /// @inheritdoc IOperatorByPartition
+    /// @dev Emits {RevokedOperatorByPartition} via
+    ///      ERC1410StorageWrapper.revokeOperatorByPartition.
+    function revokeOperatorByPartition(
+        bytes32 _partition,
+        address _operator
+    )
+        external
+        override
+        onlyUnpaused
+        onlyDefaultPartitionWithSinglePartition(_partition)
+        onlyIdentifiedAddresses(EvmAccessors.getMsgSender(), _operator)
+        onlyCompliant(EvmAccessors.getMsgSender(), _operator, false)
+    {
+        ERC1410StorageWrapper.revokeOperatorByPartition(_partition, _operator);
+    }
+
+    /// @inheritdoc IOperatorByPartition
+    /// @dev Emits {TransferByPartition} via TokenCoreOps.operatorTransferByPartition.
+    function operatorTransferByPartition(
+        IERC1410Types.OperatorTransferData calldata _operatorTransferData
+    )
+        external
+        override
+        notZeroAddress(_operatorTransferData.to)
+        onlyDefaultPartitionWithSinglePartition(_operatorTransferData.partition)
+        onlyUnProtectedPartitionsOrWildCardRole
+        onlyCanTransferFromByPartition(
+            _operatorTransferData.from,
+            _operatorTransferData.to,
+            _operatorTransferData.partition,
+            _operatorTransferData.value
+        )
+        onlyOperator(_operatorTransferData.partition, _operatorTransferData.from)
+        returns (bytes32)
+    {
+        return TokenCoreOps.operatorTransferByPartition(_operatorTransferData);
+    }
+
+    /// @inheritdoc IOperatorByPartition
+    /// @dev Emits {RedeemedByPartition} via TokenCoreOps.redeemByPartition.
+    function operatorRedeemByPartition(
+        bytes32 _partition,
+        address _tokenHolder,
+        uint256 _value,
+        bytes calldata _data,
+        bytes calldata _operatorData
+    )
+        external
+        override
+        onlyDefaultPartitionWithSinglePartition(_partition)
+        onlyUnProtectedPartitionsOrWildCardRole
+        onlyCanRedeemFromByPartition(_tokenHolder, _partition, _value)
+        onlyOperator(_partition, _tokenHolder)
+    {
+        TokenCoreOps.redeemByPartition(
+            _partition,
+            _tokenHolder,
+            EvmAccessors.getMsgSender(),
+            _value,
+            _data,
+            _operatorData
+        );
+    }
+
+    /// @inheritdoc IOperatorByPartition
+    function isOperatorForPartition(
+        bytes32 _partition,
+        address _operator,
+        address _tokenHolder
+    ) public view override returns (bool) {
+        return ERC1410StorageWrapper.isOperatorForPartition(_partition, _operator, _tokenHolder);
+    }
+}

--- a/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartitionFacet.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IOperatorByPartition } from "./IOperatorByPartition.sol";
+import { OperatorByPartition } from "./OperatorByPartition.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { _OPERATOR_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title  OperatorByPartitionFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes per-partition operator management via
+ *         `IOperatorByPartition`, registered under `_OPERATOR_BY_PARTITION_RESOLVER_KEY`.
+ * @dev    Exposes five selectors:
+ *           - `authorizeOperatorByPartition`
+ *           - `revokeOperatorByPartition`
+ *           - `isOperatorForPartition`
+ *           - `operatorTransferByPartition`
+ *           - `operatorRedeemByPartition`
+ */
+contract OperatorByPartitionFacet is OperatorByPartition, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _OPERATOR_BY_PARTITION_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
+        uint256 selectorIndex = 5;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.operatorRedeemByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.operatorTransferByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.isOperatorForPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.revokeOperatorByPartition.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.authorizeOperatorByPartition.selector;
+        }
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IOperatorByPartition).interfaceId;
+        }
+    }
+}

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-05T16:20:02.029Z
- * Facets: 115
+ * Generated: 2026-05-06T07:53:53.199Z
+ * Facets: 116
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -111,6 +111,7 @@ import {
   MintFacet__factory,
   NominalValueFacet__factory,
   NoncesFacet__factory,
+  OperatorByPartitionFacet__factory,
   OperatorClearingHoldByPartitionFacet__factory,
   OperatorFacet__factory,
   PauseFacet__factory,
@@ -7393,22 +7394,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x7b1df196",
       },
       {
-        name: "operatorRedeemByPartition",
-        signature: {
-          full: "function operatorRedeemByPartition(bytes32 _partition, address _tokenHolder, uint256 _value, bytes _data, bytes _operatorData)",
-          canonical: "operatorRedeemByPartition(bytes32,address,uint256,bytes,bytes)",
-        },
-        selector: "0x13d557bc",
-      },
-      {
-        name: "operatorTransferByPartition",
-        signature: {
-          full: "function operatorTransferByPartition((bytes32 partition, address from, address to, uint256 value, bytes data, bytes operatorData) _operatorTransferData) returns (bytes32)",
-          canonical: "operatorTransferByPartition((bytes32,address,address,uint256,bytes,bytes))",
-        },
-        selector: "0x6b9894fe",
-      },
-      {
         name: "protectedRedeemFromByPartition",
         signature: {
           full: "function protectedRedeemFromByPartition(bytes32 _partition, address _from, uint256 _amount, (uint256 deadline, uint256 nonce, bytes signature) _protectionData)",
@@ -7527,14 +7512,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xb96d9539",
       },
       {
-        name: "PartitionsAreProtectedAndNoRole",
-        signature: {
-          full: "error PartitionsAreProtectedAndNoRole(address account, bytes32 role)",
-          canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
-        },
-        selector: "0x55347310",
-      },
-      {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
@@ -7551,11 +7528,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "Unauthorized(address,address,bytes32)",
         },
         selector: "0x1e09743f",
-      },
-      {
-        name: "ZeroAddressNotAllowed",
-        signature: { full: "error ZeroAddressNotAllowed()", canonical: "ZeroAddressNotAllowed()" },
-        selector: "0x8579befe",
       },
       {
         name: "ZeroPartition",
@@ -7581,14 +7553,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "isMultiPartition",
         signature: { full: "function isMultiPartition() view returns (bool)", canonical: "isMultiPartition()" },
         selector: "0xbd09cc54",
-      },
-      {
-        name: "isOperatorForPartition",
-        signature: {
-          full: "function isOperatorForPartition(bytes32 _partition, address _operator, address _tokenHolder) view returns (bool)",
-          canonical: "isOperatorForPartition(bytes32,address,address)",
-        },
-        selector: "0x6d77cad6",
       },
       {
         name: "partitionsOf",
@@ -7715,22 +7679,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     inheritance: ["ERC1410TokenHolder", "IStaticFunctionSelectors"],
     methods: [
       {
-        name: "authorizeOperatorByPartition",
-        signature: {
-          full: "function authorizeOperatorByPartition(bytes32 _partition, address _operator)",
-          canonical: "authorizeOperatorByPartition(bytes32,address)",
-        },
-        selector: "0x103ef9e1",
-      },
-      {
-        name: "revokeOperatorByPartition",
-        signature: {
-          full: "function revokeOperatorByPartition(bytes32 _partition, address _operator)",
-          canonical: "revokeOperatorByPartition(bytes32,address)",
-        },
-        selector: "0x168ecec5",
-      },
-      {
         name: "transferByPartition",
         signature: {
           full: "function transferByPartition(bytes32 _partition, (address to, uint256 value) _basicTransferInfo, bytes _data) returns (bytes32)",
@@ -7834,11 +7782,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -11912,6 +11855,181 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new NoncesFacetTimeTravel__factory(signer),
   },
 
+  OperatorByPartitionFacet: {
+    name: "OperatorByPartitionFacet",
+    description:
+      "Diamond facet that exposes per-partition operator management via `IOperatorByPartition`, registered under `_OPERATOR_BY_PARTITION_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_OPERATOR_BY_PARTITION_RESOLVER_KEY",
+      value: "0x2809aea79e9555a03702a2bc4909c1ec379fa84126c71610671545c2d5e96957",
+    },
+    inheritance: ["OperatorByPartition", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "authorizeOperatorByPartition",
+        signature: {
+          full: "function authorizeOperatorByPartition(bytes32 _partition, address _operator)",
+          canonical: "authorizeOperatorByPartition(bytes32,address)",
+        },
+        selector: "0x103ef9e1",
+      },
+      {
+        name: "isOperatorForPartition",
+        signature: {
+          full: "function isOperatorForPartition(bytes32 _partition, address _operator, address _tokenHolder) view returns (bool)",
+          canonical: "isOperatorForPartition(bytes32,address,address)",
+        },
+        selector: "0x6d77cad6",
+      },
+      {
+        name: "operatorRedeemByPartition",
+        signature: {
+          full: "function operatorRedeemByPartition(bytes32 _partition, address _tokenHolder, uint256 _value, bytes _data, bytes _operatorData)",
+          canonical: "operatorRedeemByPartition(bytes32,address,uint256,bytes,bytes)",
+        },
+        selector: "0x13d557bc",
+      },
+      {
+        name: "operatorTransferByPartition",
+        signature: {
+          full: "function operatorTransferByPartition((bytes32 partition, address from, address to, uint256 value, bytes data, bytes operatorData) _operatorTransferData) returns (bytes32)",
+          canonical: "operatorTransferByPartition((bytes32,address,address,uint256,bytes,bytes))",
+        },
+        selector: "0x6b9894fe",
+      },
+      {
+        name: "revokeOperatorByPartition",
+        signature: {
+          full: "function revokeOperatorByPartition(bytes32 _partition, address _operator)",
+          canonical: "revokeOperatorByPartition(bytes32,address)",
+        },
+        selector: "0x168ecec5",
+      },
+    ],
+    events: [
+      {
+        name: "AuthorizedOperator",
+        signature: {
+          full: "event AuthorizedOperator(address indexed operator, address indexed tokenHolder)",
+          canonical: "AuthorizedOperator(address,address)",
+        },
+        topic0: "0xf4caeb2d6ca8932a215a353d0703c326ec2d81fc68170f320eb2ab49e9df61f9",
+      },
+      {
+        name: "AuthorizedOperatorByPartition",
+        signature: {
+          full: "event AuthorizedOperatorByPartition(bytes32 indexed partition, address indexed operator, address indexed tokenHolder)",
+          canonical: "AuthorizedOperatorByPartition(bytes32,address,address)",
+        },
+        topic0: "0x3646a897c70797ecc134b0adc32f471b07bf1d6f451133b0384badab531e3fd6",
+      },
+      {
+        name: "IssuedByPartition",
+        signature: {
+          full: "event IssuedByPartition(bytes32 indexed partition, address indexed operator, address indexed to, uint256 value, bytes data)",
+          canonical: "IssuedByPartition(bytes32,address,address,uint256,bytes)",
+        },
+        topic0: "0x5af1c8f424b104b6ba4e3c0885f2ed9fef04a9b1ea39cd9ed362432105c0791a",
+      },
+      {
+        name: "RedeemedByPartition",
+        signature: {
+          full: "event RedeemedByPartition(bytes32 indexed partition, address indexed operator, address indexed from, uint256 value, bytes data, bytes operatorData)",
+          canonical: "RedeemedByPartition(bytes32,address,address,uint256,bytes,bytes)",
+        },
+        topic0: "0xa4f62471c9bdf88115b97203943c74c59b655913ee5ee592706d84ef53fb6be2",
+      },
+      {
+        name: "RevokedOperator",
+        signature: {
+          full: "event RevokedOperator(address indexed operator, address indexed tokenHolder)",
+          canonical: "RevokedOperator(address,address)",
+        },
+        topic0: "0x50546e66e5f44d728365dc3908c63bc5cfeeab470722c1677e3073a6ac294aa1",
+      },
+      {
+        name: "RevokedOperatorByPartition",
+        signature: {
+          full: "event RevokedOperatorByPartition(bytes32 indexed partition, address indexed operator, address indexed tokenHolder)",
+          canonical: "RevokedOperatorByPartition(bytes32,address,address)",
+        },
+        topic0: "0x3b287c4f1bab4df949b33bceacef984f544dc5d5479930d00e4ee8c9d8dd96f2",
+      },
+      {
+        name: "TransferByPartition",
+        signature: {
+          full: "event TransferByPartition(bytes32 indexed _fromPartition, address _operator, address indexed _from, address indexed _to, uint256 _value, bytes _data, bytes _operatorData)",
+          canonical: "TransferByPartition(bytes32,address,address,address,uint256,bytes,bytes)",
+        },
+        topic0: "0xff4e9a26af4eb73b8bacfaa4abd4fea03d9448e7b912dc5ff4019048875aa2d4",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "InvalidPartition",
+        signature: {
+          full: "error InvalidPartition(address account, bytes32 partition)",
+          canonical: "InvalidPartition(address,bytes32)",
+        },
+        selector: "0xbf84f4ec",
+      },
+      {
+        name: "NotAllowedInMultiPartitionMode",
+        signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
+        selector: "0x76d08f88",
+      },
+      {
+        name: "PartitionNotAllowedInSinglePartitionMode",
+        signature: {
+          full: "error PartitionNotAllowedInSinglePartitionMode(bytes32 partition)",
+          canonical: "PartitionNotAllowedInSinglePartitionMode(bytes32)",
+        },
+        selector: "0xb96d9539",
+      },
+      {
+        name: "PartitionsAreProtectedAndNoRole",
+        signature: {
+          full: "error PartitionsAreProtectedAndNoRole(address account, bytes32 role)",
+          canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
+        },
+        selector: "0x55347310",
+      },
+      {
+        name: "TokenIsPaused",
+        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
+        selector: "0x649815a5",
+      },
+      {
+        name: "Unauthorized",
+        signature: {
+          full: "error Unauthorized(address operator, address tokenHolder, bytes32 partition)",
+          canonical: "Unauthorized(address,address,bytes32)",
+        },
+        selector: "0x1e09743f",
+      },
+      {
+        name: "ZeroAddressNotAllowed",
+        signature: { full: "error ZeroAddressNotAllowed()", canonical: "ZeroAddressNotAllowed()" },
+        selector: "0x8579befe",
+      },
+      {
+        name: "ZeroPartition",
+        signature: { full: "error ZeroPartition()", canonical: "ZeroPartition()" },
+        selector: "0x4a6f30c3",
+      },
+      { name: "ZeroValue", signature: { full: "error ZeroValue()", canonical: "ZeroValue()" }, selector: "0x7c946ed7" },
+    ],
+    factory: (signer) => new OperatorByPartitionFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
+  },
+
   OperatorClearingHoldByPartitionFacet: {
     name: "OperatorClearingHoldByPartitionFacet",
     description: "Diamond facet for partition-scoped operator clearing hold operations.",
@@ -14784,7 +14902,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 115 as const;
+export const TOTAL_FACETS = 116 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -82,6 +82,7 @@ const BOND_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -77,6 +77,7 @@ const BOND_FIXED_RATE_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -72,6 +72,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -72,6 +72,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -73,6 +73,7 @@ const EQUITY_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -83,6 +83,7 @@ const LOAN_FACETS = [
   "ERC1410ManagementFacet",
   "MintByPartitionFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "ERC3643ManagementFacet",
   "ERC3643ReadFacet",

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -80,6 +80,7 @@ const LOANS_PORTFOLIO_FACETS = [
   "ERC1410ReadFacet",
   "OperatorFacet",
   "ERC1410TokenHolderFacet",
+  "OperatorByPartitionFacet",
   "BurnByPartitionFacet",
   "DocumentationFacet",
   "ControllerFacet",

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
@@ -3547,25 +3547,6 @@ describe("Clearing Tests", () => {
       });
     });
 
-    describe("operatorTransferByPartition", async () => {
-      it("GIVEN valid parameters WHEN operatorTransferByPartition THEN transaction succeeds and emits Transfer", async () => {
-        await asset.connect(signer_A).authorizeOperatorByPartition(_DEFAULT_PARTITION, signer_B.address);
-
-        const operatorTransferData = {
-          partition: _DEFAULT_PARTITION,
-          from: signer_A.address,
-          to: signer_B.address,
-          value: _AMOUNT,
-          data: "0x",
-          operatorData: "0x",
-        };
-
-        await expect(asset.connect(signer_B).operatorTransferByPartition(operatorTransferData))
-          .to.emit(asset, "Transfer")
-          .withArgs(signer_A.address, signer_B.address, _AMOUNT);
-      });
-    });
-
     describe("protectedTransferFromByPartition", async () => {
       beforeEach(async () => {
         const packedData = ethers.AbiCoder.defaultAbiCoder().encode(

--- a/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
@@ -177,6 +177,7 @@ describe("OperatorByPartitionFacet Tests", () => {
     });
 
     it("GIVEN a non-operator caller WHEN operatorTransferByPartition THEN reverts with Unauthorized", async () => {
+      await asset.connect(signer_A).approve(signer_B.address, AMOUNT);
       await expect(
         asset.connect(signer_B).operatorTransferByPartition({
           partition: DEFAULT_PARTITION,

--- a/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { type IAsset, type ResolverProxy } from "@contract-types";
+import { ATS_ROLES, DEFAULT_PARTITION, EMPTY_HEX_BYTES, EMPTY_STRING, ZERO } from "@scripts";
+import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
+
+const WRONG_PARTITION = "0x0000000000000000000000000000000000000000000000000000000000000321";
+const AMOUNT = 1000;
+const EMPTY_VC_ID = EMPTY_STRING;
+
+describe("OperatorByPartitionFacet Tests", () => {
+  let diamond: ResolverProxy;
+  let signer_A: HardhatEthersSigner;
+  let signer_B: HardhatEthersSigner;
+  let signer_C: HardhatEthersSigner;
+  let signer_D: HardhatEthersSigner;
+
+  let asset: IAsset;
+
+  async function deployFixture() {
+    const base = await deployEquityTokenFixture();
+    diamond = base.diamond;
+    signer_A = base.deployer;
+    signer_B = base.user1;
+    signer_C = base.user2;
+    signer_D = base.user3;
+
+    asset = await ethers.getContractAt("IAsset", diamond.target, signer_A);
+
+    await executeRbac(asset, [
+      { role: ATS_ROLES.ISSUER_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.KYC_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.SSI_MANAGER_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.PAUSER_ROLE, members: [signer_A.address] },
+      { role: ATS_ROLES.CONTROL_LIST_ROLE, members: [signer_A.address] },
+    ]);
+
+    await asset.addIssuer(signer_A.address);
+    await asset.grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+    await asset.grantKyc(signer_B.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+    await asset.grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+    await asset.grantKyc(signer_D.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+
+    await asset.issueByPartition({
+      partition: DEFAULT_PARTITION,
+      tokenHolder: signer_A.address,
+      value: AMOUNT,
+      data: EMPTY_HEX_BYTES,
+    });
+  }
+
+  beforeEach(async () => {
+    await loadFixture(deployFixture);
+  });
+
+  // ─── authorizeOperatorByPartition ────────────────────────────────────────────
+
+  describe("authorizeOperatorByPartition", () => {
+    it("GIVEN a paused token WHEN authorizeOperatorByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.pause();
+      await expect(
+        asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN an incompatible partition WHEN authorizeOperatorByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      await expect(asset.connect(signer_A).authorizeOperatorByPartition(WRONG_PARTITION, signer_B.address))
+        .to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode")
+        .withArgs(WRONG_PARTITION);
+    });
+
+    it("GIVEN a blocked operator WHEN authorizeOperatorByPartition THEN reverts with AccountIsBlocked", async () => {
+      await asset.addToControlList(signer_B.address);
+      await expect(
+        asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "AccountIsBlocked");
+    });
+
+    it("GIVEN valid inputs WHEN authorizeOperatorByPartition THEN emits AuthorizedOperatorByPartition and isOperatorForPartition returns true", async () => {
+      await expect(asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address))
+        .to.emit(asset, "AuthorizedOperatorByPartition")
+        .withArgs(DEFAULT_PARTITION, signer_B.address, signer_A.address);
+
+      expect(await asset.isOperatorForPartition(DEFAULT_PARTITION, signer_B.address, signer_A.address)).to.equal(true);
+    });
+  });
+
+  // ─── revokeOperatorByPartition ────────────────────────────────────────────────
+
+  describe("revokeOperatorByPartition", () => {
+    beforeEach(async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+    });
+
+    it("GIVEN a paused token WHEN revokeOperatorByPartition THEN reverts with TokenIsPaused", async () => {
+      await asset.pause();
+      await expect(
+        asset.connect(signer_A).revokeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    });
+
+    it("GIVEN an incompatible partition WHEN revokeOperatorByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      await expect(asset.connect(signer_A).revokeOperatorByPartition(WRONG_PARTITION, signer_B.address))
+        .to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode")
+        .withArgs(WRONG_PARTITION);
+    });
+
+    it("GIVEN a blocked operator WHEN revokeOperatorByPartition THEN reverts with AccountIsBlocked", async () => {
+      await asset.addToControlList(signer_B.address);
+      await expect(
+        asset.connect(signer_A).revokeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "AccountIsBlocked");
+    });
+
+    it("GIVEN a previously authorised operator WHEN revokeOperatorByPartition THEN emits RevokedOperatorByPartition and isOperatorForPartition returns false", async () => {
+      await expect(asset.connect(signer_A).revokeOperatorByPartition(DEFAULT_PARTITION, signer_B.address))
+        .to.emit(asset, "RevokedOperatorByPartition")
+        .withArgs(DEFAULT_PARTITION, signer_B.address, signer_A.address);
+
+      expect(await asset.isOperatorForPartition(DEFAULT_PARTITION, signer_B.address, signer_A.address)).to.equal(false);
+    });
+  });
+
+  // ─── isOperatorForPartition ───────────────────────────────────────────────────
+
+  describe("isOperatorForPartition", () => {
+    it("GIVEN no approval WHEN isOperatorForPartition THEN returns false", async () => {
+      expect(await asset.isOperatorForPartition(DEFAULT_PARTITION, signer_B.address, signer_A.address)).to.equal(false);
+    });
+
+    it("GIVEN per-partition approval WHEN isOperatorForPartition THEN returns true", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      expect(await asset.isOperatorForPartition(DEFAULT_PARTITION, signer_B.address, signer_A.address)).to.equal(true);
+    });
+
+    it("GIVEN revoked per-partition approval WHEN isOperatorForPartition THEN returns false", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      await asset.connect(signer_A).revokeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      expect(await asset.isOperatorForPartition(DEFAULT_PARTITION, signer_B.address, signer_A.address)).to.equal(false);
+    });
+  });
+
+  // ─── operatorTransferByPartition ─────────────────────────────────────────────
+
+  describe("operatorTransferByPartition", () => {
+    it("GIVEN to address is zero WHEN operatorTransferByPartition THEN reverts with ZeroAddressNotAllowed", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      await expect(
+        asset.connect(signer_B).operatorTransferByPartition({
+          partition: DEFAULT_PARTITION,
+          from: signer_A.address,
+          to: ethers.ZeroAddress,
+          value: AMOUNT,
+          data: EMPTY_HEX_BYTES,
+          operatorData: EMPTY_HEX_BYTES,
+        }),
+      ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+    });
+
+    it("GIVEN an incompatible partition WHEN operatorTransferByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      await expect(
+        asset.connect(signer_B).operatorTransferByPartition({
+          partition: WRONG_PARTITION,
+          from: signer_A.address,
+          to: signer_C.address,
+          value: AMOUNT,
+          data: EMPTY_HEX_BYTES,
+          operatorData: EMPTY_HEX_BYTES,
+        }),
+      )
+        .to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode")
+        .withArgs(WRONG_PARTITION);
+    });
+
+    it("GIVEN a non-operator caller WHEN operatorTransferByPartition THEN reverts with Unauthorized", async () => {
+      await expect(
+        asset.connect(signer_B).operatorTransferByPartition({
+          partition: DEFAULT_PARTITION,
+          from: signer_A.address,
+          to: signer_C.address,
+          value: AMOUNT,
+          data: EMPTY_HEX_BYTES,
+          operatorData: EMPTY_HEX_BYTES,
+        }),
+      ).to.be.revertedWithCustomError(asset, "Unauthorized");
+    });
+
+    it("GIVEN valid inputs WHEN operatorTransferByPartition THEN emits TransferByPartition and balances update correctly", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+
+      const initialBalanceA = await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
+      const initialBalanceC = await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_C.address);
+
+      await expect(
+        asset.connect(signer_B).operatorTransferByPartition({
+          partition: DEFAULT_PARTITION,
+          from: signer_A.address,
+          to: signer_C.address,
+          value: AMOUNT,
+          data: EMPTY_HEX_BYTES,
+          operatorData: EMPTY_HEX_BYTES,
+        }),
+      )
+        .to.emit(asset, "TransferByPartition")
+        .withArgs(
+          DEFAULT_PARTITION,
+          signer_B.address,
+          signer_A.address,
+          signer_C.address,
+          AMOUNT,
+          EMPTY_HEX_BYTES,
+          EMPTY_HEX_BYTES,
+        );
+
+      expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(
+        initialBalanceA - BigInt(AMOUNT),
+      );
+      expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_C.address)).to.equal(
+        initialBalanceC + BigInt(AMOUNT),
+      );
+    });
+  });
+
+  // ─── operatorRedeemByPartition ────────────────────────────────────────────────
+
+  describe("operatorRedeemByPartition", () => {
+    it("GIVEN an incompatible partition WHEN operatorRedeemByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      await expect(
+        asset
+          .connect(signer_B)
+          .operatorRedeemByPartition(WRONG_PARTITION, signer_A.address, AMOUNT, EMPTY_HEX_BYTES, EMPTY_HEX_BYTES),
+      )
+        .to.be.revertedWithCustomError(asset, "PartitionNotAllowedInSinglePartitionMode")
+        .withArgs(WRONG_PARTITION);
+    });
+
+    it("GIVEN a non-operator caller WHEN operatorRedeemByPartition THEN reverts with InsufficientAllowance", async () => {
+      await expect(
+        asset
+          .connect(signer_B)
+          .operatorRedeemByPartition(DEFAULT_PARTITION, signer_A.address, AMOUNT, EMPTY_HEX_BYTES, EMPTY_HEX_BYTES),
+      ).to.be.revertedWithCustomError(asset, "InsufficientAllowance");
+    });
+
+    it("GIVEN insufficient balance WHEN operatorRedeemByPartition THEN reverts", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+      await expect(
+        asset
+          .connect(signer_B)
+          .operatorRedeemByPartition(DEFAULT_PARTITION, signer_A.address, AMOUNT + 1, EMPTY_HEX_BYTES, EMPTY_HEX_BYTES),
+      ).to.be.reverted;
+    });
+
+    it("GIVEN valid inputs WHEN operatorRedeemByPartition THEN emits RedeemedByPartition and totalSupply decreases", async () => {
+      await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
+
+      const initialSupply = await asset.totalSupplyByPartition(DEFAULT_PARTITION);
+      const initialBalance = await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address);
+
+      await expect(
+        asset
+          .connect(signer_B)
+          .operatorRedeemByPartition(DEFAULT_PARTITION, signer_A.address, AMOUNT, EMPTY_HEX_BYTES, EMPTY_HEX_BYTES),
+      )
+        .to.emit(asset, "RedeemedByPartition")
+        .withArgs(DEFAULT_PARTITION, signer_B.address, signer_A.address, AMOUNT, EMPTY_HEX_BYTES, EMPTY_HEX_BYTES);
+
+      expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(
+        initialBalance - BigInt(AMOUNT),
+      );
+      expect(await asset.totalSupplyByPartition(DEFAULT_PARTITION)).to.equal(initialSupply - BigInt(AMOUNT));
+    });
+  });
+});


### PR DESCRIPTION
This pull request refactors the ERC-1410 per-partition operator functionality by extracting related functions from several contracts and consolidating them into a new dedicated `OperatorByPartitionFacet`. This improves code organization, modularity, and maintainability without breaking existing interfaces or changing function selectors. The update also includes interface changes, registration updates, and new integration tests.

**Operator by partition extraction and refactor:**

- Introduced new files: `IOperatorByPartition.sol`, `OperatorByPartition.sol`, and `OperatorByPartitionFacet.sol`, encapsulating all per-partition operator logic. [[1]](diffhunk://#diff-dce1c2590b9c1c1fbe9b0aef1f62801b2f03d4a9924f515a796538465c0169baR1-R31) [[2]](diffhunk://#diff-d2f089e7c462506c12df33bf0ce2b4e464a1c25564556187fe4245628f753069R1-R95)
- Added the `_OPERATOR_BY_PARTITION_RESOLVER_KEY` constant to `resolverKeys.sol` for facet registration. [[1]](diffhunk://#diff-dce1c2590b9c1c1fbe9b0aef1f62801b2f03d4a9924f515a796538465c0169baR1-R31) [[2]](diffhunk://#diff-a6761447814cc412fd1b009f087d5b68cc0a5e3ad8ef1dd4e34fdd2e6b3b465dR162-R164)

**Contract and interface updates:**

- Removed `authorizeOperatorByPartition`, `revokeOperatorByPartition`, and related functions from `ERC1410TokenHolder`, `ERC1410Read`, and `ERC1410Management` contracts and their interfaces, reducing selector counts. [[1]](diffhunk://#diff-dce1c2590b9c1c1fbe9b0aef1f62801b2f03d4a9924f515a796538465c0169baR1-R31) [[2]](diffhunk://#diff-79bd307caa0f3ccdc866cfee70466a4e0235c4afdff4fc717c4e0c5ae264f570L40-L66) [[3]](diffhunk://#diff-d2065131f105ddca63d8482661f2742c36c833dc7f68b18b5ffff8861d1e88f7L24-L37) [[4]](diffhunk://#diff-de852b031f32eb1ca2181f998724d2901fcc7ac4c6a58a9bc052f5ec14c8542dL16-L23) [[5]](diffhunk://#diff-6f7a12f1d44e1b5b0e0f4c0e4e597361af8f649559ea7e71ba37d9bede882007L25-L37) [[6]](diffhunk://#diff-cafaa302f9b330c8181db871e8f7da1158345268d203e3c9f8b253a77fcda9baL4-L62) [[7]](diffhunk://#diff-751ced9fd73ce3c50b20c3aa64ce857ee4aac8e029465fd011da39981f0b685bL18-L42)
- Updated `IAsset` and `IERC1410` to inherit from the new `IOperatorByPartition` interface, ensuring all per-partition operator functions remain accessible. [[1]](diffhunk://#diff-dce1c2590b9c1c1fbe9b0aef1f62801b2f03d4a9924f515a796538465c0169baR1-R31) [[2]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75R127) [[3]](diffhunk://#diff-40dbee73667a1c027b07f3aba73c9a5f76a07c2e6cb6c8b88fe4201d84435d75L247-R249)

**Configuration and registration:**

- Registered the new `OperatorByPartitionFacet` in `Configuration.ts` and associated configuration scripts. [[1]](diffhunk://#diff-dce1c2590b9c1c1fbe9b0aef1f62801b2f03d4a9924f515a796538465c0169baR1-R31) [[2]](diffhunk://#diff-409dd60ab11b542fadbe019ebe0bae2d62b9a88197c5df9c72dbf6139790278bR92)

**Testing:**

- Added comprehensive integration tests for the new facet, covering authorization, revocation, querying, operator transfers, and operator redemptions.

**Backward compatibility:**

- All 4-byte selectors for affected functions remain unchanged, ensuring existing calls through `IAsset` or `IERC1410` continue to work without modification.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
