### PR TITLE
fix(ci): align mass-payout + bond test with IPrincipal split

### DIFF
--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/principal/principal.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/principal/principal.test.ts
@@ -6,7 +6,7 @@ import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js"
 import { type ResolverProxy, type IAsset } from "@contract-types";
 import { DEFAULT_PARTITION, ATS_ROLES, ZERO, EMPTY_STRING } from "@scripts";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { deployBondTokenFixture, getBondDetails, getDltTimestamp } from "@test";
+import { deployBondTokenFixture, getDltTimestamp } from "@test";
 import { executeRbac, MAX_UINT256 } from "@test";
 import { TIME_PERIODS_S } from "@scripts";
 

--- a/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
+++ b/packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol
@@ -25,6 +25,7 @@ import {
     ICouponSecurityHolders
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/couponSecurityHolders/ICouponSecurityHolders.sol";
 import { IBondRead } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondRead.sol";
+import { IPrincipal } from "@hashgraph/asset-tokenization-contracts/contracts/facets/principal/IPrincipal.sol";
 import { IEquity } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/equity/IEquity.sol";
 import { IDividend } from "@hashgraph/asset-tokenization-contracts/contracts/facets/dividend/IDividend.sol";
 import {
@@ -864,7 +865,7 @@ abstract contract LifeCycleCashFlowStorageWrapper is ILifeCycleCashFlow, HederaT
         address _holder,
         uint8 _paymentTokenDecimals
     ) private view returns (uint256) {
-        IBondRead.PrincipalFor memory principalFor = IBondRead(_asset).getPrincipalFor(_holder);
+        IPrincipal.PrincipalFor memory principalFor = IPrincipal(_asset).getPrincipalFor(_holder);
         return (principalFor.numerator * 10 ** _paymentTokenDecimals) / principalFor.denominator;
     }
 

--- a/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
+++ b/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
@@ -13,6 +13,7 @@ import { IVotingTypes } from "@hashgraph/asset-tokenization-contracts/contracts/
 // solhint-disable max-line-length
 import { IDividendTypes } from "@hashgraph/asset-tokenization-contracts/contracts/facets/dividend/IDividendTypes.sol";
 import { IBondTypes } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondTypes.sol";
+import { IPrincipal } from "@hashgraph/asset-tokenization-contracts/contracts/facets/principal/IPrincipal.sol";
 
 // solhint-disable no-unused-vars
 contract AssetMock is IAssetMock {
@@ -59,7 +60,7 @@ contract AssetMock is IAssetMock {
         holders_[1] = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
     }
 
-    function getPrincipalFor(address) external view returns (IBondTypes.PrincipalFor memory principalFor_) {
+    function getPrincipalFor(address) external view returns (IPrincipal.PrincipalFor memory principalFor_) {
         principalFor_.numerator = _numerator;
         principalFor_.denominator = 1;
     }


### PR DESCRIPTION
## Summary
Restore green CI on `development`. PR #1060 (principal facet split) moved `PrincipalFor` + `getPrincipalFor` from `IBondRead` / `IBondTypes` to the new `IPrincipal` interface; two consumers were missed:

- `packages/ats/contracts/test/.../principal.test.ts` left an unused `getBondDetails` import → 103 ATS Lint error.
- `packages/mass-payout/contracts/contracts/LifeCycleCashFlowStorageWrapper.sol` and `test/testAsset/AssetMock.sol` still reference `IBondRead.PrincipalFor` / `IBondTypes.PrincipalFor` → 101 MP Test fails at `hardhat compile` (HH600 / DeclarationError).

## Verification
- `npm run ats:lint:js` clean
- `npm run ats:lint:sol` clean (warnings only)
- `npm run mass-payout:lint` / `mass-payout:format:check` clean
- `npx hardhat compile` in `packages/mass-payout/contracts` → compiled 14 files, 0 errors