### PR TITLE
refactor: rename isPaused to paused function and Pause errors and events refactor

### DIFF
--- a/.changeset/paused-function.md
+++ b/.changeset/paused-function.md
@@ -3,4 +3,4 @@
 "@hashgraph/asset-tokenization-sdk": minor
 ---
 
-add paused fucntion to Pause Facet and rename Pause events and errors without Token word
+rename isPaused to paused fucntion in Pause Facet and rename Pause events and errors without Token word

--- a/.changeset/paused-function.md
+++ b/.changeset/paused-function.md
@@ -1,0 +1,6 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+"@hashgraph/asset-tokenization-sdk": minor
+---
+
+add paused fucntion to Pause Facet and rename Pause events and errors without Token word

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "release:ats": "changeset version --ignore '@hashgraph/mass-payout*'",
     "release:mp": "changeset version --ignore '@hashgraph/asset-tokenization-*'",
     "release:preview": "changeset status",
+    "test": "npm run ats:test && npm run mass-payout:test",
     "docs:start": "npm run start --workspace=apps/docs",
     "docs:build": "npm run build --workspace=apps/docs",
     "docs:serve": "npm run serve --workspace=apps/docs",

--- a/packages/ats/contracts/contracts/domain/core/PauseStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/PauseStorageWrapper.sol
@@ -77,10 +77,10 @@ library PauseStorageWrapper {
     }
 
     function checkUnpaused() internal view {
-        if (isPaused()) revert IPause.TokenIsPaused();
+        if (isPaused()) revert IPause.IsPaused();
     }
 
     function checkPaused() internal view {
-        if (!isPaused()) revert IPause.TokenIsUnpaused();
+        if (!isPaused()) revert IPause.IsUnpaused();
     }
 }

--- a/packages/ats/contracts/contracts/facets/compliance/Compliance.sol
+++ b/packages/ats/contracts/contracts/facets/compliance/Compliance.sol
@@ -45,7 +45,7 @@ abstract contract Compliance is IComplianceFacet, Modifiers {
         bytes memory _data
     ) external view override onlyWithoutMultiPartition returns (bool, bytes1, bytes32) {
         if (PauseStorageWrapper.isPaused()) {
-            return (false, Eip1066.PAUSED, IPause.TokenIsPaused.selector);
+            return (false, Eip1066.PAUSED, IPause.IsPaused.selector);
         }
         (bool status, bytes1 statusCode, bytes32 reason, ) = ERC1594StorageWrapper.isAbleToTransferFromByPartition(
             EvmAccessors.getMsgSender(),
@@ -75,7 +75,7 @@ abstract contract Compliance is IComplianceFacet, Modifiers {
         bytes memory _data
     ) external view override onlyWithoutMultiPartition returns (bool, bytes1, bytes32) {
         if (PauseStorageWrapper.isPaused()) {
-            return (false, Eip1066.PAUSED, IPause.TokenIsPaused.selector);
+            return (false, Eip1066.PAUSED, IPause.IsPaused.selector);
         }
         (bool status, bytes1 statusCode, bytes32 reason, ) = ERC1594StorageWrapper.isAbleToTransferFromByPartition(
             _from,

--- a/packages/ats/contracts/contracts/facets/complianceByPartition/ComplianceByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/complianceByPartition/ComplianceByPartition.sol
@@ -28,7 +28,7 @@ abstract contract ComplianceByPartition is IComplianceByPartition {
         bytes calldata _operatorData
     ) external view override returns (bool, bytes1, bytes32) {
         if (PauseStorageWrapper.isPaused()) {
-            return (false, Eip1066.PAUSED, IPause.TokenIsPaused.selector);
+            return (false, Eip1066.PAUSED, IPause.IsPaused.selector);
         }
         (bool status, bytes1 statusCode, bytes32 reason, ) = ERC1594StorageWrapper.isAbleToTransferFromByPartition(
             _from,
@@ -50,7 +50,7 @@ abstract contract ComplianceByPartition is IComplianceByPartition {
         bytes calldata _operatorData
     ) external view override returns (bool, bytes1, bytes32) {
         if (PauseStorageWrapper.isPaused()) {
-            return (false, Eip1066.PAUSED, IPause.TokenIsPaused.selector);
+            return (false, Eip1066.PAUSED, IPause.IsPaused.selector);
         }
         (bool status, bytes1 code, bytes32 reason, ) = ERC1594StorageWrapper.isAbleToRedeemFromByPartition(
             _from,

--- a/packages/ats/contracts/contracts/facets/deactivate/IDeactivate.sol
+++ b/packages/ats/contracts/contracts/facets/deactivate/IDeactivate.sol
@@ -24,7 +24,7 @@ interface IDeactivate {
     /**
      * @notice Sets the token's deactivation flag, retiring the token irreversibly.
      * @dev Requires `DEACTIVATE_ROLE`, the token to be currently unpaused, and the token to be
-     *      currently activated. Reverts with `AccountHasNoRole`, `TokenIsPaused`, or
+     *      currently activated. Reverts with `AccountHasNoRole`, `IsPaused`, or
      *      `Deactivated` respectively when those preconditions fail. The state change is
      *      one-way and cannot be undone.
      */

--- a/packages/ats/contracts/contracts/facets/pause/IPause.sol
+++ b/packages/ats/contracts/contracts/facets/pause/IPause.sol
@@ -19,30 +19,30 @@ interface IPause {
      * @notice Emitted when the token's internal pause flag is set to `true`.
      * @param operator Address of the caller who triggered the pause.
      */
-    event TokenPaused(address indexed operator);
+    event Paused(address indexed operator);
 
     /**
      * @notice Emitted when the token's internal pause flag is cleared to `false`.
      * @param operator Address of the caller who triggered the unpause.
      */
-    event TokenUnpaused(address indexed operator);
+    event Unpaused(address indexed operator);
 
     /**
      * @notice Thrown when an operation that requires the token to be unpaused is attempted while
      *         the token is paused (own flag or any external pause contract).
      */
-    error TokenIsPaused();
+    error IsPaused();
 
     /**
      * @notice Thrown when `unpause` is called while the token's internal pause flag is already
      *         cleared.
      */
-    error TokenIsUnpaused();
+    error IsUnpaused();
 
     /**
      * @notice Sets the token's internal pause flag, blocking all guarded operations.
      * @dev Requires `PAUSER_ROLE` and the token to be currently unpaused. Reverts with
-     *      `TokenIsPaused` if the token is already paused. Emits `TokenPaused`.
+     *      `IsPaused` if the token is already paused. Emits `Paused`.
      * @return success_ True if the token was successfully paused.
      */
     function pause() external returns (bool success_);
@@ -50,7 +50,7 @@ interface IPause {
     /**
      * @notice Clears the token's internal pause flag, restoring guarded operations.
      * @dev Requires `PAUSER_ROLE` and the token's internal flag to be set. Reverts with
-     *      `TokenIsUnpaused` if the internal flag is already cleared. Emits `TokenUnpaused`.
+     *      `IsUnpaused` if the internal flag is already cleared. Emits `Unpaused`.
      *      Note: if any external pause contract remains paused, `isPaused` will still return
      *      `true` after this call.
      * @return success_ True if the internal pause flag was successfully cleared.
@@ -64,4 +64,13 @@ interface IPause {
      * @return True if the token is paused by any source, false otherwise.
      */
     function isPaused() external view returns (bool);
+
+    /**
+     * @notice Checks whether the token is currently paused.
+     * @dev Returns `true` if the token's own pause flag is set, or if any registered external
+     *      pause contract returns `true` from its `isPaused()` call (OR semantics).
+     *      created to be compatible with ERC3643
+     * @return True if the token is paused by any source, false otherwise.
+     */
+    function paused() external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/pause/IPause.sol
+++ b/packages/ats/contracts/contracts/facets/pause/IPause.sol
@@ -61,14 +61,6 @@ interface IPause {
      * @notice Checks whether the token is currently paused.
      * @dev Returns `true` if the token's own pause flag is set, or if any registered external
      *      pause contract returns `true` from its `isPaused()` call (OR semantics).
-     * @return True if the token is paused by any source, false otherwise.
-     */
-    function isPaused() external view returns (bool);
-
-    /**
-     * @notice Checks whether the token is currently paused.
-     * @dev Returns `true` if the token's own pause flag is set, or if any registered external
-     *      pause contract returns `true` from its `isPaused()` call (OR semantics).
      *      created to be compatible with ERC3643
      * @return True if the token is paused by any source, false otherwise.
      */

--- a/packages/ats/contracts/contracts/facets/pause/Pause.sol
+++ b/packages/ats/contracts/contracts/facets/pause/Pause.sol
@@ -32,11 +32,6 @@ abstract contract Pause is IPause, Modifiers {
     }
 
     /// @inheritdoc IPause
-    function isPaused() external view override returns (bool) {
-        return PauseStorageWrapper.isPaused();
-    }
-
-    /// @inheritdoc IPause
     function paused() external view override returns (bool) {
         return PauseStorageWrapper.isPaused();
     }

--- a/packages/ats/contracts/contracts/facets/pause/Pause.sol
+++ b/packages/ats/contracts/contracts/facets/pause/Pause.sol
@@ -20,19 +20,24 @@ abstract contract Pause is IPause, Modifiers {
     /// @inheritdoc IPause
     function pause() external override onlyUnpaused onlyRole(PAUSER_ROLE) returns (bool success_) {
         PauseStorageWrapper.setPause(true);
-        emit IPause.TokenPaused(EvmAccessors.getMsgSender());
+        emit IPause.Paused(EvmAccessors.getMsgSender());
         success_ = true;
     }
 
     /// @inheritdoc IPause
     function unpause() external override onlyRole(PAUSER_ROLE) onlyPaused returns (bool success_) {
         PauseStorageWrapper.setPause(false);
-        emit IPause.TokenUnpaused(EvmAccessors.getMsgSender());
+        emit IPause.Unpaused(EvmAccessors.getMsgSender());
         success_ = true;
     }
 
     /// @inheritdoc IPause
     function isPaused() external view override returns (bool) {
+        return PauseStorageWrapper.isPaused();
+    }
+
+    /// @inheritdoc IPause
+    function paused() external view override returns (bool) {
         return PauseStorageWrapper.isPaused();
     }
 }

--- a/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
+++ b/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
@@ -24,10 +24,11 @@ contract PauseFacet is Pause, IStaticFunctionSelectors {
     /// @inheritdoc IStaticFunctionSelectors
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
+        staticFunctionSelectors_ = new bytes4[](4);
         staticFunctionSelectors_[selectorIndex++] = this.pause.selector;
         staticFunctionSelectors_[selectorIndex++] = this.unpause.selector;
         staticFunctionSelectors_[selectorIndex++] = this.isPaused.selector;
+        staticFunctionSelectors_[selectorIndex++] = this.paused.selector;
     }
 
     /// @inheritdoc IStaticFunctionSelectors

--- a/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
+++ b/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
@@ -24,10 +24,9 @@ contract PauseFacet is Pause, IStaticFunctionSelectors {
     /// @inheritdoc IStaticFunctionSelectors
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
         uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
+        staticFunctionSelectors_ = new bytes4[](3);
         staticFunctionSelectors_[selectorIndex++] = this.pause.selector;
         staticFunctionSelectors_[selectorIndex++] = this.unpause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isPaused.selector;
         staticFunctionSelectors_[selectorIndex++] = this.paused.selector;
     }
 

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-07T13:39:00.543Z
+ * Generated: 2026-05-07T13:43:18.807Z
  * Facets: 122
  * Infrastructure: 2
  *
@@ -10173,11 +10173,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     inheritance: ["Pause", "IStaticFunctionSelectors"],
     methods: [
       {
-        name: "isPaused",
-        signature: { full: "function isPaused() view returns (bool)", canonical: "isPaused()" },
-        selector: "0xb187bd26",
-      },
-      {
         name: "pause",
         signature: { full: "function pause() returns (bool success_)", canonical: "pause()" },
         selector: "0x8456cb59",
@@ -13953,11 +13948,6 @@ export const INFRASTRUCTURE_CONTRACTS: Record<string, ContractDefinition> = {
           canonical: "initialize_BusinessLogicResolver()",
         },
         selector: "0xb86ffa1a",
-      },
-      {
-        name: "isPaused",
-        signature: { full: "function isPaused() view returns (bool)", canonical: "isPaused()" },
-        selector: "0xb187bd26",
       },
       {
         name: "isResolverProxyConfigurationRegistered",

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-07T11:15:12.555Z
+ * Generated: 2026-05-07T13:39:00.543Z
  * Facets: 122
  * Infrastructure: 2
  *
@@ -375,6 +375,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xf50c17aa",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "RolesAndActivesLengthMismatch",
         signature: {
@@ -390,11 +391,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "RolesNotApplied(bytes32[],bool[],address)",
         },
         selector: "0xaa4b6234",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new AccessControlFacet__factory(signer),
@@ -555,11 +551,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
@@ -668,6 +660,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xf180d8f9",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -677,11 +670,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SpenderWithZeroAddress",
         signature: { full: "error SpenderWithZeroAddress()", canonical: "SpenderWithZeroAddress()" },
         selector: "0x80e32d8f",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -988,6 +976,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -1005,11 +994,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -1280,6 +1264,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InputAmountsArrayLengthMismatch()", canonical: "InputAmountsArrayLengthMismatch()" },
         selector: "0x64f13710",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -1289,11 +1274,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new BatchBurnFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -1349,6 +1329,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InputAmountsArrayLengthMismatch()", canonical: "InputAmountsArrayLengthMismatch()" },
         selector: "0x64f13710",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -1358,11 +1339,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new BatchControllerFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -1498,6 +1474,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -1515,11 +1492,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -1586,6 +1558,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InputAmountsArrayLengthMismatch()", canonical: "InputAmountsArrayLengthMismatch()" },
         selector: "0x64f13710",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "MaxSupplyReached",
         signature: { full: "error MaxSupplyReached(uint256 maxSupply)", canonical: "MaxSupplyReached(uint256)" },
@@ -1595,11 +1568,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
         selector: "0x76d08f88",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new BatchMintFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -1643,6 +1611,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InputAmountsArrayLengthMismatch()", canonical: "InputAmountsArrayLengthMismatch()" },
         selector: "0x64f13710",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -1655,11 +1624,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new BatchTransferFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -2169,6 +2133,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x90e55392",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -2194,11 +2159,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -2263,6 +2223,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NewMaxSupplyByPartitionTooHigh",
         signature: {
@@ -2278,11 +2239,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "NewMaxSupplyForPartitionTooLow(bytes32,uint256,uint256)",
         },
         selector: "0x820c68a8",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new CapByPartitionFacet__factory(signer),
@@ -2360,6 +2316,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "MaxSupplyReached",
         signature: { full: "error MaxSupplyReached(uint256 maxSupply)", canonical: "MaxSupplyReached(uint256)" },
@@ -2401,11 +2358,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "NewMaxSupplyTooLow(uint256,uint256)",
         },
         selector: "0x98c2b03b",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new CapFacet__factory(signer),
@@ -2740,6 +2692,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -2755,11 +2708,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -2987,11 +2935,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "WrongClearingId",
         signature: { full: "error WrongClearingId()", canonical: "WrongClearingId()" },
@@ -3175,6 +3119,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -3190,11 +3135,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -3311,15 +3251,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
         selector: "0x76d08f88",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new ComplianceFacet__factory(signer),
@@ -3436,6 +3372,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -3453,11 +3390,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -3698,6 +3630,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xefafde54",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -3707,11 +3640,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -3892,6 +3820,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error IsNotEscrow()", canonical: "IsNotEscrow()" },
         selector: "0xf86f2a37",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -3917,11 +3846,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "TokenIsNotControllable",
         signature: { full: "error TokenIsNotControllable()", canonical: "TokenIsNotControllable()" },
         selector: "0xf4b7b072",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WrongExpirationTimestamp",
@@ -4047,15 +3971,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ListedAccount",
         signature: { full: "error ListedAccount(address account)", canonical: "ListedAccount(address)" },
         selector: "0x1a4a04ba",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnlistedAccount",
@@ -4215,11 +4135,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new CoreFacet__factory(signer),
   },
@@ -4577,6 +4493,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "SnapshotIdDoesNotExists",
         signature: {
@@ -4589,11 +4506,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -4828,11 +4740,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error Deactivated()", canonical: "Deactivated()" },
         selector: "0x1142a68c",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new DeactivateFacet__factory(signer),
   },
@@ -5113,6 +5021,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "SnapshotIdDoesNotExists",
         signature: {
@@ -5125,11 +5034,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -5297,11 +5201,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       { name: "EmptyHASH", signature: { full: "error EmptyHASH()", canonical: "EmptyHASH()" }, selector: "0x402e72be" },
       { name: "EmptyName", signature: { full: "error EmptyName()", canonical: "EmptyName()" }, selector: "0x2ef13105" },
       { name: "EmptyURI", signature: { full: "error EmptyURI()", canonical: "EmptyURI()" }, selector: "0xd07b00d6" },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new DocumentationFacet__factory(signer),
   },
@@ -5564,6 +5464,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x4b800e46",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -5573,11 +5474,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SpenderWithZeroAddress",
         signature: { full: "error SpenderWithZeroAddress()", canonical: "SpenderWithZeroAddress()" },
         selector: "0x80e32d8f",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -5758,11 +5654,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x7f07449b",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
@@ -6030,15 +5922,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbd29da3f",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ListedControlList",
         signature: { full: "error ListedControlList(address controlList)", canonical: "ListedControlList(address)" },
         selector: "0x67a1e319",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnlistedControlList",
@@ -6197,15 +6085,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x8a85ec02",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ListedKycList",
         signature: { full: "error ListedKycList(address kycList)", canonical: "ListedKycList(address)" },
         selector: "0x91c6b79d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnlistedKycList",
@@ -6353,15 +6237,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x2d931b36",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ListedPause",
         signature: { full: "error ListedPause(address pause)", canonical: "ListedPause(address)" },
         selector: "0x267b9ec9",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnlistedPause",
@@ -6445,11 +6325,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InterestRateIsFixed()", canonical: "InterestRateIsFixed()" },
         selector: "0x849d4eb8",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new FixedRateFacet__factory(signer),
     timeTravelFactory: (signer) => new FixedRateFacetTimeTravel__factory(signer),
@@ -6663,6 +6539,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -6680,11 +6557,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -7026,6 +6898,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error IsNotEscrow()", canonical: "IsNotEscrow()" },
         selector: "0xf86f2a37",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -7054,11 +6927,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -7323,11 +7191,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new IdentityFacet__factory(signer),
   },
@@ -7558,11 +7422,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
         selector: "0x68eba14f",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "WrongImpactDataValues",
         signature: {
@@ -7670,15 +7530,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x8914d40b",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "KpiDataAlreadyExists",
         signature: { full: "error KpiDataAlreadyExists(uint256 date)", canonical: "KpiDataAlreadyExists(uint256)" },
         selector: "0x74efd82c",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -7776,15 +7632,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x8914d40b",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "KpiDataAlreadyExists",
         signature: { full: "error KpiDataAlreadyExists(uint256 date)", canonical: "KpiDataAlreadyExists(uint256)" },
         selector: "0x74efd82c",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -7953,15 +7805,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidZeroAddress()", canonical: "InvalidZeroAddress()" },
         selector: "0xf6b2911f",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "KycIsNotGranted",
         signature: { full: "error KycIsNotGranted()", canonical: "KycIsNotGranted()" },
         selector: "0xd5209e15",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -8047,11 +7895,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "WrongDates",
         signature: {
@@ -8319,11 +8163,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xfc6c68ca",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ZeroAddressNotAllowed",
         signature: { full: "error ZeroAddressNotAllowed()", canonical: "ZeroAddressNotAllowed()" },
@@ -8535,6 +8375,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "LockExpirationNotReached",
         signature: { full: "error LockExpirationNotReached()", canonical: "LockExpirationNotReached()" },
@@ -8560,11 +8401,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -8735,6 +8571,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "LockExpirationNotReached",
         signature: { full: "error LockExpirationNotReached()", canonical: "LockExpirationNotReached()" },
@@ -8765,11 +8602,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -8905,6 +8737,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -8925,11 +8758,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -9080,6 +8908,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "SnapshotIdDoesNotExists",
         signature: {
@@ -9092,11 +8921,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -9161,11 +8985,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new MetadataFacet__factory(signer),
   },
@@ -9206,6 +9026,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x90e55392",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "MaxSupplyReached",
         signature: { full: "error MaxSupplyReached(uint256 maxSupply)", canonical: "MaxSupplyReached(uint256)" },
@@ -9226,11 +9047,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionNotAllowedInSinglePartitionMode(bytes32)",
         },
         selector: "0xb96d9539",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -9306,6 +9122,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "MaxSupplyReached",
         signature: { full: "error MaxSupplyReached(uint256 maxSupply)", canonical: "MaxSupplyReached(uint256)" },
@@ -9315,11 +9132,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
         selector: "0x76d08f88",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new MintFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -9544,6 +9356,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -9564,11 +9377,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -9758,6 +9566,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -9773,11 +9582,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -9978,6 +9782,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -9993,11 +9798,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -10102,11 +9902,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x10210dec",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
     ],
     factory: (signer) => new OperatorFacet__factory(signer),
   },
@@ -10277,6 +10073,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error IsNotEscrow()", canonical: "IsNotEscrow()" },
         selector: "0xf86f2a37",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -10305,11 +10102,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "Unauthorized",
@@ -10391,6 +10183,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8456cb59",
       },
       {
+        name: "paused",
+        signature: { full: "function paused() view returns (bool)", canonical: "paused()" },
+        selector: "0x5c975abb",
+      },
+      {
         name: "unpause",
         signature: { full: "function unpause() returns (bool success_)", canonical: "unpause()" },
         selector: "0x3f4ba83a",
@@ -10398,14 +10195,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     events: [
       {
-        name: "TokenPaused",
-        signature: { full: "event TokenPaused(address indexed operator)", canonical: "TokenPaused(address)" },
-        topic0: "0xf017c0de579727a3cd3ee18077ee8b4c43bf21892985952d1d5a0d52f983502d",
+        name: "Paused",
+        signature: { full: "event Paused(address indexed operator)", canonical: "Paused(address)" },
+        topic0: "0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258",
       },
       {
-        name: "TokenUnpaused",
-        signature: { full: "event TokenUnpaused(address indexed operator)", canonical: "TokenUnpaused(address)" },
-        topic0: "0xf38578ed892ce2ce655ca8ae03c73464ad74915a1331a9b4085e637534daeedf",
+        name: "Unpaused",
+        signature: { full: "event Unpaused(address indexed operator)", canonical: "Unpaused(address)" },
+        topic0: "0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa",
       },
     ],
     errors: [
@@ -10425,15 +10222,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
-      {
-        name: "TokenIsUnpaused",
-        signature: { full: "error TokenIsUnpaused()", canonical: "TokenIsUnpaused()" },
-        selector: "0x72058d69",
+        name: "IsUnpaused",
+        signature: { full: "error IsUnpaused()", canonical: "IsUnpaused()" },
+        selector: "0xff1e9666",
       },
     ],
     factory: (signer) => new PauseFacet__factory(signer),
@@ -10583,6 +10376,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ProceedRecipientAlreadyExists",
         signature: {
@@ -10598,11 +10392,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "ProceedRecipientNotFound(address)",
         },
         selector: "0x664dc89c",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -10735,6 +10524,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ProceedRecipientAlreadyExists",
         signature: {
@@ -10750,11 +10540,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "ProceedRecipientNotFound(address)",
         },
         selector: "0x664dc89c",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -10887,6 +10672,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ProceedRecipientAlreadyExists",
         signature: {
@@ -10902,11 +10688,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "ProceedRecipientNotFound(address)",
         },
         selector: "0x664dc89c",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "ZeroAddressNotAllowed",
@@ -10981,15 +10762,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xa1180aad",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new ProtectedByPartitionFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -11188,15 +10965,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -11399,15 +11172,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -11614,6 +11383,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error IsNotEscrow()", canonical: "IsNotEscrow()" },
         selector: "0xf86f2a37",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
@@ -11631,11 +11401,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -11781,6 +11546,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreProtected",
         signature: { full: "error PartitionsAreProtected()", canonical: "PartitionsAreProtected()" },
@@ -11798,11 +11564,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "PartitionsAreUnProtected",
         signature: { full: "error PartitionsAreUnProtected()", canonical: "PartitionsAreUnProtected()" },
         selector: "0x05681565",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new ProtectedPartitionsFacet__factory(signer),
@@ -12089,11 +11850,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
@@ -12177,11 +11934,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
@@ -12264,11 +12017,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
       },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
-      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
@@ -12470,6 +12219,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "SnapshotIdDoesNotExists",
         signature: {
@@ -12482,11 +12232,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -12610,15 +12355,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error AccountIsNotIssuer(address issuer)", canonical: "AccountIsNotIssuer(address)" },
         selector: "0xcd324f53",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "ListedIssuer",
         signature: { full: "error ListedIssuer(address issuer)", canonical: "ListedIssuer(address)" },
         selector: "0xcb2beece",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnlistedIssuer",
@@ -12728,6 +12469,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x4f56f79f",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotExistingProject",
         signature: { full: "error NotExistingProject(address project)", canonical: "NotExistingProject(address)" },
@@ -12740,11 +12482,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "ProvidedListsLengthMismatch(uint256,uint256)",
         },
         selector: "0x4470462b",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
     ],
     factory: (signer) => new SustainabilityPerformanceTargetRateFacet__factory(signer),
@@ -12952,6 +12689,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
         signature: {
@@ -12980,11 +12718,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -13092,6 +12825,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -13117,11 +12851,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -13230,6 +12959,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -13255,11 +12985,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -13368,6 +13093,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -13393,11 +13119,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -13506,6 +13227,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -13531,11 +13253,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -13771,6 +13488,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x5d6824c4",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },
@@ -13783,11 +13501,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "PartitionsAreProtectedAndNoRole(address,bytes32)",
         },
         selector: "0x55347310",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "WalletRecovered",
@@ -13888,6 +13601,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
         selector: "0xb7d09497",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "SnapshotIdDoesNotExists",
         signature: {
@@ -13900,11 +13614,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
-      },
-      {
-        name: "TokenIsPaused",
-        signature: { full: "error TokenIsPaused()", canonical: "TokenIsPaused()" },
-        selector: "0x649815a5",
       },
       {
         name: "UnexpectedError",
@@ -14262,6 +13971,11 @@ export const INFRASTRUCTURE_CONTRACTS: Record<string, ContractDefinition> = {
         name: "pause",
         signature: { full: "function pause() returns (bool success_)", canonical: "pause()" },
         selector: "0x8456cb59",
+      },
+      {
+        name: "paused",
+        signature: { full: "function paused() view returns (bool)", canonical: "paused()" },
+        selector: "0x5c975abb",
       },
       {
         name: "registerBusinessLogics",

--- a/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
@@ -87,41 +87,41 @@ describe("Access Control Tests", () => {
       .withArgs(3, 6);
   });
 
-  it("GIVEN a paused Token WHEN grantRole THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN grantRole THEN transaction fails with IsPaused", async () => {
     await asset.connect(signer_B).pause();
 
     await expect(
       asset.connect(deployer).grantRole(ATS_ROLES.PAUSER_ROLE, unknownSigner.address),
-    ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
-  it("GIVEN a paused Token WHEN revokeRole THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN revokeRole THEN transaction fails with IsPaused", async () => {
     await asset.connect(signer_B).pause();
 
     await expect(
       asset.connect(deployer).revokeRole(ATS_ROLES.PAUSER_ROLE, unknownSigner.address),
-    ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
-  it("GIVEN a paused Token WHEN renounce THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN renounce THEN transaction fails with IsPaused", async () => {
     // Pausing the token
     await asset.connect(signer_B).pause();
 
     // revoke role fails
     await expect(asset.connect(deployer).renounceRole(ATS_ROLES.PAUSER_ROLE)).to.be.revertedWithCustomError(
       asset,
-      "TokenIsPaused",
+      "IsPaused",
     );
   });
 
-  it("GIVEN an paused Token WHEN applyRoles THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN an paused Token WHEN applyRoles THEN transaction fails with IsPaused", async () => {
     // Pausing the token
     await asset.connect(signer_B).pause();
 
     // revoke role fails
     await expect(
       asset.connect(signer_B).applyRoles([ATS_ROLES.DEFAULT_ADMIN_ROLE], [true], unknownSigner.address),
-    ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN an account with administrative role WHEN grantRole THEN transaction succeeds", async () => {

--- a/packages/ats/contracts/test/contracts/integration/adjustBalances/adjustBalancesFacet.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/adjustBalances/adjustBalancesFacet.test.ts
@@ -77,12 +77,12 @@ describe("AdjustBalancesFacet Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN a paused Token WHEN setScheduledBalanceAdjustment THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setScheduledBalanceAdjustment THEN transaction fails with IsPaused", async () => {
       await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
       await expect(
         asset.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an account with corporateActions role WHEN setScheduledBalanceAdjustment with invalid timestamp THEN transaction fails with WrongTimestamp", async () => {
@@ -191,14 +191,14 @@ describe("AdjustBalancesFacet Tests", () => {
         );
       });
 
-      it("GIVEN a paused Token WHEN cancelScheduledBalanceAdjustment THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN cancelScheduledBalanceAdjustment THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_B.address);
         await asset.connect(signer_B).setScheduledBalanceAdjustment(balanceAdjustmentData);
         await asset.connect(signer_B).pause();
 
         await expect(asset.connect(signer_B).cancelScheduledBalanceAdjustment(1)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
@@ -393,12 +393,12 @@ describe("AdjustBalancesFacet Tests", () => {
       );
     });
 
-    it("GIVEN a paused Token WHEN adjustBalances THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN adjustBalances THEN transaction fails with IsPaused", async () => {
       await grantRoleAndPauseToken(asset, ATS_ROLES.ADJUSTMENT_BALANCE_ROLE, signer_A, signer_B, signer_C.address);
 
       await expect(asset.connect(signer_C).adjustBalances(adjustFactor, adjustDecimals)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 
@@ -491,12 +491,12 @@ describe("AdjustBalancesFacet Tests", () => {
   });
 
   describe("triggerAndSyncAll", () => {
-    it("GIVEN a paused token WHEN triggerAndSyncAll THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN triggerAndSyncAll THEN transaction fails with IsPaused", async () => {
       await asset.connect(signer_B).pause();
 
       await expect(
         asset.connect(signer_A).triggerAndSyncAll(DEFAULT_PARTITION, signer_A.address, ethers.ZeroAddress),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an unpaused token with elapsed pending adjustment WHEN triggerAndSyncAll THEN pending adjustment is applied", async () => {

--- a/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
@@ -111,12 +111,9 @@ describe("Allowance Facet Tests", () => {
         expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(amount / 2);
       });
 
-      it("GIVEN a paused token WHEN approve THEN reverts with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN approve THEN reverts with IsPaused", async () => {
         await asset.connect(signer_B).pause();
-        await expect(assetSignerC.approve(signer_D.address, amount)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+        await expect(assetSignerC.approve(signer_D.address, amount)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN a blacklisted caller WHEN approve THEN reverts with AccountIsBlocked", async () => {
@@ -152,11 +149,11 @@ describe("Allowance Facet Tests", () => {
         expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(amount / 2);
       });
 
-      it("GIVEN a paused token WHEN increaseAllowance THEN reverts with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN increaseAllowance THEN reverts with IsPaused", async () => {
         await asset.connect(signer_B).pause();
         await expect(assetSignerC.increaseAllowance(signer_D.address, amount)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
@@ -219,11 +216,11 @@ describe("Allowance Facet Tests", () => {
         expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(amount / 2);
       });
 
-      it("GIVEN a paused token WHEN decreaseAllowance THEN reverts with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN decreaseAllowance THEN reverts with IsPaused", async () => {
         await asset.connect(signer_B).pause();
         await expect(assetSignerC.decreaseAllowance(signer_D.address, amount)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 

--- a/packages/ats/contracts/test/contracts/integration/batchBurn/batchBurn.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchBurn/batchBurn.test.ts
@@ -137,7 +137,7 @@ describe("BatchBurn Tests", () => {
       );
     });
 
-    it("GIVEN a paused token WHEN batchBurn THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN batchBurn THEN transaction fails with IsPaused", async () => {
       await asset.pause();
 
       const userAddresses = [signer_D.address];
@@ -145,7 +145,7 @@ describe("BatchBurn Tests", () => {
 
       await expect(asset.connect(signer_A).batchBurn(userAddresses, amounts)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/batchController/batchController.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchController/batchController.test.ts
@@ -151,7 +151,7 @@ describe("BatchController Tests", () => {
         );
       });
 
-      it("GIVEN a paused token WHEN batchForcedTransfer THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN batchForcedTransfer THEN transaction fails with IsPaused", async () => {
         await asset.pause();
 
         const fromList = [signer_F.address];
@@ -160,7 +160,7 @@ describe("BatchController Tests", () => {
 
         await expect(
           asset.connect(signer_A).batchForcedTransfer(fromList, toList, amounts),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/batchFreeze/batchFreeze.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchFreeze/batchFreeze.test.ts
@@ -117,7 +117,7 @@ describe("BatchFreeze Tests", () => {
         );
       });
 
-      it("GIVEN paused token WHEN batchSetAddressFrozen THEN fails with TokenIsPaused", async () => {
+      it("GIVEN paused token WHEN batchSetAddressFrozen THEN fails with IsPaused", async () => {
         const userAddresses = [signer_D.address, signer_E.address];
         // grant KYC to signer_A.address
         await asset.connect(signer_B).grantKyc(signer_A.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_E.address);
@@ -127,7 +127,7 @@ describe("BatchFreeze Tests", () => {
         // First, freeze the addresses
         await expect(asset.batchSetAddressFrozen(userAddresses, [true, true])).to.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
@@ -300,23 +300,23 @@ describe("BatchFreeze Tests", () => {
         await asset.pause();
       });
 
-      it("GIVEN a paused token WHEN batchFreezePartialTokens THEN transactions revert with TokenIsPaused error", async () => {
+      it("GIVEN a paused token WHEN batchFreezePartialTokens THEN transactions revert with IsPaused error", async () => {
         const userAddresses = [signer_D.address, signer_E.address];
         const amounts = [100, 100];
 
         await expect(asset.batchFreezePartialTokens(userAddresses, amounts)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused token WHEN batchUnfreezePartialTokens THEN transactions revert with TokenIsPaused error", async () => {
+      it("GIVEN a paused token WHEN batchUnfreezePartialTokens THEN transactions revert with IsPaused error", async () => {
         const userAddresses = [signer_D.address, signer_E.address];
         const amounts = [100, 100];
 
         await expect(asset.batchUnfreezePartialTokens(userAddresses, amounts)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
     });

--- a/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
@@ -129,14 +129,14 @@ describe("BatchMint Tests", () => {
         );
       });
 
-      it("GIVEN a paused token WHEN batchMint THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN batchMint THEN transaction fails with IsPaused", async () => {
         await asset.pause();
 
         const mintAmount = AMOUNT / 2;
         const toList = [signer_D.address];
         const amounts = [mintAmount];
 
-        await expect(asset.batchMint(toList, amounts)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        await expect(asset.batchMint(toList, amounts)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
@@ -158,7 +158,7 @@ describe("BatchTransfer Tests", () => {
         );
       });
 
-      it("GIVEN a paused token WHEN batchTransfer THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN batchTransfer THEN transaction fails with IsPaused", async () => {
         await asset.pause();
 
         const toList = [signer_F.address];
@@ -166,7 +166,7 @@ describe("BatchTransfer Tests", () => {
 
         await expect(asset.connect(signer_E).batchTransfer(toList, amounts)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 

--- a/packages/ats/contracts/test/contracts/integration/burn/burn.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/burn/burn.test.ts
@@ -159,9 +159,9 @@ describe("Burn Tests", () => {
         expect(await asset.totalSupplyByPartition(DEFAULT_PARTITION)).to.be.equal(AMOUNT / 2);
       });
 
-      it("GIVEN a paused token WHEN attempting to burn TokenIsPaused error", async () => {
+      it("GIVEN a paused token WHEN attempting to burn IsPaused error", async () => {
         await asset.connect(signer_B).pause();
-        await expect(asset.burn(signer_A.address, AMOUNT)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        await expect(asset.burn(signer_A.address, AMOUNT)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN an account without CONTROLLER_ROLE or AGENT_ROLE WHEN burn THEN transaction fails with AccountHasNoRole", async () => {
@@ -196,13 +196,10 @@ describe("Burn Tests", () => {
         expect(await asset.totalSupplyByPartition(DEFAULT_PARTITION)).to.be.equal(AMOUNT / 2);
       });
 
-      it("GIVEN a paused Token WHEN redeem THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN redeem THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_E.address);
         await asset.connect(signer_B).pause();
-        await expect(asset.connect(signer_E).redeem(AMOUNT, DATA)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+        await expect(asset.connect(signer_E).redeem(AMOUNT, DATA)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN blocked account WHEN redeem THEN transaction fails with AccountIsBlocked", async () => {
@@ -257,12 +254,12 @@ describe("Burn Tests", () => {
         expect(await asset.totalSupplyByPartition(DEFAULT_PARTITION)).to.be.equal(AMOUNT / 2);
       });
 
-      it("GIVEN a paused Token WHEN redeemFrom THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN redeemFrom THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_E.address);
         await asset.connect(signer_B).pause();
         await expect(
           asset.connect(signer_D).redeemFrom(signer_E.address, AMOUNT / 2, DATA),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN blocked accounts WHEN redeemFrom THEN transaction fails with AccountIsBlocked", async () => {

--- a/packages/ats/contracts/test/contracts/integration/burnByPartition/burnByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/burnByPartition/burnByPartition.test.ts
@@ -91,12 +91,12 @@ describe("BurnByPartitionFacet Tests", () => {
         .withArgs(WRONG_PARTITION);
     });
 
-    it("GIVEN a paused token WHEN redeemByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN redeemByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_C).pause();
 
       await expect(
         asset.connect(signer_E).redeemByPartition(DEFAULT_PARTITION, AMOUNT, EMPTY_HEX_BYTES),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN insufficient balance WHEN redeemByPartition THEN reverts", async () => {

--- a/packages/ats/contracts/test/contracts/integration/cap/cap.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/cap/cap.test.ts
@@ -97,12 +97,9 @@ describe("Cap Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setMaxSupply THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setMaxSupply THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
-      await expect(asset.connect(signer_C).setMaxSupply(maxSupply)).to.be.revertedWithCustomError(
-        asset,
-        "TokenIsPaused",
-      );
+      await expect(asset.connect(signer_C).setMaxSupply(maxSupply)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/capByPartition/capByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/capByPartition/capByPartition.test.ts
@@ -71,11 +71,11 @@ describe("CapByPartition Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setMaxSupplyByPartition THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setMaxSupplyByPartition THEN transaction fails with IsPaused", async () => {
       // transfer from with data fails
       await expect(
         asset.connect(signer_C).setMaxSupplyByPartition(_PARTITION_ID_1, maxSupplyByPartition),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -119,7 +119,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
     });
 
-    it("GIVEN a paused token WHEN clearingRedeemByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN clearingRedeemByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_D).pause();
       const clearingOperation = {
         partition: _DEFAULT_PARTITION,
@@ -128,7 +128,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN clearing deactivated WHEN clearingRedeemByPartition THEN reverts with ClearingIsDisabled", async () => {
@@ -249,7 +249,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
     });
 
-    it("GIVEN a paused token WHEN clearingRedeemFromByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN clearingRedeemFromByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_D).pause();
       const clearingOperationFrom = {
         clearingOperation: {
@@ -262,7 +262,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a recovered sender WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
@@ -458,7 +458,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
     });
 
-    it("GIVEN a paused token WHEN clearingTransferByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN clearingTransferByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_D).pause();
       const clearingOperation = {
         partition: _DEFAULT_PARTITION,
@@ -467,7 +467,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN clearing deactivated WHEN clearingTransferByPartition THEN reverts with ClearingIsDisabled", async () => {
@@ -616,7 +616,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
     });
 
-    it("GIVEN a paused token WHEN clearingTransferFromByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN clearingTransferFromByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_D).pause();
       const clearingOperationFrom = {
         clearingOperation: {
@@ -629,7 +629,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN clearing deactivated WHEN clearingTransferFromByPartition THEN reverts with ClearingIsDisabled", async () => {
@@ -885,7 +885,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
     });
 
-    it("GIVEN a paused token WHEN approveClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN approveClearingOperationByPartition THEN reverts with IsPaused", async () => {
       const clearingOperation = {
         partition: _DEFAULT_PARTITION,
         expirationTimestamp: EXPIRATION_TIMESTAMP,
@@ -901,7 +901,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_A).approveClearingOperationByPartition(identifier),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN no CLEARING_VALIDATOR_ROLE WHEN approveClearingOperationByPartition THEN reverts with AccountHasNoRole", async () => {
@@ -1017,7 +1017,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
     });
 
-    it("GIVEN a paused token WHEN cancelClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN cancelClearingOperationByPartition THEN reverts with IsPaused", async () => {
       const clearingOperation = {
         partition: _DEFAULT_PARTITION,
         expirationTimestamp: EXPIRATION_TIMESTAMP,
@@ -1033,7 +1033,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN no CLEARING_VALIDATOR_ROLE WHEN cancelClearingOperationByPartition THEN reverts with AccountHasNoRole", async () => {
@@ -1292,7 +1292,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
     });
 
-    it("GIVEN a paused token WHEN reclaimClearingOperationByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN reclaimClearingOperationByPartition THEN reverts with IsPaused", async () => {
       const clearingOperation = {
         partition: _DEFAULT_PARTITION,
         expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
@@ -1309,7 +1309,7 @@ describe("ClearingByPartitionFacet Tests", () => {
       };
       await expect(
         asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN clearing deactivated WHEN reclaimClearingOperationByPartition THEN reverts with ClearingIsDisabled", async () => {

--- a/packages/ats/contracts/test/contracts/integration/clearingHoldByPartition/clearingHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingHoldByPartition/clearingHoldByPartition.test.ts
@@ -180,11 +180,11 @@ describe("ClearingHoldByPartitionFacet Tests", () => {
       });
 
       describe("onlyUnpaused modifier", () => {
-        it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+        it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
           await asset.connect(signer_D).pause();
           await expect(
             asset.connect(signer_A).clearingCreateHoldByPartition(clearingOperation, hold),
-          ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+          ).to.be.revertedWithCustomError(asset, "IsPaused");
         });
       });
 
@@ -306,11 +306,11 @@ describe("ClearingHoldByPartitionFacet Tests", () => {
       });
 
       describe("onlyUnpaused modifier", () => {
-        it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+        it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with IsPaused", async () => {
           await asset.connect(signer_D).pause();
           await expect(
             asset.connect(signer_B).clearingCreateHoldFromByPartition(clearingOperationFrom, hold),
-          ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+          ).to.be.revertedWithCustomError(asset, "IsPaused");
         });
       });
 

--- a/packages/ats/contracts/test/contracts/integration/compliance/compliance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/compliance/compliance.test.ts
@@ -143,12 +143,12 @@ describe("Compliance Tests", () => {
         expect(await asset.connect(signer_C).canTransfer(signer_D.address, AMOUNT, DATA)).to.be.deep.equal([
           false,
           EIP1066_CODES.PAUSED,
-          getSelector(asset, "TokenIsPaused"),
+          getSelector(asset, "IsPaused"),
         ]);
 
         expect(
           await asset.connect(signer_C).canTransferFrom(signer_E.address, signer_D.address, AMOUNT, DATA),
-        ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "TokenIsPaused")]);
+        ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "IsPaused")]);
       });
     });
 
@@ -360,11 +360,11 @@ describe("Compliance Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN a paused token WHEN setCompliance THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN setCompliance THEN transaction fails with IsPaused", async () => {
       await asset.connect(signer_B).pause();
       await expect(asset.setCompliance(complianceMock.target as string)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/complianceByPartition/complianceByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/complianceByPartition/complianceByPartition.test.ts
@@ -77,14 +77,14 @@ describe("ComplianceByPartition Tests", () => {
   });
 
   describe("canTransferByPartition", () => {
-    it("GIVEN a paused token WHEN canTransferByPartition THEN returns PAUSED with TokenIsPaused selector", async () => {
+    it("GIVEN a paused token WHEN canTransferByPartition THEN returns PAUSED with IsPaused selector", async () => {
       await asset.connect(signer_B).pause();
 
       expect(
         await asset
           .connect(signer_C)
           .canTransferByPartition(signer_C.address, signer_D.address, _PARTITION_ID_1, AMOUNT, DATA, OPERATOR_DATA),
-      ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "TokenIsPaused")]);
+      ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "IsPaused")]);
     });
 
     it("GIVEN clearing is active WHEN canTransferByPartition THEN returns UNAVAILABLE with ClearingIsActivated selector", async () => {
@@ -222,14 +222,14 @@ describe("ComplianceByPartition Tests", () => {
   });
 
   describe("canRedeemByPartition", () => {
-    it("GIVEN a paused token WHEN canRedeemByPartition THEN returns PAUSED with TokenIsPaused selector", async () => {
+    it("GIVEN a paused token WHEN canRedeemByPartition THEN returns PAUSED with IsPaused selector", async () => {
       await asset.connect(signer_B).pause();
 
       expect(
         await asset
           .connect(signer_C)
           .canRedeemByPartition(signer_C.address, _PARTITION_ID_1, AMOUNT, DATA, OPERATOR_DATA),
-      ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "TokenIsPaused")]);
+      ).to.be.deep.equal([false, EIP1066_CODES.PAUSED, getSelector(asset, "IsPaused")]);
     });
 
     it("GIVEN clearing is active WHEN canRedeemByPartition THEN returns UNAVAILABLE with ClearingIsActivated selector", async () => {

--- a/packages/ats/contracts/test/contracts/integration/controlList/controlList.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/controlList/controlList.test.ts
@@ -37,29 +37,39 @@ describe("Control List Tests", () => {
   });
 
   it("GIVEN an initialized contract WHEN trying to initialize it again THEN transaction fails with AlreadyInitialized", async () => {
-    await expect(asset.initializeControlList(true)).to.be.rejectedWith("AlreadyInitialized");
+    await expect(asset.initializeControlList(true)).to.be.revertedWithCustomError(asset, "AlreadyInitialized");
   });
 
   it("GIVEN an account without controlList role WHEN addToControlList THEN transaction fails with AccountHasNoRole", async () => {
-    await expect(asset.connect(signer_B).addToControlList(signer_C.address)).to.be.rejectedWith("AccountHasNoRole");
-  });
-
-  it("GIVEN an account without controlList role WHEN removeFromControlList THEN transaction fails with AccountHasNoRole", async () => {
-    await expect(asset.connect(signer_B).removeFromControlList(signer_C.address)).to.be.rejectedWith(
+    await expect(asset.connect(signer_B).addToControlList(signer_C.address)).to.be.revertedWithCustomError(
+      asset,
       "AccountHasNoRole",
     );
   });
 
-  it("GIVEN a paused Token WHEN addToControlList THEN transaction fails with TokenIsPaused", async () => {
-    await grantRoleAndPauseToken(asset, ATS_ROLES.CONTROL_LIST_ROLE, signer_A, signer_B, signer_C.address);
-
-    await expect(asset.connect(signer_C).addToControlList(signer_D.address)).to.be.rejectedWith("TokenIsPaused");
+  it("GIVEN an account without controlList role WHEN removeFromControlList THEN transaction fails with AccountHasNoRole", async () => {
+    await expect(asset.connect(signer_B).removeFromControlList(signer_C.address)).to.be.revertedWithCustomError(
+      asset,
+      "AccountHasNoRole",
+    );
   });
 
-  it("GIVEN a paused Token WHEN removeFromControlList THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN addToControlList THEN transaction fails with IsPaused", async () => {
     await grantRoleAndPauseToken(asset, ATS_ROLES.CONTROL_LIST_ROLE, signer_A, signer_B, signer_C.address);
 
-    await expect(asset.connect(signer_C).removeFromControlList(signer_D.address)).to.be.rejectedWith("TokenIsPaused");
+    await expect(asset.connect(signer_C).addToControlList(signer_D.address)).to.be.revertedWithCustomError(
+      asset,
+      "IsPaused",
+    );
+  });
+
+  it("GIVEN a paused Token WHEN removeFromControlList THEN transaction fails with IsPaused", async () => {
+    await grantRoleAndPauseToken(asset, ATS_ROLES.CONTROL_LIST_ROLE, signer_A, signer_B, signer_C.address);
+
+    await expect(asset.connect(signer_C).removeFromControlList(signer_D.address)).to.be.revertedWithCustomError(
+      asset,
+      "IsPaused",
+    );
   });
 
   it("GIVEN an account with controlList role WHEN addToControlList and removeFromControlList THEN transaction succeeds", async () => {

--- a/packages/ats/contracts/test/contracts/integration/controller/controller.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/controller/controller.test.ts
@@ -73,21 +73,21 @@ describe("Controller Tests", () => {
         await grantRoleAndPauseToken(asset, ATS_ROLES.CONTROLLER_ROLE, signer_A, signer_B, signer_C.address);
       });
 
-      it("GIVEN a paused Token WHEN controllerTransfer THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN controllerTransfer THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).controllerTransfer(signer_D.address, signer_E.address, amount, "0x", "0x"),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN controllerRedeem THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN controllerRedeem THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).controllerRedeem(signer_D.address, amount, "0x", "0x"),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN attempting to addAgent or removeAgent THEN transactions revert with TokenIsPaused error", async () => {
-        await expect(asset.addAgent(signer_A.address)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
-        await expect(asset.removeAgent(signer_A.address)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      it("GIVEN a paused token WHEN attempting to addAgent or removeAgent THEN transactions revert with IsPaused error", async () => {
+        await expect(asset.addAgent(signer_A.address)).to.be.revertedWithCustomError(asset, "IsPaused");
+        await expect(asset.removeAgent(signer_A.address)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 
@@ -242,12 +242,12 @@ describe("Controller Tests", () => {
         expect(await asset.totalSupplyByPartition(DEFAULT_PARTITION)).to.be.equal(amount * 2);
       });
 
-      it("GIVEN a paused token WHEN attempting to forcedTransfer TokenIsPaused error", async () => {
+      it("GIVEN a paused token WHEN attempting to forcedTransfer IsPaused error", async () => {
         await asset.connect(signer_B).pause();
 
         await expect(
           asset.forcedTransfer(signer_A.address, signer_B.address, amount - 1),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/controllerByPartition/controllerByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/controllerByPartition/controllerByPartition.test.ts
@@ -100,7 +100,7 @@ describe("ControllerByPartition Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused token WHEN controllerTransferByPartition THEN revert TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN controllerTransferByPartition THEN revert IsPaused", async () => {
         await expect(
           asset
             .connect(signer_C)
@@ -112,15 +112,15 @@ describe("ControllerByPartition Tests", () => {
               _DATA,
               _OPERATOR_DATA,
             ),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN controllerRedeemByPartition THEN revert TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN controllerRedeemByPartition THEN revert IsPaused", async () => {
         await expect(
           asset
             .connect(signer_C)
             .controllerRedeemByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, _DATA, _OPERATOR_DATA),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/controllerHoldByPartition/controllerHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/controllerHoldByPartition/controllerHoldByPartition.test.ts
@@ -195,10 +195,10 @@ describe("ControllerHoldByPartition Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN controllerCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN controllerCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.controllerCreateHoldByPartition(DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/core/core.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/core/core.test.ts
@@ -102,9 +102,9 @@ describe("Core Facet Tests", () => {
       await expect(asset.connect(signer_C).setName(newName)).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN a paused token WHEN setName THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN setName THEN reverts with IsPaused", async () => {
       await asset.connect(signer_B).pause();
-      await expect(asset.connect(signer_A).setName(newName)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_A).setName(newName)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 
@@ -127,9 +127,9 @@ describe("Core Facet Tests", () => {
       );
     });
 
-    it("GIVEN a paused token WHEN setSymbol THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN setSymbol THEN reverts with IsPaused", async () => {
       await asset.connect(signer_B).pause();
-      await expect(asset.connect(signer_A).setSymbol(newSymbol)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_A).setSymbol(newSymbol)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/deactivate/deactivate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/deactivate/deactivate.test.ts
@@ -33,7 +33,7 @@ describe("Deactivate Tests", () => {
     await expect(asset.connect(unknownSigner).deactivate()).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused Token WHEN deactivate THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN deactivate THEN transaction fails with IsPaused", async () => {
     // Grant DEACTIVATE_ROLE to unknownSigner and pause the token using deployer's PAUSER_ROLE
     await asset.connect(deployer).grantRole(ATS_ROLES.PAUSER_ROLE, deployer.address);
     await grantRoleAndPauseToken(
@@ -45,7 +45,7 @@ describe("Deactivate Tests", () => {
     );
 
     // deactivate fails because token is paused
-    await expect(asset.connect(unknownSigner).deactivate()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    await expect(asset.connect(unknownSigner).deactivate()).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN an account with deactivate role WHEN deactivate THEN transaction succeeds and isDeactivated returns true", async () => {

--- a/packages/ats/contracts/test/contracts/integration/externalControlLists/externalControlList.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/externalControlLists/externalControlList.test.ts
@@ -287,26 +287,26 @@ describe("ExternalControlList Management Tests", () => {
   });
 
   describe("Pause Tests", () => {
-    it("GIVEN a paused token WHEN addExternalControlList THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN addExternalControlList THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       const newControlList = externalWhitelistMock2.target as string;
       await expect(
         asset.connect(signer_A).addExternalControlList(newControlList, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused token WHEN removeExternalControlList THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN removeExternalControlList THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       await expect(
         asset.connect(signer_A).removeExternalControlList(externalWhitelistMock1.target as string, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused token WHEN updateExternalControlLists THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN updateExternalControlLists THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       const controlLists = [externalWhitelistMock1.target as string];
       const actives = [false];
@@ -314,7 +314,7 @@ describe("ExternalControlList Management Tests", () => {
         asset.connect(signer_A).updateExternalControlLists(controlLists, actives, {
           gasLimit: GAS_LIMIT.high,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/externalKycLists/externalKycList.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/externalKycLists/externalKycList.test.ts
@@ -375,26 +375,26 @@ describe("ExternalKycList Management Tests", () => {
   });
 
   describe("Pause Tests", () => {
-    it("GIVEN a paused token WHEN addExternalKycList THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN addExternalKycList THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       const newKycList = externalKycListMock3.target as string;
       await expect(
         asset.connect(signer_A).addExternalKycList(newKycList, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused token WHEN removeExternalKycList THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN removeExternalKycList THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       await expect(
         asset.connect(signer_A).removeExternalKycList(externalKycListMock1.target as string, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused token WHEN updateExternalKycLists THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN updateExternalKycLists THEN it reverts with IsPaused", async () => {
       await asset.connect(signer_A).pause();
       const kycLists = [externalKycListMock1.target as string];
       const actives = [false];
@@ -402,7 +402,7 @@ describe("ExternalKycList Management Tests", () => {
         asset.connect(signer_A).updateExternalKycLists(kycLists, actives, {
           gasLimit: GAS_LIMIT.high,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/externalPauses/externalPause.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/externalPauses/externalPause.test.ts
@@ -280,7 +280,7 @@ describe("ExternalPause Tests", () => {
   });
 
   describe("Pause Modifier Tests (onlyUnpaused)", () => {
-    it("GIVEN an external pause is paused WHEN calling a function with onlyUnpaused THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN an external pause is paused WHEN calling a function with onlyUnpaused THEN it reverts with IsPaused", async () => {
       await externalPauseMock1.setPaused(true, {
         gasLimit: GAS_LIMIT.default,
       });
@@ -289,19 +289,19 @@ describe("ExternalPause Tests", () => {
         asset.addExternalPause(externalPauseMock3.target as string, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused"); // Assumes TokenIsPaused is inherited/available
+      ).to.be.revertedWithCustomError(asset, "IsPaused"); // Assumes IsPaused is inherited/available
       await expect(
         asset.removeExternalPause(externalPauseMock2.target as string, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
       const pauses = [externalPauseMock2.target as string];
       const actives = [false];
       await expect(
         asset.updateExternalPauses(pauses, actives, {
           gasLimit: GAS_LIMIT.high,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN all external pauses are unpaused WHEN calling a function with onlyUnpaused THEN it succeeds", async () => {

--- a/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
@@ -302,41 +302,35 @@ describe("HoldByPartition Tests", () => {
       });
 
       // Create
-      it("GIVEN a paused Token WHEN createHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN createHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.createHoldByPartition(_DEFAULT_PARTITION, hold)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN createHoldFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN createHoldFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.createHoldFromByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Execute
-      it("GIVEN a paused Token WHEN executeHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN executeHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.executeHoldByPartition(holdIdentifier, signer_C.address, 1)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
       // Release
-      it("GIVEN a paused Token WHEN releaseHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
-        await expect(asset.releaseHoldByPartition(holdIdentifier, 1)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+      it("GIVEN a paused Token WHEN releaseHoldByPartition THEN transaction fails with IsPaused", async () => {
+        await expect(asset.releaseHoldByPartition(holdIdentifier, 1)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Reclaim
-      it("GIVEN a paused Token WHEN reclaimHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
-        await expect(asset.reclaimHoldByPartition(holdIdentifier)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+      it("GIVEN a paused Token WHEN reclaimHoldByPartition THEN transaction fails with IsPaused", async () => {
+        await expect(asset.reclaimHoldByPartition(holdIdentifier)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
@@ -644,91 +644,91 @@ describe("Clearing Tests", () => {
       });
 
       // Activate/Deactivate clearing
-      it("GIVEN a paused Token WHEN switching clearing mode THEN transaction fails with TokenIsPaused", async () => {
-        await expect(asset.activateClearing()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
-        await expect(asset.deactivateClearing()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      it("GIVEN a paused Token WHEN switching clearing mode THEN transaction fails with IsPaused", async () => {
+        await expect(asset.activateClearing()).to.be.revertedWithCustomError(asset, "IsPaused");
+        await expect(asset.deactivateClearing()).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Transfers
-      it("GIVEN a paused Token WHEN clearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN clearingTransferFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingTransferFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_A.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingTransferByPartition(clearingOperationFrom, _AMOUNT, signer_A.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Holds
-      it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingCreateHoldByPartition(clearingOperation, hold)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingCreateHoldFromByPartition(clearingOperationFrom, hold),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingCreateHoldByPartition(clearingOperationFrom, hold),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       //Redeems
 
-      it("GIVEN a paused Token WHEN clearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingRedeemByPartition(clearingOperation, _AMOUNT)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN clearingRedeemFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingRedeemFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingRedeemByPartition(clearingOperationFrom, _AMOUNT),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Approve / Cancel / Reclaim
-      it("GIVEN a paused Token WHEN approveClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN approveClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.approveClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN cancelClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN cancelClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.cancelClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN reclaimClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN reclaimClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.reclaimClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
     });
@@ -3443,7 +3443,7 @@ describe("Clearing Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3455,10 +3455,10 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingTransferByPartition(protectedClearingOperation, _AMOUNT, signer_B.address, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3470,10 +3470,10 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingRedeemByPartition(protectedClearingOperation, _AMOUNT, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3485,7 +3485,7 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingCreateHoldByPartition(protectedClearingOperation, hold, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1594/erc1594.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1594/erc1594.test.ts
@@ -168,25 +168,22 @@ describe("ERC1594 Tests", () => {
         await asset.connect(signer_B).pause();
       });
 
-      it("GIVEN a paused Token WHEN issue THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN issue THEN transaction fails with IsPaused", async () => {
         // issue fails
         await expect(asset.connect(signer_C).issue(signer_E.address, AMOUNT, DATA)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN redeem THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN redeem THEN transaction fails with IsPaused", async () => {
         // transfer with data fails
-        await expect(asset.connect(signer_C).redeem(AMOUNT, DATA)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+        await expect(asset.connect(signer_C).redeem(AMOUNT, DATA)).to.be.revertedWithCustomError(asset, "IsPaused");
 
         // transfer from with data fails
         await expect(asset.connect(signer_C).redeemFrom(signer_E.address, AMOUNT, DATA)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
     });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC20Permit/erc20Permit.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC20Permit/erc20Permit.test.ts
@@ -33,7 +33,7 @@ describe("ERC20Permit Tests", () => {
 
   describe("Single Partition", () => {
     describe("permit", () => {
-      it("GIVEN a paused token WHEN permit is called THEN the transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN permit is called THEN the transaction fails with IsPaused", async () => {
         await asset.pause();
 
         const expiry = (await getDltTimestamp()) + 3600;
@@ -48,7 +48,7 @@ describe("ERC20Permit Tests", () => {
             "0x0000000000000000000000000000000000000000000000000000000000000000",
             "0x0000000000000000000000000000000000000000000000000000000000000000",
           ),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN an owner address of zero WHEN permit is called THEN the transaction fails with ZeroAddressNotAllowed", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC20Votes/erc20Votes.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC20Votes/erc20Votes.test.ts
@@ -136,12 +136,12 @@ describe("ERC20Votes Tests", () => {
       });
     });
 
-    it("GIVEN a paused token WHEN delegate THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN delegate THEN transaction fails with IsPaused", async () => {
       // Pause the token
       await asset.pause();
 
       // Try to delegate while paused
-      await expect(asset.delegate(signer_B.address)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.delegate(signer_B.address)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN tokens issued WHEN delegate THEN delegate is set correctly", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC3643/erc3643.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC3643/erc3643.test.ts
@@ -131,11 +131,11 @@ describe("ERC3643 Tests", () => {
       await loadFixture(deploySecurityFixtureSinglePartition);
     });
 
-    it("GIVEN a paused token WHEN attempting to update name or symbol THEN transactions revert with TokenIsPaused error", async () => {
+    it("GIVEN a paused token WHEN attempting to update name or symbol THEN transactions revert with IsPaused error", async () => {
       await asset.connect(signer_B).pause();
 
-      await expect(asset.setName(newName)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
-      await expect(asset.setName(newSymbol)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.setName(newName)).to.be.revertedWithCustomError(asset, "IsPaused");
+      await expect(asset.setName(newSymbol)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an initialized token WHEN retrieving the version THEN returns the right version", async () => {
@@ -1028,7 +1028,7 @@ describe("ERC3643 Tests", () => {
           );
         });
 
-        it("GIVEN a paused token WHEN batchForcedTransfer THEN transaction fails with TokenIsPaused", async () => {
+        it("GIVEN a paused token WHEN batchForcedTransfer THEN transaction fails with IsPaused", async () => {
           await asset.pause();
 
           const fromList = [signer_F.address];
@@ -1037,7 +1037,7 @@ describe("ERC3643 Tests", () => {
 
           await expect(
             asset.connect(signer_A).batchForcedTransfer(fromList, toList, amounts),
-          ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+          ).to.be.revertedWithCustomError(asset, "IsPaused");
         });
       });
     });
@@ -1080,30 +1080,24 @@ describe("ERC3643 Tests", () => {
       beforeEach(async () => {
         await asset.pause();
       });
-      it("GIVEN a paused token WHEN freezePartialTokens THEN transactions revert with TokenIsPaused error", async () => {
-        await expect(asset.freezePartialTokens(signer_A.address, 10)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+      it("GIVEN a paused token WHEN freezePartialTokens THEN transactions revert with IsPaused error", async () => {
+        await expect(asset.freezePartialTokens(signer_A.address, 10)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN unfreezePartialTokens THEN transactions revert with TokenIsPaused error", async () => {
+      it("GIVEN a paused token WHEN unfreezePartialTokens THEN transactions revert with IsPaused error", async () => {
         await expect(asset.unfreezePartialTokens(signer_A.address, 10)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused token WHEN setAddressFrozen THEN transactions revert with TokenIsPaused error", async () => {
-        await expect(asset.setAddressFrozen(signer_A.address, true)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+      it("GIVEN a paused token WHEN setAddressFrozen THEN transactions revert with IsPaused error", async () => {
+        await expect(asset.setAddressFrozen(signer_A.address, true)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN attempting to update name or symbol THEN transactions revert with TokenIsPaused error", async () => {
-        await expect(asset.setName(newName)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
-        await expect(asset.setSymbol(newSymbol)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      it("GIVEN a paused token WHEN attempting to update name or symbol THEN transactions revert with IsPaused error", async () => {
+        await expect(asset.setName(newName)).to.be.revertedWithCustomError(asset, "IsPaused");
+        await expect(asset.setSymbol(newSymbol)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
     describe("Adjust balances", () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/bond.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/bond.test.ts
@@ -213,16 +213,16 @@ describe("Bond Tests", () => {
         );
       });
 
-      it("GIVEN the token is paused WHEN redeeming at maturity THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN the token is paused WHEN redeeming at maturity THEN transaction fails with IsPaused", async () => {
         await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
         await expect(
           asset.connect(signer_C).redeemAtMaturityByPartition(signer_C.address, DEFAULT_PARTITION, amount),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
 
         await expect(asset.connect(signer_C).fullRedeemAtMaturity(signer_C.address)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
@@ -644,91 +644,91 @@ describe("Clearing Tests", () => {
       });
 
       // Activate/Deactivate clearing
-      it("GIVEN a paused Token WHEN switching clearing mode THEN transaction fails with TokenIsPaused", async () => {
-        await expect(asset.activateClearing()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
-        await expect(asset.deactivateClearing()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      it("GIVEN a paused Token WHEN switching clearing mode THEN transaction fails with IsPaused", async () => {
+        await expect(asset.activateClearing()).to.be.revertedWithCustomError(asset, "IsPaused");
+        await expect(asset.deactivateClearing()).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Transfers
-      it("GIVEN a paused Token WHEN clearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN clearingTransferFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingTransferFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_A.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingTransferByPartition(clearingOperationFrom, _AMOUNT, signer_A.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Holds
-      it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingCreateHoldByPartition(clearingOperation, hold)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingCreateHoldFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.clearingCreateHoldFromByPartition(clearingOperationFrom, hold),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingCreateHoldByPartition(clearingOperationFrom, hold),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       //Redeems
 
-      it("GIVEN a paused Token WHEN clearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingRedeemByPartition(clearingOperation, _AMOUNT)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN clearingRedeemFromByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN clearingRedeemFromByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN operatorClearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN operatorClearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.operatorClearingRedeemByPartition(clearingOperationFrom, _AMOUNT),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       // Approve / Cancel / Reclaim
-      it("GIVEN a paused Token WHEN approveClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN approveClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.approveClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN cancelClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN cancelClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.cancelClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
 
-      it("GIVEN a paused Token WHEN reclaimClearingOperationByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN reclaimClearingOperationByPartition THEN transaction fails with IsPaused", async () => {
         await expect(asset.reclaimClearingOperationByPartition(clearingIdentifier)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
     });
@@ -3646,7 +3646,7 @@ describe("Clearing Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingTransferByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3658,10 +3658,10 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingTransferByPartition(protectedClearingOperation, _AMOUNT, signer_B.address, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3673,10 +3673,10 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingRedeemByPartition(protectedClearingOperation, _AMOUNT, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
         const protectedClearingOperation = {
           clearingOperation: clearingOperation,
           from: signer_A.address,
@@ -3688,7 +3688,7 @@ describe("Clearing Tests", () => {
 
         await expect(
           asset.protectedClearingCreateHoldByPartition(protectedClearingOperation, hold, signature),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
@@ -163,11 +163,11 @@ describe("Coupon Tests", () => {
     );
   });
 
-  it("GIVEN a paused Token WHEN setCoupon THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN setCoupon THEN transaction fails with IsPaused", async () => {
     // Granting Role to account C and Pause
     await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
-    await expect(asset.connect(signer_C).setCoupon(couponData)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    await expect(asset.connect(signer_C).setCoupon(couponData)).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN an account with corporateActions role WHEN setCoupon with wrong dates THEN transaction fails", async () => {
@@ -629,14 +629,14 @@ describe("Coupon Tests", () => {
     await expect(asset.connect(signer_D).cancelCoupon(1)).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused Token WHEN cancelCoupon THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN cancelCoupon THEN transaction fails with IsPaused", async () => {
     await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_C);
 
     await asset.connect(signer_C).setCoupon(couponData);
 
     await asset.connect(signer_B).pause();
 
-    await expect(asset.connect(signer_C).cancelCoupon(1)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    await expect(asset.connect(signer_C).cancelCoupon(1)).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN no existing coupon WHEN cancelCoupon with invalid ID THEN transaction fails", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/dividend/dividend.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/dividend/dividend.test.ts
@@ -197,13 +197,10 @@ describe("Dividends", () => {
     );
   });
 
-  it("GIVEN a paused Token WHEN setDividend THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN setDividend THEN transaction fails with IsPaused", async () => {
     await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
-    await expect(asset.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(
-      asset,
-      "TokenIsPaused",
-    );
+    await expect(asset.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN an account with corporateActions role WHEN setDividend with wrong dates THEN transaction fails", async () => {
@@ -510,12 +507,12 @@ describe("Dividends", () => {
       await expect(asset.connect(signer_C).cancelDividend(1)).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with IsPaused", async () => {
       await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_B.address);
       await asset.connect(signer_B).setDividend(dividendData);
       await asset.connect(signer_B).pause();
 
-      await expect(asset.connect(signer_B).cancelDividend(1)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_B).cancelDividend(1)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a dividend already executed WHEN cancelDividend THEN transaction fails with DividendAlreadyExecuted", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/documentation/documentation.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/documentation/documentation.test.ts
@@ -61,24 +61,24 @@ describe("Documentation Tests", () => {
     );
   });
 
-  it("GIVEN a paused Token WHEN setDocument THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN setDocument THEN transaction fails with IsPaused", async () => {
     // Granting Role to account C and Pause
     await grantRoleAndPauseToken(asset, ATS_ROLES.DOCUMENTER_ROLE, signer_A, signer_B, signer_C.address);
 
     // add document fails
     await expect(
       asset.connect(signer_C).setDocument(documentName_1, documentURI_1, documentHASH_1),
-    ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
-  it("GIVEN a paused Token WHEN removeDocument THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN removeDocument THEN transaction fails with IsPaused", async () => {
     // Granting Role to account C and Pause
     await grantRoleAndPauseToken(asset, ATS_ROLES.DOCUMENTER_ROLE, signer_A, signer_B, signer_C.address);
 
     // remove document
     await expect(asset.connect(signer_C).removeDocument(documentName_1)).to.be.revertedWithCustomError(
       asset,
-      "TokenIsPaused",
+      "IsPaused",
     );
   });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/equity/equity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/equity/equity.test.ts
@@ -247,15 +247,12 @@ describe("Equity Tests", () => {
       );
     });
 
-    it("GIVEN a paused Token WHEN setDividend THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setDividend THEN transaction fails with IsPaused", async () => {
       // Granting Role to account C and Pause
       await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
       // set dividend fails
-      await expect(asset.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(
-        asset,
-        "TokenIsPaused",
-      );
+      await expect(asset.connect(signer_C).setDividend(dividendData)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an account with corporateActions role WHEN setDividend with wrong dates THEN transaction fails", async () => {
@@ -564,12 +561,12 @@ describe("Equity Tests", () => {
         );
       });
 
-      it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN cancelDividend THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_B.address);
         await asset.connect(signer_B).setDividend(dividendData);
         await asset.connect(signer_B).pause();
 
-        await expect(asset.connect(signer_B).cancelDividend(1)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        await expect(asset.connect(signer_B).cancelDividend(1)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN a dividend already executed WHEN cancelDividend THEN transaction fails with DividendAlreadyExecuted", async () => {
@@ -680,12 +677,12 @@ describe("Equity Tests", () => {
       );
     });
 
-    it("GIVEN a paused Token WHEN setVoting THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setVoting THEN transaction fails with IsPaused", async () => {
       // Granting Role to account C and Pause
       await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
       // set voting fails
-      await expect(asset.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an account with corporateActions role WHEN setVoting with invalid timestamp THEN transaction fails with WrongTimestamp", async () => {
@@ -750,12 +747,12 @@ describe("Equity Tests", () => {
       );
     });
 
-    it("GIVEN a paused Token WHEN setVoting THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setVoting THEN transaction fails with IsPaused", async () => {
       // Granting Role to account C and Pause
       await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
       // set dividend fails
-      await expect(asset.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_C).setVoting(votingData)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a duplicate voting WHEN setVoting THEN transaction fails with VotingRightsCreationFailed", async () => {
@@ -856,12 +853,12 @@ describe("Equity Tests", () => {
         await expect(asset.connect(signer_C).cancelVoting(1)).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
       });
 
-      it("GIVEN a paused Token WHEN cancelVoting THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN cancelVoting THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.CORPORATE_ACTION_ROLE, signer_B.address);
         await asset.connect(signer_B).setVoting(votingData);
         await asset.connect(signer_B).pause();
 
-        await expect(asset.connect(signer_B).cancelVoting(1)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        await expect(asset.connect(signer_B).cancelVoting(1)).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN a voting already recorded WHEN cancelVoting THEN transaction fails with VotingAlreadyRecorded", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/identity/identity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/identity/identity.test.ts
@@ -93,10 +93,10 @@ describe("Identity Tests", () => {
       );
     });
 
-    it("GIVEN a paused token WHEN setOnchainID THEN transactions revert with TokenIsPaused error", async () => {
+    it("GIVEN a paused token WHEN setOnchainID THEN transactions revert with IsPaused error", async () => {
       await asset.connect(signer_B).pause();
 
-      await expect(asset.setOnchainID(onchainId)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.setOnchainID(onchainId)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 
@@ -119,12 +119,12 @@ describe("Identity Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN a paused token WHEN setIdentityRegistry THEN transactions revert with TokenIsPaused error", async () => {
+    it("GIVEN a paused token WHEN setIdentityRegistry THEN transactions revert with IsPaused error", async () => {
       await asset.connect(signer_B).pause();
 
       await expect(asset.setIdentityRegistry(identityRegistryMock.target as string)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
@@ -54,9 +54,9 @@ describe("Fixed Rate Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setFixedRate THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setFixedRate THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
-      await expect(asset.connect(signer_A).setRate(1, 2)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_A).setRate(1, 2)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -74,7 +74,7 @@ describe("Kpi Linked Rate Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
         kpiLinkedRateFacet.connect(signer_A).setInterestRate({
@@ -87,10 +87,10 @@ describe("Kpi Linked Rate Tests", () => {
           reportPeriod: 5000,
           rateDecimals: 1,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
         kpiLinkedRateFacet.connect(signer_A).setImpactData({
@@ -100,7 +100,7 @@ describe("Kpi Linked Rate Tests", () => {
           impactDataDecimals: 1,
           adjustmentPrecision: 3,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/sustainabilityPerformanceTargetRate/sustainabilityPerformanceTargetRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/sustainabilityPerformanceTargetRate/sustainabilityPerformanceTargetRate.test.ts
@@ -161,7 +161,7 @@ describe("Sustainability Performance Target Rate Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with IsPaused", async () => {
       await expect(
         sustainabilityPerformanceTargetRateFacet.connect(signer_A).setInterestRate({
           baseRate: 60,
@@ -169,10 +169,10 @@ describe("Sustainability Performance Target Rate Tests", () => {
           startRate: 60,
           rateDecimals: 2,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with IsPaused", async () => {
       await expect(
         sustainabilityPerformanceTargetRateFacet.connect(signer_A).setImpactData(
           [
@@ -185,7 +185,7 @@ describe("Sustainability Performance Target Rate Tests", () => {
           ],
           [project1],
         ),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/kpi/kpiLatest/kpiLatest.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/kpi/kpiLatest/kpiLatest.test.ts
@@ -69,7 +69,7 @@ describe("Kpi Latest Tests", () => {
       );
     });
 
-    it("GIVEN a paused contract WHEN addKpiData is called THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused contract WHEN addKpiData is called THEN transaction fails with IsPaused", async () => {
       await asset.connect(signer_B).pause();
 
       const date = 1000;
@@ -77,7 +77,7 @@ describe("Kpi Latest Tests", () => {
 
       await expect(asset.connect(signer_A).addKpiData(date, value, project1)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/lock/lock.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/lock/lock.test.ts
@@ -117,16 +117,16 @@ describe("Lock Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN lock THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN lock THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).lock(_AMOUNT, signer_A.address, currentTimestamp),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN release THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN release THEN transaction fails with IsPaused", async () => {
         await expect(asset.connect(signer_C).release(1, signer_A.address)).to.be.revertedWithCustomError(
           asset,
-          "TokenIsPaused",
+          "IsPaused",
         );
       });
     });

--- a/packages/ats/contracts/test/contracts/integration/layer_1/proceedRecipients/proceedRecipients.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/proceedRecipients/proceedRecipients.test.ts
@@ -61,14 +61,14 @@ describe("Proceed Recipients Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN an unlisted proceed recipient WHEN user adds if token is paused THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN an unlisted proceed recipient WHEN user adds if token is paused THEN it reverts with IsPaused", async () => {
       await asset.pause({ gasLimit: GAS_LIMIT.default });
 
       await expect(
         asset.addProceedRecipient(PROCEED_RECIPIENT_1, PROCEED_RECIPIENT_1_DATA, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a listed proceed recipient WHEN adding it again THEN it reverts with ProceedRecipientAlreadyExists", async () => {
@@ -118,13 +118,13 @@ describe("Proceed Recipients Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN an listed proceed recipient WHEN user removes it if token is paused THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN an listed proceed recipient WHEN user removes it if token is paused THEN it reverts with IsPaused", async () => {
       await asset.pause({ gasLimit: GAS_LIMIT.default });
       await expect(
         asset.removeProceedRecipient(PROCEED_RECIPIENT_2, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a unlisted proceed recipient WHEN removing it again THEN it reverts with ProceedRecipientNotFound", async () => {
@@ -169,13 +169,13 @@ describe("Proceed Recipients Tests", () => {
       ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
     });
 
-    it("GIVEN an listed proceed recipient WHEN user updates its data if token is paused THEN it reverts with TokenIsPaused", async () => {
+    it("GIVEN an listed proceed recipient WHEN user updates its data if token is paused THEN it reverts with IsPaused", async () => {
       await asset.pause({ gasLimit: GAS_LIMIT.default });
       await expect(
         asset.updateProceedRecipientData(PROCEED_RECIPIENT_2, PROCEED_RECIPIENT_1_DATA, {
           gasLimit: GAS_LIMIT.default,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a unlisted proceed recipient WHEN updating its data THEN it reverts with ProceedRecipientNotFound", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
@@ -370,9 +370,9 @@ describe("ProtectedPartitions Tests", () => {
 
       await asset.connect(signer_B).pause();
 
-      await expect(asset.connect(signer_B).protectPartitions()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_B).protectPartitions()).to.be.revertedWithCustomError(asset, "IsPaused");
 
-      await expect(asset.connect(signer_B).unprotectPartitions()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(signer_B).unprotectPartitions()).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a account without the protected partition role WHEN protecting or unprotecting partitions THEN transaction fails with AccountHasNoRole", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/scheduledTasks/scheduledTasks/scheduledTasks.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/scheduledTasks/scheduledTasks/scheduledTasks.test.ts
@@ -57,18 +57,18 @@ describe("Scheduled Tasks Tests", () => {
     await loadFixture(deploySecurityFixtureSinglePartition);
   });
 
-  it("GIVEN a paused Token WHEN triggerTasks THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN triggerTasks THEN transaction fails with IsPaused", async () => {
     // Pausing the token
     await asset.connect(signer_B).pause();
 
     // trigger scheduled snapshots
     await expect(asset.connect(signer_C).triggerPendingScheduledCrossOrderedTasks()).to.be.revertedWithCustomError(
       asset,
-      "TokenIsPaused",
+      "IsPaused",
     );
     await expect(asset.connect(signer_C).triggerScheduledCrossOrderedTasks(1)).to.be.revertedWithCustomError(
       asset,
-      "TokenIsPaused",
+      "IsPaused",
     );
   });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/snapshots/snapshots.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/snapshots/snapshots.test.ts
@@ -95,11 +95,11 @@ describe("Snapshots Tests", () => {
     await expect(asset.connect(signer_C).takeSnapshot()).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused Token WHEN takeSnapshot THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN takeSnapshot THEN transaction fails with IsPaused", async () => {
     // Granting Role to account C and Pause
     await grantRoleAndPauseToken(asset, ATS_ROLES.SNAPSHOT_ROLE, signer_A, signer_B, signer_C.address);
 
-    await expect(asset.connect(signer_C).takeSnapshot()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    await expect(asset.connect(signer_C).takeSnapshot()).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   it("GIVEN no snapshot WHEN reading snapshot values THEN transaction fails", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/transferAndLock/transferAndLock.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/transferAndLock/transferAndLock.test.ts
@@ -106,11 +106,11 @@ describe("Transfer and lock Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN transferAndLock THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN transferAndLock THEN transaction fails with IsPaused", async () => {
         // transfer from with data fails
         await expect(
           asset.connect(signer_C).transferAndLock(signer_B.address, _AMOUNT, "0x", currentTimestamp),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_2/amortization/amortization.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/amortization/amortization.test.ts
@@ -69,12 +69,12 @@ describe("AmortizationFacet", () => {
         .withArgs(user3.address, ATS_ROLES.CORPORATE_ACTION_ROLE);
     });
 
-    it("GIVEN paused token WHEN setAmortization THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN paused token WHEN setAmortization THEN reverts with IsPaused", async () => {
       await asset.grantRole(ATS_ROLES.PAUSER_ROLE, user1.address);
       await asset.connect(user1).pause();
 
       const data = await makeAmortizationData();
-      await expect(asset.connect(user2).setAmortization(data)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(user2).setAmortization(data)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN recordDate >= executionDate WHEN setAmortization THEN reverts with WrongDates", async () => {
@@ -172,12 +172,12 @@ describe("AmortizationFacet", () => {
         .withArgs(user3.address, ATS_ROLES.CORPORATE_ACTION_ROLE);
     });
 
-    it("GIVEN paused token WHEN cancelAmortization THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN paused token WHEN cancelAmortization THEN reverts with IsPaused", async () => {
       await asset.grantRole(ATS_ROLES.PAUSER_ROLE, user1.address);
 
       await asset.connect(user1).pause();
 
-      await expect(asset.connect(user2).cancelAmortization(1)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.connect(user2).cancelAmortization(1)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN non-existent amortization ID WHEN cancelAmortization THEN reverts with WrongIndexForAction", async () => {
@@ -680,7 +680,7 @@ describe("AmortizationFacet", () => {
         .withArgs(user3.address, ATS_ROLES.AMORTIZATION_ROLE);
     });
 
-    it("GIVEN paused token WHEN setAmortizationHold THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN paused token WHEN setAmortizationHold THEN reverts with IsPaused", async () => {
       await asset.grantRole(ATS_ROLES.PAUSER_ROLE, user1.address);
 
       const data = await makeAmortizationData();
@@ -697,7 +697,7 @@ describe("AmortizationFacet", () => {
 
       await expect(
         asset.connect(user2).setAmortizationHold(1, deployer.address, BigInt(TOKENS_TO_REDEEM)),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN tokenAmount exceeds holder balance WHEN setAmortizationHold THEN reverts with AmortizationHoldFailed or hold error", async () => {
@@ -821,13 +821,13 @@ describe("AmortizationFacet", () => {
         .withArgs(user3.address, ATS_ROLES.AMORTIZATION_ROLE);
     });
 
-    it("GIVEN paused token WHEN releaseAmortizationHold THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN paused token WHEN releaseAmortizationHold THEN reverts with IsPaused", async () => {
       await asset.grantRole(ATS_ROLES.PAUSER_ROLE, user1.address);
       await asset.connect(user1).pause();
 
       await expect(asset.connect(user2).releaseAmortizationHold(1, deployer.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_2/loan/loan.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/loan/loan.test.ts
@@ -109,12 +109,12 @@ describe("Loan Tests", () => {
       );
     });
 
-    it("GIVEN a paused token WHEN setLoanDetails THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN setLoanDetails THEN transaction fails with IsPaused", async () => {
       await asset.connect(signer_B).pause();
       const loanDetails = await getLoanDetails();
       await expect(asset.connect(signer_A).setLoanDetails(loanDetails)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
@@ -159,7 +159,7 @@ describe("LoansPortfolio Token Tests", () => {
       ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
     });
 
-    it("GIVEN a paused portfolio WHEN adding asset THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused portfolio WHEN adding asset THEN reverts with IsPaused", async () => {
       await asset.connect(signer_B).pause();
 
       await expect(
@@ -168,7 +168,7 @@ describe("LoansPortfolio Token Tests", () => {
           holdingsAssetType: HoldingsAssetType.LOAN,
           country: "ES",
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an unauthorized account WHEN adding asset THEN reverts with AccountHasNoRole", async () => {
@@ -277,7 +277,7 @@ describe("LoansPortfolio Token Tests", () => {
       ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
     });
 
-    it("GIVEN a paused portfolio WHEN removing LOAN asset THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused portfolio WHEN removing LOAN asset THEN reverts with IsPaused", async () => {
       const holdingsAsset = {
         assetAddress: await loanAsset.getAddress(),
         holdingsAssetType: HoldingsAssetType.LOAN,
@@ -286,7 +286,7 @@ describe("LoansPortfolio Token Tests", () => {
       await asset.addHoldingsAsset(holdingsAsset);
       await asset.connect(signer_B).pause();
 
-      await expect(asset.removeHoldingsAsset(holdingsAsset)).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      await expect(asset.removeHoldingsAsset(holdingsAsset)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an unauthorized account WHEN removing LOAN asset THEN reverts with AccountHasNoRole", async () => {
@@ -368,7 +368,7 @@ describe("LoansPortfolio Token Tests", () => {
       );
     });
 
-    it("GIVEN a paused portfolio WHEN notifying update THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused portfolio WHEN notifying update THEN reverts with IsPaused", async () => {
       const loanAddress = await loanAsset.getAddress();
       await asset.addHoldingsAsset({
         assetAddress: loanAddress,
@@ -377,10 +377,7 @@ describe("LoansPortfolio Token Tests", () => {
       });
       await asset.connect(signer_B).pause();
 
-      await expect(asset.notifyLoanHoldingsAssetUpdate(loanAddress)).to.be.revertedWithCustomError(
-        asset,
-        "TokenIsPaused",
-      );
+      await expect(asset.notifyLoanHoldingsAssetUpdate(loanAddress)).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an unauthorized account WHEN notifying update THEN reverts with AccountHasNoRole", async () => {
@@ -431,7 +428,7 @@ describe("LoansPortfolio Token Tests", () => {
       ).to.be.revertedWithCustomError(asset, "ZeroValue");
     });
 
-    it("GIVEN portfolio paused WHEN withdrawing THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN portfolio paused WHEN withdrawing THEN reverts with IsPaused", async () => {
       await asset.addHoldingsAsset({
         assetAddress: await loanAsset.getAddress(),
         holdingsAssetType: HoldingsAssetType.LOAN,
@@ -442,7 +439,7 @@ describe("LoansPortfolio Token Tests", () => {
 
       await expect(
         asset.loansPortfolioWithdraw(await loanAsset.getAddress(), signer_A.address, 0n),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN asset not in portfolio WHEN withdrawing THEN reverts with HoldingAssetNotFound", async () => {

--- a/packages/ats/contracts/test/contracts/integration/lockByPartition/lockByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/lockByPartition/lockByPartition.test.ts
@@ -127,16 +127,16 @@ describe("LockByPartition Tests", () => {
         await asset.connect(signer_D).pause();
       });
 
-      it("GIVEN a paused Token WHEN lockByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN lockByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).lockByPartition(_NON_DEFAULT_PARTITION, _AMOUNT, signer_A.address, currentTimestamp),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused Token WHEN releaseByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN releaseByPartition THEN transaction fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).releaseByPartition(_NON_DEFAULT_PARTITION, 1, signer_A.address),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -134,12 +134,12 @@ describe("Maturity Tests", () => {
       );
     });
 
-    it("GIVEN the token is paused WHEN fullRedeemAtMaturity THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN the token is paused WHEN fullRedeemAtMaturity THEN reverts with IsPaused", async () => {
       await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
       await expect(asset.connect(signer_C).fullRedeemAtMaturity(signer_C.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 
@@ -234,7 +234,7 @@ describe("Maturity Tests", () => {
       expect(maturityDateAfter).to.be.equal(maturityDateBefore);
     });
 
-    it("GIVEN the token is paused WHEN updateMaturityDate THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN the token is paused WHEN updateMaturityDate THEN reverts with IsPaused", async () => {
       await grantRoleAndPauseToken(asset, ATS_ROLES.BOND_MANAGER_ROLE, signer_A, signer_B, signer_C.address);
 
       const maturityDateBefore = (await asset.getBondDetails()).maturityDate;
@@ -242,7 +242,7 @@ describe("Maturity Tests", () => {
 
       await expect(asset.connect(signer_C).updateMaturityDate(newMaturityDate)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
       const maturityDateAfter = (await asset.getBondDetails()).maturityDate;
       expect(maturityDateAfter).to.be.equal(maturityDateBefore);

--- a/packages/ats/contracts/test/contracts/integration/maturityByPartition/maturityByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturityByPartition/maturityByPartition.test.ts
@@ -139,12 +139,12 @@ describe("MaturityByPartition Tests", () => {
         ).to.be.revertedWithCustomError(asset, "ClearingIsActivated");
       });
 
-      it("GIVEN the token is paused WHEN redeeming at maturity THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN the token is paused WHEN redeeming at maturity THEN transaction fails with IsPaused", async () => {
         await grantRoleAndPauseToken(asset, ATS_ROLES.CORPORATE_ACTION_ROLE, signer_A, signer_B, signer_C.address);
 
         await expect(
           asset.connect(signer_C).redeemAtMaturityByPartition(signer_C.address, DEFAULT_PARTITION, amount),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN the token holder lacks valid KYC status WHEN redeeming at maturity THEN transaction fails with InvalidKycStatus", async () => {

--- a/packages/ats/contracts/test/contracts/integration/metadata/metadata.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/metadata/metadata.test.ts
@@ -62,10 +62,10 @@ describe("Metadata Tests", () => {
       await asset.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN setMetadata THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setMetadata THEN transaction fails with IsPaused", async () => {
       await expect(asset.connect(signer_A).setMetadata(KEY_A, [PAYLOAD_1])).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
@@ -87,7 +87,7 @@ describe("MintByPartitionFacet Tests", () => {
         .withArgs(signer_B.address, [ATS_ROLES.ISSUER_ROLE, ATS_ROLES.AGENT_ROLE]);
     });
 
-    it("GIVEN a paused token WHEN issueByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN issueByPartition THEN reverts with IsPaused", async () => {
       await asset.connect(signer_C).pause();
 
       await expect(
@@ -97,7 +97,7 @@ describe("MintByPartitionFacet Tests", () => {
           value: AMOUNT,
           data: EMPTY_HEX_BYTES,
         }),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN single-partition mode WHEN issueByPartition with wrong partition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {

--- a/packages/ats/contracts/test/contracts/integration/operator/operator.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operator/operator.test.ts
@@ -73,11 +73,11 @@ describe("Operator Facet Tests", () => {
       expect(await asset.isOperator(signer_B.address, signer_C.address)).to.equal(true);
     });
 
-    it("GIVEN a paused token WHEN authorizeOperator THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN authorizeOperator THEN reverts with IsPaused", async () => {
       await asset.pause();
       await expect(asset.connect(signer_C).authorizeOperator(signer_B.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 
@@ -103,12 +103,12 @@ describe("Operator Facet Tests", () => {
       expect(await asset.isOperator(signer_B.address, signer_C.address)).to.equal(false);
     });
 
-    it("GIVEN a paused token WHEN revokeOperator THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN revokeOperator THEN reverts with IsPaused", async () => {
       await asset.connect(signer_C).authorizeOperator(signer_B.address);
       await asset.pause();
       await expect(asset.connect(signer_C).revokeOperator(signer_B.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 

--- a/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorByPartition/operatorByPartition.test.ts
@@ -60,11 +60,11 @@ describe("OperatorByPartitionFacet Tests", () => {
   // ─── authorizeOperatorByPartition ────────────────────────────────────────────
 
   describe("authorizeOperatorByPartition", () => {
-    it("GIVEN a paused token WHEN authorizeOperatorByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN authorizeOperatorByPartition THEN reverts with IsPaused", async () => {
       await asset.pause();
       await expect(
         asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an incompatible partition WHEN authorizeOperatorByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {
@@ -96,11 +96,11 @@ describe("OperatorByPartitionFacet Tests", () => {
       await asset.connect(signer_A).authorizeOperatorByPartition(DEFAULT_PARTITION, signer_B.address);
     });
 
-    it("GIVEN a paused token WHEN revokeOperatorByPartition THEN reverts with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN revokeOperatorByPartition THEN reverts with IsPaused", async () => {
       await asset.pause();
       await expect(
         asset.connect(signer_A).revokeOperatorByPartition(DEFAULT_PARTITION, signer_B.address),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN an incompatible partition WHEN revokeOperatorByPartition THEN reverts with PartitionNotAllowedInSinglePartitionMode", async () => {

--- a/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
@@ -161,14 +161,14 @@ describe("OperatorClearingByPartition Tests", () => {
       });
 
       describe("Paused", () => {
-        it("GIVEN a paused token WHEN operatorClearingTransferByPartition THEN transaction fails with TokenIsPaused", async () => {
+        it("GIVEN a paused token WHEN operatorClearingTransferByPartition THEN transaction fails with IsPaused", async () => {
           await asset.connect(signer_D).pause();
 
           await expect(
             asset
               .connect(signer_A)
               .operatorClearingTransferByPartition(clearingOperationFrom, _AMOUNT, signer_A.address),
-          ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+          ).to.be.revertedWithCustomError(asset, "IsPaused");
         });
       });
 
@@ -237,12 +237,12 @@ describe("OperatorClearingByPartition Tests", () => {
       });
 
       describe("Paused", () => {
-        it("GIVEN a paused token WHEN operatorClearingRedeemByPartition THEN transaction fails with TokenIsPaused", async () => {
+        it("GIVEN a paused token WHEN operatorClearingRedeemByPartition THEN transaction fails with IsPaused", async () => {
           await asset.connect(signer_D).pause();
 
           await expect(
             asset.connect(signer_A).operatorClearingRedeemByPartition(clearingOperationFrom, _AMOUNT),
-          ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+          ).to.be.revertedWithCustomError(asset, "IsPaused");
         });
       });
 

--- a/packages/ats/contracts/test/contracts/integration/operatorHoldByPartition/operatorHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorHoldByPartition/operatorHoldByPartition.test.ts
@@ -204,11 +204,11 @@ describe("operatorCreateHoldByPartition", () => {
   });
 
   // --- modifier: onlyUnpaused ---
-  it("GIVEN a paused token WHEN operatorCreateHoldByPartition THEN reverts with TokenIsPaused", async () => {
+  it("GIVEN a paused token WHEN operatorCreateHoldByPartition THEN reverts with IsPaused", async () => {
     await asset.connect(signer_D).pause();
     await expect(
       asset.operatorCreateHoldByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES),
-    ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
   // --- modifier: onlyClearingDisabled ---

--- a/packages/ats/contracts/test/contracts/integration/pause/pause.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/pause/pause.test.ts
@@ -83,10 +83,7 @@ describe("Pause Tests", () => {
       .to.emit(asset, "Paused")
       .withArgs(await unknownSigner.getAddress());
 
-    let paused = await asset.isPaused();
-    expect(paused).to.be.equal(true);
-
-    paused = await asset.paused();
+    let paused = await asset.paused();
     expect(paused).to.be.equal(true);
 
     // UNPAUSE
@@ -94,28 +91,25 @@ describe("Pause Tests", () => {
       .to.emit(asset, "Unpaused")
       .withArgs(await unknownSigner.getAddress());
 
-    paused = await asset.isPaused();
-    expect(paused).to.be.equal(false);
-
     paused = await asset.paused();
     expect(paused).to.be.equal(false);
   });
 
   it("GIVEN an external pause WHEN isPaused THEN it reflects the external pause state", async () => {
     // Initially unpaused
-    let isPaused = await asset.isPaused();
+    let isPaused = await asset.paused();
     expect(isPaused).to.be.false;
 
     // Set external pause to true
     await externalPauseMock.setPaused(true);
-    isPaused = await asset.isPaused();
+    isPaused = await asset.paused();
     expect(isPaused).to.be.true;
 
     // Set external pause to false
     await externalPauseMock.setPaused(false, {
       gasLimit: GAS_LIMIT.default,
     });
-    isPaused = await asset.isPaused();
+    isPaused = await asset.paused();
     expect(isPaused).to.be.false;
   });
 
@@ -124,7 +118,7 @@ describe("Pause Tests", () => {
     await asset.pause();
 
     // Check isPaused
-    const isPaused = await asset.isPaused();
+    const isPaused = await asset.paused();
     expect(isPaused).to.be.true;
   });
 
@@ -135,14 +129,14 @@ describe("Pause Tests", () => {
 
     // Set external pause to true
     await externalPauseMock.setPaused(true);
-    let isPaused = await asset.isPaused();
+    let isPaused = await asset.paused();
     expect(isPaused).to.be.true;
 
     // Set external pause to false
     await externalPauseMock.setPaused(false, {
       gasLimit: GAS_LIMIT.default,
     });
-    isPaused = await asset.isPaused();
+    isPaused = await asset.paused();
     expect(isPaused).to.be.false;
   });
 });

--- a/packages/ats/contracts/test/contracts/integration/pause/pause.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/pause/pause.test.ts
@@ -53,7 +53,7 @@ describe("Pause Tests", () => {
     await expect(asset.connect(unknownSigner).unpause()).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused Token WHEN pause THEN transaction fails with TokenIsPaused", async () => {
+  it("GIVEN a paused Token WHEN pause THEN transaction fails with IsPaused", async () => {
     // Granting Role and Pause
     await grantRoleAndPauseToken(
       asset,
@@ -64,14 +64,14 @@ describe("Pause Tests", () => {
     );
 
     // pause fails
-    await expect(asset.connect(unknownSigner).pause()).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+    await expect(asset.connect(unknownSigner).pause()).to.be.revertedWithCustomError(asset, "IsPaused");
   });
 
-  it("GIVEN an unpause Token WHEN unpause THEN transaction fails with TokenIsUnpaused", async () => {
+  it("GIVEN an unpause Token WHEN unpause THEN transaction fails with IsUnpaused", async () => {
     await asset.connect(deployer).grantRole(ATS_ROLES.PAUSER_ROLE, await unknownSigner.getAddress());
 
     // unpause fails
-    await expect(asset.connect(unknownSigner).unpause()).to.be.revertedWithCustomError(asset, "TokenIsUnpaused");
+    await expect(asset.connect(unknownSigner).unpause()).to.be.revertedWithCustomError(asset, "IsUnpaused");
   });
 
   it("GIVEN an account with pause role WHEN pause and unpause THEN transaction succeeds", async () => {
@@ -80,18 +80,24 @@ describe("Pause Tests", () => {
 
     // PAUSE
     await expect(asset.connect(unknownSigner).pause())
-      .to.emit(asset, "TokenPaused")
+      .to.emit(asset, "Paused")
       .withArgs(await unknownSigner.getAddress());
 
     let paused = await asset.isPaused();
     expect(paused).to.be.equal(true);
 
+    paused = await asset.paused();
+    expect(paused).to.be.equal(true);
+
     // UNPAUSE
     await expect(asset.connect(unknownSigner).unpause())
-      .to.emit(asset, "TokenUnpaused")
+      .to.emit(asset, "Unpaused")
       .withArgs(await unknownSigner.getAddress());
 
     paused = await asset.isPaused();
+    expect(paused).to.be.equal(false);
+
+    paused = await asset.paused();
     expect(paused).to.be.equal(false);
   });
 

--- a/packages/ats/contracts/test/contracts/integration/protectedHoldByPartition/protectedHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/protectedHoldByPartition/protectedHoldByPartition.test.ts
@@ -516,7 +516,7 @@ describe("ProtectedHoldByPartition Tests", () => {
   });
 
   describe("Token State Checks", () => {
-    it("GIVEN a paused token WHEN protectedCreateHoldByPartition THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused token WHEN protectedCreateHoldByPartition THEN transaction fails with IsPaused", async () => {
       const expirationTimestamp = MAX_UINT256;
       const hold: HoldData = {
         amount: 1,
@@ -536,7 +536,7 @@ describe("ProtectedHoldByPartition Tests", () => {
 
       await expect(
         asset.protectedCreateHoldByPartition(DEFAULT_PARTITION, signer_A.address, protectedHold, "0x1234"),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
     it("GIVEN a token in clearing mode WHEN protectedCreateHoldByPartition THEN transaction fails with ClearingIsActivated", async () => {

--- a/packages/ats/contracts/test/contracts/integration/resolver/BusinessLogicResolver.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/BusinessLogicResolver.test.ts
@@ -92,11 +92,11 @@ describe("BusinessLogicResolver", () => {
       await pause.connect(signer_B).pause();
     });
 
-    it("GIVEN a paused Token WHEN registrying logics THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN registrying logics THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
         businessLogicResolver.registerBusinessLogics(BUSINESS_LOGIC_KEYS.slice(0, 2)),
-      ).to.be.revertedWithCustomError(businessLogicResolver, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(businessLogicResolver, "IsPaused");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -85,7 +85,7 @@ describe("DiamondCutManager", () => {
   });
 
   afterEach(async () => {
-    const isPaused = await pause.isPaused();
+    const isPaused = await pause.paused();
     if (isPaused) {
       await pause.connect(signer_B).unpause();
     }

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -409,7 +409,7 @@ describe("DiamondCutManager", () => {
     ).to.be.revertedWithCustomError(diamondCutManager, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused resolver WHEN adding a new configuration THEN fails with TokenIsPaused", async () => {
+  it("GIVEN a paused resolver WHEN adding a new configuration THEN fails with IsPaused", async () => {
     await pause.connect(signer_B).pause();
 
     const facetConfigurations: IDiamondCutManager.FacetConfigurationStruct[] = [];
@@ -422,7 +422,7 @@ describe("DiamondCutManager", () => {
 
     await expect(
       diamondCutManager.connect(signer_A).createConfiguration(TEST_CONFIG_IDS.PAUSE_TEST, facetConfigurations),
-    ).to.be.revertedWithCustomError(diamondCutManager, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(diamondCutManager, "IsPaused");
 
     await pause.connect(signer_B).unpause();
   });
@@ -532,7 +532,7 @@ describe("DiamondCutManager", () => {
     ).to.be.revertedWithCustomError(diamondCutManager, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused resolver WHEN adding a new configuration with createBatchConfiguration THEN fails with TokenIsPaused", async () => {
+  it("GIVEN a paused resolver WHEN adding a new configuration with createBatchConfiguration THEN fails with IsPaused", async () => {
     await pause.connect(signer_B).pause();
 
     const facetConfigurations: IDiamondCutManager.FacetConfigurationStruct[] = [];
@@ -547,7 +547,7 @@ describe("DiamondCutManager", () => {
       diamondCutManager
         .connect(signer_A)
         .createBatchConfiguration(TEST_CONFIG_IDS.PAUSE_BATCH_TEST, facetConfigurations, false),
-    ).to.be.revertedWithCustomError(diamondCutManager, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(diamondCutManager, "IsPaused");
 
     await pause.connect(signer_B).unpause();
   });
@@ -651,7 +651,7 @@ describe("DiamondCutManager", () => {
     ).to.be.revertedWithCustomError(diamondCutManager, "AccountHasNoRole");
   });
 
-  it("GIVEN a paused resolver WHEN canceling a batch configuration THEN fails with TokenIsPaused", async () => {
+  it("GIVEN a paused resolver WHEN canceling a batch configuration THEN fails with IsPaused", async () => {
     const testConfigId = "0x0000000000000000000000000000000000000000000000000000000000000012";
 
     const facetConfigurations: IDiamondCutManager.FacetConfigurationStruct[] = [
@@ -667,7 +667,7 @@ describe("DiamondCutManager", () => {
 
     await expect(
       diamondCutManager.connect(signer_A).cancelBatchConfiguration(testConfigId),
-    ).to.be.revertedWithCustomError(diamondCutManager, "TokenIsPaused");
+    ).to.be.revertedWithCustomError(diamondCutManager, "IsPaused");
   });
 
   it("GIVEN a resolver WHEN canceling a batch configuration with configId at 0 THEN fails with DefaultValueForConfigurationIdNotPermitted", async () => {

--- a/packages/ats/contracts/test/contracts/integration/ssi/ssi.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/ssi/ssi.test.ts
@@ -50,23 +50,23 @@ describe("SSI Tests", () => {
       await asset.connect(signer_A).pause();
     });
 
-    it("GIVEN a paused Token WHEN setRevocationRegistryAddress THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN setRevocationRegistryAddress THEN transaction fails with IsPaused", async () => {
       await expect(
         asset.connect(signer_C).setRevocationRegistryAddress(revocationList.target),
-      ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
     });
 
-    it("GIVEN a paused Token WHEN addIssuer THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN addIssuer THEN transaction fails with IsPaused", async () => {
       await expect(asset.connect(signer_C).addIssuer(signer_B.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
 
-    it("GIVEN a paused Token WHEN removeIssuer THEN transaction fails with TokenIsPaused", async () => {
+    it("GIVEN a paused Token WHEN removeIssuer THEN transaction fails with IsPaused", async () => {
       await expect(asset.connect(signer_C).removeIssuer(signer_B.address)).to.be.revertedWithCustomError(
         asset,
-        "TokenIsPaused",
+        "IsPaused",
       );
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/transfer/transfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/transfer/transfer.test.ts
@@ -301,26 +301,23 @@ describe("Transfer Facet Tests", () => {
         await asset.connect(signer_B).pause();
       });
 
-      it("GIVEN a paused ERC20 WHEN transfer or transferFrom THEN reverts with TokenIsPaused", async () => {
-        await expect(assetSignerC.transfer(signer_D.address, amount)).to.be.revertedWithCustomError(
-          asset,
-          "TokenIsPaused",
-        );
+      it("GIVEN a paused ERC20 WHEN transfer or transferFrom THEN reverts with IsPaused", async () => {
+        await expect(assetSignerC.transfer(signer_D.address, amount)).to.be.revertedWithCustomError(asset, "IsPaused");
         await expect(
           assetSignerD.transferFrom(signer_C.address, signer_D.address, amount),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN transferWithData THEN fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN transferWithData THEN fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).transferWithData(signer_D.address, amount / 2, DATA),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a paused token WHEN transferFromWithData THEN fails with TokenIsPaused", async () => {
+      it("GIVEN a paused token WHEN transferFromWithData THEN fails with IsPaused", async () => {
         await expect(
           asset.connect(signer_C).transferFromWithData(signer_E.address, signer_D.address, amount / 2, DATA),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN a paused token WHEN transferWithData called by non-paused path THEN transferWithData is NOT blocked by pause", async () => {

--- a/packages/ats/contracts/test/contracts/integration/transferAndLockByPartition/transferAndLockByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/transferAndLockByPartition/transferAndLockByPartition.test.ts
@@ -102,14 +102,14 @@ describe("TransferAndLockByPartition Tests", () => {
     });
 
     describe("transferAndLockByPartition", () => {
-      it("GIVEN a paused Token WHEN transferAndLockByPartition THEN transaction fails with TokenIsPaused", async () => {
+      it("GIVEN a paused Token WHEN transferAndLockByPartition THEN transaction fails with IsPaused", async () => {
         await asset.connect(signer_D).pause();
 
         await expect(
           asset
             .connect(signer_C)
             .transferAndLockByPartition(_NON_DEFAULT_PARTITION, signer_B.address, _AMOUNT, "0x", currentTimestamp),
-        ).to.be.revertedWithCustomError(asset, "TokenIsPaused");
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
       it("GIVEN an account without LOCKER role WHEN transferAndLockByPartition THEN transaction fails with AccountHasNoRole", async () => {

--- a/packages/ats/contracts/test/helpers/errors.ts
+++ b/packages/ats/contracts/test/helpers/errors.ts
@@ -36,8 +36,8 @@ export function getCommonErrorSelector(errorSignature: string, asBytes4: boolean
 }
 
 export const ERROR_SELECTOR_MAP: Record<string, string> = {
-  "0x649815a5": "TokenIsPaused",
-  "0x72058d69": "TokenIsUnpaused",
+  "0x649815a5": "IsPaused",
+  "0x72058d69": "IsUnpaused",
   "0x796c1f0d": "AccountIsBlocked",
   "0x8579befe": "ZeroAddressNotAllowed",
   "0x0fc23480": "WrongDates",
@@ -57,8 +57,8 @@ export const ERROR_SELECTOR_MAP: Record<string, string> = {
 };
 
 export const KNOWN_ERRORS: Record<string, string> = {
-  TokenIsPaused: "0x649815a5",
-  TokenIsUnpaused: "0x72058d69",
+  IsPaused: "0x649815a5",
+  IsUnpaused: "0x72058d69",
   AccountIsBlocked: "0x796c1f0d",
   ZeroAddressNotAllowed: "0x8579befe",
   WrongDates: "0x0fc23480",

--- a/packages/ats/sdk/src/domain/context/security/error/operations/contractsErrorsMapper/ContractsErrorMapper.ts
+++ b/packages/ats/sdk/src/domain/context/security/error/operations/contractsErrorsMapper/ContractsErrorMapper.ts
@@ -36,7 +36,7 @@ export class ContractsErrorMapper {
   private static readonly SELECTORS = {
     zeroAddressNotAllowed: this.createSelector("ZeroAddressNotAllowed()"),
     accountIsBlocked: this.createSelector("AccountIsBlocked(address)"),
-    tokenIsPaused: this.createSelector("TokenIsPaused()"),
+    tokenIsPaused: this.createSelector("IsPaused()"),
     clearingIsActivated: this.createSelector("ClearingIsActivated()"),
     complianceNotAllowed: this.createSelector("ComplianceNotAllowed()"),
     invalidKycStatus: this.createSelector("InvalidKycStatus()"),

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -230,7 +230,7 @@ export class RPCQueryAdapter {
     const internalKycActivated = await this.connect(IAsset__factory, address.toString()).isInternalKycActivated();
     const isMultiPartition = await this.connect(IAsset__factory, address.toString()).isMultiPartition();
     const isIssuable = await this.connect(IAsset__factory, address.toString()).isIssuable();
-    const isPaused = await this.connect(IAsset__factory, address.toString()).isPaused();
+    const isPaused = await this.connect(IAsset__factory, address.toString()).paused();
     const regulationInfo = await this.connect(IAsset__factory, address.toString()).getSecurityRegulationData();
     const diamondAddress = await this.mirrorNode.getHederaIdfromContractAddress(address.toString());
     const regulation: Regulation = {
@@ -559,7 +559,7 @@ export class RPCQueryAdapter {
   async isPaused(address: EvmAddress): Promise<boolean> {
     LogService.logTrace(`Checking if the security: ${address.toString()} is paused`);
 
-    return await this.connect(IAsset__factory, address.toString()).isPaused();
+    return await this.connect(IAsset__factory, address.toString()).paused();
   }
 
   async arePartitionsProtected(address: EvmAddress): Promise<boolean> {


### PR DESCRIPTION
## Description

rename isPaused to paused fucntion in Pause Facet and rename Pause events and errors without Token word

## Type of change

- [ ] Bug fix 🐞
- [] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [X] Refactor 🔧

## Testing

	•	Automated tests – npm run test
	•	Local GitHub Actions – act pull_request

**Node version**:

- [ ] 20
- [ ] 22
- [X] 24

## Checklist

- [X] Style Guidelines followed ✅
- [X] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X] Local Tests Pass ✅
- [X] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
