### PR TITLE
fix: [FIND-073] Non-Sequential Nonce Allows Targeted Invalidation of Pending Operations

### DIFF
--- a/.changeset/fix-find-073-sequential-nonce-enforcement.md
+++ b/.changeset/fix-find-073-sequential-nonce-enforcement.md
@@ -1,0 +1,15 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-073: enforce sequential nonces in EIP-712 protected operations.
+
+`_isNonceValid` accepted any nonce strictly greater than the current value (`_currentNonce < _nonce`), allowing an attacker to submit a signed operation with an arbitrarily large nonce (e.g. 1000). The on-chain counter would jump to that value, permanently invalidating all intermediate pre-signed operations — a denial-of-service against legitimate pending signatures.
+
+`NonceStorageWrapper.setNonceFor` compounded the issue by directly assigning the caller-supplied value to storage instead of incrementing, making the jump persistent.
+
+The fix closes both vectors:
+
+- `_isNonceValid` now requires strict equality: `_nonce == _currentNonce + 1`.
+- `setNonceFor` signature changed to `setNonceFor(address _account)` — it unconditionally increments by 1 and no longer accepts an arbitrary value.
+- All call sites updated: `protectedTransferFromByPartition`, `protectedRedeemFromByPartition`, `protectedCreateHoldByPartition`, the three `protectedClearing*` operations, and `ERC20Permit.permit`.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -349,7 +349,7 @@ library ERC1410StorageWrapper {
             ERC20StorageWrapper.getName()
         );
 
-        NonceStorageWrapper.setNonceFor(protectionData.nonce, from);
+        NonceStorageWrapper.setNonceFor(from);
 
         return
             transferByPartition(
@@ -383,7 +383,7 @@ library ERC1410StorageWrapper {
             protectionData,
             ERC20StorageWrapper.getName()
         );
-        NonceStorageWrapper.setNonceFor(protectionData.nonce, from);
+        NonceStorageWrapper.setNonceFor(from);
 
         redeemByPartition(partition, from, EvmAccessors.getMsgSender(), amount, "", "");
     }

--- a/packages/ats/contracts/contracts/domain/asset/ERC20PermitStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20PermitStorageWrapper.sol
@@ -37,7 +37,7 @@ library ERC20PermitStorageWrapper {
 
         uint256 currentNonce = NonceStorageWrapper.getNonceFor(owner);
 
-        NonceStorageWrapper.setNonceFor(currentNonce + 1, owner);
+        NonceStorageWrapper.setNonceFor(owner);
         // solhint-disable-next-line func-name-mixedcase
         address signer = ECDSA.recover(
             ECDSA.toTypedDataHash(

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -88,7 +88,7 @@ library HoldStorageWrapper {
             ERC20StorageWrapper.getName()
         );
 
-        NonceStorageWrapper.setNonceFor(_protectedHold.nonce, _from);
+        NonceStorageWrapper.setNonceFor(_from);
 
         return createHoldByPartition(_partition, _from, _protectedHold.hold, "", ThirdPartyType.PROTECTED);
     }

--- a/packages/ats/contracts/contracts/domain/core/NonceStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/NonceStorageWrapper.sol
@@ -8,8 +8,10 @@ struct NonceDataStorage {
 }
 
 library NonceStorageWrapper {
-    function setNonceFor(uint256 _nonce, address _account) internal {
-        nonceStorage().nonces[_account] = _nonce;
+    function setNonceFor(address _account) internal {
+        unchecked {
+            ++nonceStorage().nonces[_account];
+        }
     }
 
     function getNonceFor(address _account) internal view returns (uint256) {

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingProtectedOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingProtectedOps.sol
@@ -40,7 +40,7 @@ library ClearingProtectedOps {
             ERC20StorageWrapper.getName()
         );
 
-        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.nonce, _protectedClearingOperation.from);
+        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.from);
 
         (success_, clearingId_) = ClearingOps.clearingTransferCreation(
             _protectedClearingOperation.clearingOperation,
@@ -74,7 +74,7 @@ library ClearingProtectedOps {
             ERC20StorageWrapper.getName()
         );
 
-        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.nonce, _protectedClearingOperation.from);
+        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.from);
 
         (success_, clearingId_) = ClearingOps.clearingRedeemCreation(
             _protectedClearingOperation.clearingOperation,
@@ -107,7 +107,7 @@ library ClearingProtectedOps {
             ERC20StorageWrapper.getName()
         );
 
-        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.nonce, _protectedClearingOperation.from);
+        NonceStorageWrapper.setNonceFor(_protectedClearingOperation.from);
 
         (success_, clearingId_) = ClearingOps.clearingHoldCreationCreation(
             _protectedClearingOperation.clearingOperation,

--- a/packages/ats/contracts/contracts/infrastructure/utils/ERC712.sol
+++ b/packages/ats/contracts/contracts/infrastructure/utils/ERC712.sol
@@ -207,7 +207,7 @@ function _isDeadlineValid(uint256 _deadline, uint256 _blockTimestamp) pure retur
 }
 
 function _isNonceValid(uint256 _nonce, uint256 _currentNonce) pure returns (bool) {
-    return _currentNonce < _nonce;
+    return _nonce == _currentNonce + 1;
 }
 
 function _recoverSigner(bytes32 _prefixedHash, bytes memory _signature) pure returns (address) {

--- a/packages/ats/contracts/contracts/infrastructure/utils/ERC712.sol
+++ b/packages/ats/contracts/contracts/infrastructure/utils/ERC712.sol
@@ -207,7 +207,9 @@ function _isDeadlineValid(uint256 _deadline, uint256 _blockTimestamp) pure retur
 }
 
 function _isNonceValid(uint256 _nonce, uint256 _currentNonce) pure returns (bool) {
-    return _nonce == _currentNonce + 1;
+    unchecked {
+        return _nonce == _currentNonce + 1;
+    }
 }
 
 function _recoverSigner(bytes32 _prefixedHash, bytes memory _signature) pure returns (address) {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/protectedPartitions/protectedPartitions.test.ts
@@ -531,6 +531,67 @@ describe("ProtectedPartitions Tests", () => {
         await asset.connect(signer_B).transferAndLock(signer_C.address, amount, "0x1234", MAX_UINT256);
       });
 
+      it("GIVEN a signed protected transfer with nonce > currentNonce+1 WHEN executed THEN reverts with WrongNonce (FIND-073)", async () => {
+        const deadline = MAX_UINT256;
+        const NONCE_GAP = 1000;
+        const signature = await signer_A.signTypedData(domain, transferType, {
+          _partition: DEFAULT_PARTITION,
+          _from: signer_A.address,
+          _to: signer_B.address,
+          _amount: amount,
+          _deadline: deadline,
+          _nonce: NONCE_GAP,
+        });
+        await asset.connect(signer_B).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
+        await expect(
+          asset
+            .connect(signer_B)
+            .protectedTransferFromByPartition(DEFAULT_PARTITION, signer_A.address, signer_B.address, amount, {
+              deadline,
+              nonce: NONCE_GAP,
+              signature,
+            }),
+        ).to.be.revertedWithCustomError(asset, "WrongNonce");
+      });
+
+      it("GIVEN three pre-signed transfers with consecutive nonces WHEN executed in order THEN all succeed and nonce is 3 (FIND-073)", async () => {
+        const deadline = MAX_UINT256;
+        const signatures: string[] = [];
+        for (let n = 1; n <= 3; n++) {
+          signatures.push(
+            await signer_A.signTypedData(domain, transferType, {
+              _partition: DEFAULT_PARTITION,
+              _from: signer_A.address,
+              _to: signer_B.address,
+              _amount: amount,
+              _deadline: deadline,
+              _nonce: n,
+            }),
+          );
+        }
+        await asset.connect(signer_B).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: 3 * amount,
+          data: "0x",
+        });
+        for (let n = 1; n <= 3; n++) {
+          await asset
+            .connect(signer_B)
+            .protectedTransferFromByPartition(DEFAULT_PARTITION, signer_A.address, signer_B.address, amount, {
+              deadline,
+              nonce: n,
+              signature: signatures[n - 1],
+            });
+        }
+        expect(await asset.nonces(signer_A.address)).to.equal(3);
+      });
+
       it("GIVEN a correct signature WHEN performing a protected transfer THEN transaction succeeds", async () => {
         const deadline = MAX_UINT256;
 
@@ -743,6 +804,47 @@ describe("ProtectedPartitions Tests", () => {
               "0x0011223344112233441122334411223344112233441122334411223344112233441122334411223344112233441122334411223344112233441122334411223344",
             ),
         ).to.be.revertedWithCustomError(asset, "WrongSignature");
+      });
+
+      it("GIVEN signed protected clearing ops with nonce > currentNonce+1 WHEN executed THEN revert with WrongNonce (FIND-073)", async () => {
+        const NONCE_GAP = 1000;
+        protectedClearingOperation.nonce = NONCE_GAP;
+
+        const signatureTransfer = await signer_A.signTypedData(domain, clearingTransferType, {
+          _protectedClearingOperation: protectedClearingOperation,
+          _amount: amount,
+          _to: signer_C.address,
+        });
+        await expect(
+          asset
+            .connect(signer_B)
+            .protectedClearingTransferByPartition(
+              protectedClearingOperation,
+              amount,
+              signer_C.address,
+              signatureTransfer,
+            ),
+        ).to.be.revertedWithCustomError(asset, "WrongNonce");
+
+        const signatureHold = await signer_A.signTypedData(domain, clearingCreateHoldType, {
+          _protectedClearingOperation: protectedClearingOperation,
+          _hold: hold,
+        });
+        await expect(
+          asset
+            .connect(signer_B)
+            .protectedClearingCreateHoldByPartition(protectedClearingOperation, hold, signatureHold),
+        ).to.be.revertedWithCustomError(asset, "WrongNonce");
+
+        const signatureRedeem = await signer_A.signTypedData(domain, clearingRedeemType, {
+          _protectedClearingOperation: protectedClearingOperation,
+          _amount: amount,
+        });
+        await expect(
+          asset
+            .connect(signer_B)
+            .protectedClearingRedeemByPartition(protectedClearingOperation, amount, signatureRedeem),
+        ).to.be.revertedWithCustomError(asset, "WrongNonce");
       });
 
       it("GIVEN a wrong nonce WHEN performing a protected clearing THEN transaction fails with WrongNonce", async () => {


### PR DESCRIPTION
This pull request strengthens nonce handling for protected asset operations, ensuring stricter sequential nonce validation and simplifying nonce management logic. It also adds comprehensive tests to verify correct and incorrect nonce usage in protected transfers and clearing operations.

**Nonce Management Improvements:**

* Refactored the `NonceStorageWrapper.setNonceFor` function to increment the nonce automatically for a given account, removing the need to explicitly provide the next nonce value. Call sites throughout the codebase now call `setNonceFor(address)` instead of passing a specific nonce value. [[1]](diffhunk://#diff-1c6c69555864cfa528b6e979729baf4e7433a609dfdeac8b5e4ef28f50190bbbL11-R14) [[2]](diffhunk://#diff-70656b98471e35757a5011a441e7bc382ffa6764ed4fbf602fe5237e7a7b908cL352-R352) [[3]](diffhunk://#diff-70656b98471e35757a5011a441e7bc382ffa6764ed4fbf602fe5237e7a7b908cL386-R386) [[4]](diffhunk://#diff-129a9dd9a1c31573aae835c1357ef956dcbf6207700dad78420f8e14a2b21519L40-R40) [[5]](diffhunk://#diff-9d0d744e7cebc6a0e0957d1d99644b486542b317400fb6cd0b3014e811e10ef5L91-R91) [[6]](diffhunk://#diff-b7e07e8e86de7690e569ab7af5fc79ba8571a1010536f7e8b389204808bbfac2L43-R43) [[7]](diffhunk://#diff-b7e07e8e86de7690e569ab7af5fc79ba8571a1010536f7e8b389204808bbfac2L77-R77) [[8]](diffhunk://#diff-b7e07e8e86de7690e569ab7af5fc79ba8571a1010536f7e8b389204808bbfac2L110-R110)

* Updated the nonce validation logic in the `_isNonceValid` function to require that the provided nonce is exactly one greater than the current nonce, enforcing strict sequential usage and preventing gaps.

**Testing Enhancements:**

* Added new integration tests to verify that:
  - Transactions with a nonce greater than `currentNonce + 1` are correctly rejected with a `WrongNonce` error.
  - Multiple pre-signed transfers with consecutive nonces succeed when executed in order and increment the nonce as expected.
  - Protected clearing operations with invalid nonces are rejected as expected. [[1]](diffhunk://#diff-c5fe009af5b06e16a555a967959ac67cc198e5ad86f3b1e2db2a93795217cea4R534-R594) [[2]](diffhunk://#diff-c5fe009af5b06e16a555a967959ac67cc198e5ad86f3b1e2db2a93795217cea4R809-R849)

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
