### PR TITLE
fix: [FIND-066] self-transfer of full balance removes user from token holder registry

### DIFF
--- a/.changeset/fix-self-transfer-removes-holder.md
+++ b/.changeset/fix-self-transfer-removes-holder.md
@@ -1,0 +1,9 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix: self-transfer of full balance silently removes holder from registry.
+
+In `beforeTokenTransfer`, a self-transfer (`from == to`) with the full balance caused `removeFrom = true` (full balance transferred) while `addTo = false` (recipient already had balance), triggering `removeTokenHolder(from)` even though the holder still retained their tokens. Any affected holder would be excluded from all future dividend, coupon, and corporate action distributions.
+
+Fix adds an early return at the top of `beforeTokenTransfer` when `from == to`. A self-transfer produces no net balance change, so no snapshot updates, holder registry mutations, or balance adjustments are needed.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -389,6 +389,7 @@ library ERC1410StorageWrapper {
     }
 
     function beforeTokenTransfer(bytes32 partition, address from, address to, uint256 amount) internal {
+        if (from == to) return;
         triggerAndSyncAll(partition, from, to);
 
         bool addTo;

--- a/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
@@ -316,4 +316,44 @@ describe("SecurityHoldersFacet Tests", () => {
       expect(uniqueHolders.size).to.equal(allHolders.length);
     });
   });
+
+  describe("self-transfer holder registry integrity", () => {
+    it("GIVEN a holder with full balance WHEN self-transfer of full balance THEN holder remains in registry", async () => {
+      const tokenAmount = 1000n;
+
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_B.address,
+        value: tokenAmount,
+        data: "0x",
+      });
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+
+      await asset.connect(signer_B).transfer(signer_B.address, tokenAmount);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+      const holders = await asset.getSecurityHolders(0, 10);
+      expect(holders).to.include(signer_B.address);
+      expect(await asset.balanceOf(signer_B.address)).to.equal(tokenAmount);
+    });
+
+    it("GIVEN a holder with full balance WHEN partial self-transfer THEN holder remains in registry", async () => {
+      const tokenAmount = 1000n;
+
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_B.address,
+        value: tokenAmount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_B).transfer(signer_B.address, tokenAmount / 2n);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+      const holders = await asset.getSecurityHolders(0, 10);
+      expect(holders).to.include(signer_B.address);
+      expect(await asset.balanceOf(signer_B.address)).to.equal(tokenAmount);
+    });
+  });
 });


### PR DESCRIPTION
This pull request introduces a fix to ensure that self-transfers (when a token holder transfers tokens to themselves) do not affect the security holders registry or cause unintended side effects. Additionally, new tests are added to verify the correct behavior of the registry during self-transfers.

**Bug fix for self-transfer handling:**

* Updated the `beforeTokenTransfer` function in `ERC1410StorageWrapper` to immediately return if the `from` and `to` addresses are the same, preventing unnecessary registry updates or side effects during self-transfers.

**Test coverage improvements:**

* Added integration tests in `SecurityHoldersFacet` to confirm that self-transfers (both full and partial) do not remove the holder from the registry and that the holder's balance remains correct after the transfer.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
