### PR TITLE
fix: [FIND-111] TREX Deployment Omits DEFAULT_ADMIN_ROLE for Token Owner — Admin Functions Permanently Bricked

### DIFF
--- a/.changeset/fix-find-111-default-admin-role.md
+++ b/.changeset/fix-find-111-default-admin-role.md
@@ -1,0 +1,9 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-111: grant DEFAULT_ADMIN_ROLE to \_tRexOwner in SecurityDeploymentLib.\_prepareRbacs.
+
+`_prepareRbacs` only added `address(this)` (the `TREXFactoryAts` factory) as a `DEFAULT_ADMIN_ROLE` member. After deployment, `TREXBaseDeploymentLib::deployTREXSuite` calls `renounceRole(DEFAULT_ADMIN_ROLE)` on behalf of the factory, removing the sole holder. If the token owner did not explicitly include themselves in `DEFAULT_ADMIN_ROLE` during the initial RBAC setup, all admin-gated functions on the deployed token were permanently locked with no recovery path.
+
+The fix adds `_tRexOwner` alongside `address(this)` in the `DEFAULT_ADMIN_ROLE` members array appended by `_prepareRbacs`. The factory continues to hold the role temporarily during deployment and renounces it afterwards, while the token owner retains permanent admin access regardless of whether they passed an explicit RBAC configuration.

--- a/packages/ats/contracts/contracts/factory/ERC3643/libraries/core/SecurityDeploymentLib.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/libraries/core/SecurityDeploymentLib.sol
@@ -80,8 +80,9 @@ library SecurityDeploymentLib {
 
         newRbacs[length] = IResolverProxy.Rbac({ role: TREX_OWNER_ROLE, members: membersArr });
 
-        membersArr = new address[](1);
+        membersArr = new address[](2);
         membersArr[0] = address(this);
+        membersArr[1] = _tRexOwner;
 
         newRbacs[length + 1] = IResolverProxy.Rbac({ role: DEFAULT_ADMIN_ROLE, members: membersArr });
 

--- a/packages/ats/contracts/test/contracts/integration/factory/trex/factory.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/factory/trex/factory.test.ts
@@ -348,6 +348,35 @@ describe("TREX Factory Tests", () => {
       expect(suiteDetails).to.not.equal(ADDRESS_ZERO);
     });
 
+    it("GIVEN no DEFAULT_ADMIN_ROLE in rbacs WHEN deploying equity THEN tRexOwner has DEFAULT_ADMIN_ROLE after deployment", async () => {
+      const equityData = {
+        security: getSecurityData(businessLogicResolver), // rbacs: [] — owner does NOT explicitly grant themselves DEFAULT_ADMIN_ROLE
+        equityDetails: getEquityDetails(),
+      };
+      equityData.security.resolverProxyConfiguration = {
+        key: EQUITY_CONFIG_ID,
+        version: 1,
+      };
+
+      const factoryRegulationData = getRegulationData();
+
+      const deploymentResult = await factoryAts
+        .connect(deployer)
+        .deployTREXSuiteAtsEquity(
+          "salt-equity-no-admin-role",
+          tokenDetails,
+          claimDetails,
+          equityData,
+          factoryRegulationData,
+        );
+
+      const deploymentReceipt = await deploymentResult.wait();
+      const decoded = await decodeEvent(factoryAts, "TREXSuiteDeployed", deploymentReceipt);
+      await setFacets(decoded._token);
+
+      expect(await accessControlFacet.hasRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, deployer.address)).to.be.true;
+    });
+
     it("GIVEN rbacs with existing TREX_OWNER_ROLE matching tRexOwner WHEN deploying equity THEN SecurityDeploymentLib handles owner match", async () => {
       const equityData = {
         security: getSecurityData(businessLogicResolver, {
@@ -1211,6 +1240,31 @@ describe("TREX Factory Tests", () => {
 
       const suiteDetails = await factoryAts.getToken("salt-bond");
       expect(suiteDetails).to.not.equal(ADDRESS_ZERO);
+    });
+
+    it("GIVEN no DEFAULT_ADMIN_ROLE in rbacs WHEN deploying bond THEN tRexOwner has DEFAULT_ADMIN_ROLE after deployment", async () => {
+      const bondData = {
+        security: getSecurityData(businessLogicResolver), // rbacs: [] — owner does NOT explicitly grant themselves DEFAULT_ADMIN_ROLE
+        bondDetails: await getBondDetails(),
+        proceedRecipients: [],
+        proceedRecipientsData: [],
+      };
+      bondData.security.resolverProxyConfiguration = {
+        key: BOND_CONFIG_ID,
+        version: 1,
+      };
+
+      const factoryRegulationData = getRegulationData();
+
+      const deploymentResult = await factoryAts
+        .connect(deployer)
+        .deployTREXSuiteAtsBond("salt-bond-no-admin-role", tokenDetails, claimDetails, bondData, factoryRegulationData);
+
+      const deploymentReceipt = await deploymentResult.wait();
+      const decoded = await decodeEvent(factoryAts, "TREXSuiteDeployed", deploymentReceipt);
+      await setFacets(decoded._token);
+
+      expect(await accessControlFacet.hasRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, deployer.address)).to.be.true;
     });
 
     it("GIVEN rbacs with existing TREX_OWNER_ROLE matching tRexOwner WHEN deploying bond THEN SecurityDeploymentLib handles owner match", async () => {


### PR DESCRIPTION
This pull request enhances the assignment of the `DEFAULT_ADMIN_ROLE` during the deployment of equity and bond contracts, ensuring that the `tRexOwner` is always granted the admin role even if it is not explicitly specified in the RBACs. Additionally, it introduces new tests to verify this behavior for both equity and bond deployments.

**Role assignment improvements:**

* Updated `SecurityDeploymentLib` to always include both the contract itself and the `_tRexOwner` as members of the `DEFAULT_ADMIN_ROLE`, ensuring proper admin rights assignment during deployment.

**Test coverage enhancements:**

* Added a test to verify that when no `DEFAULT_ADMIN_ROLE` is specified in RBACs during equity deployment, the `tRexOwner` is still granted the `DEFAULT_ADMIN_ROLE`.
* Added a similar test for bond deployment, confirming that the `tRexOwner` receives the `DEFAULT_ADMIN_ROLE` even if not explicitly set in RBACs.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
