### PR TITLE
feat: [BBND-1730] add nominalValueCurrency to NominalValue facet

### DIFF
--- a/.changeset/bbnd-1730-nominal-value-currency.md
+++ b/.changeset/bbnd-1730-nominal-value-currency.md
@@ -1,0 +1,6 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+"@hashgraph/asset-tokenization-sdk": minor
+---
+
+Add `nominalValueCurrency` (ISO 4217 `bytes3`) to the `NominalValue` facet. Extends `initializeNominalValue` to accept the currency and adds `setNominalValueCurrency` / `getNominalValueCurrency` external functions, plus the matching SDK command, query, request DTOs, and adapter wiring. Factory forwards `bondDetails.currency` / `equityDetails.currency` on new deploys. Renames `initialize_NominalValue` to `initializeNominalValue` (camelCase, drops the solhint disable). [BBND-1730]

--- a/packages/ats/contracts/contracts/domain/asset/nominalValue/NominalValueStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/nominalValue/NominalValueStorageWrapper.sol
@@ -18,10 +18,17 @@ import { ScheduledTasksStorageWrapper } from "../ScheduledTasksStorageWrapper.so
  * @author Asset Tokenization Studio Team
  */
 library NominalValueStorageWrapper {
+    /**
+     * @notice Dedicated storage layout for the nominal value capability.
+     * @dev `nominalValueCurrency` is appended after `initialized` so the slot layout of tokens
+     *      already deployed under the prior 3-field struct stays stable; the new field lives in
+     *      a fresh slot and reads `bytes3(0)` for pre-existing tokens until set.
+     */
     struct NominalValueDataStorage {
         uint256 nominalValue;
         uint8 nominalValueDecimals;
         bool initialized;
+        bytes3 nominalValueCurrency;
     }
 
     // ============================================= LEGACY SLOT OFFSETS =============================================
@@ -41,18 +48,37 @@ library NominalValueStorageWrapper {
     //             ^-- bool at byte 0, uint8 at byte 1
     // ============================================ LEGACY SLOT OFFSETS =============================================
 
-    // --- Dedicated storage ---
-
-    // --- Dedicated accessors ---
-
-    function initializeNominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals) internal {
+    /**
+     * @notice Initialises the dedicated nominal value storage with amount, decimals, and currency.
+     * @dev Order is load-bearing: `setNominalValue` runs the legacy bond/equity migration BEFORE
+     *      `setNominalValueCurrency` writes the dedicated currency slot. This guarantees that the
+     *      legacy `bytes3 currency` slot at `BondDataStorage.slot+0` has been left alone by the
+     *      migration (which only touches legacy nominalValue fields) and the newly-written
+     *      currency lives exclusively in the dedicated `NominalValueDataStorage` layout.
+     * @param _nominalValue Initial nominal value amount.
+     * @param _nominalValueDecimals Number of decimals applied to `_nominalValue`.
+     * @param _nominalValueCurrency ISO 4217 currency code as `bytes3`.
+     */
+    function initializeNominalValue(
+        uint256 _nominalValue,
+        uint8 _nominalValueDecimals,
+        bytes3 _nominalValueCurrency
+    ) internal {
         _nominalValueStorage().initialized = true;
         setNominalValue(_nominalValue, _nominalValueDecimals);
+        setNominalValueCurrency(_nominalValueCurrency);
     }
 
+    /**
+     * @notice Writes the nominal value amount and decimals to the dedicated storage slot.
+     * @dev Runs `_migrateLegacyNominalValue` first so any non-zero legacy bond/equity slots are
+     *      cleared before the dedicated write, ensuring the aggregating getters return the new
+     *      value alone rather than double-counting legacy data.
+     * @param _nominalValue New nominal value amount.
+     * @param _nominalValueDecimals New decimals applied to `_nominalValue`.
+     */
     function setNominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals) internal {
-        migrateBondNominalValue();
-        migrateEquityNominalValue();
+        _migrateLegacyNominalValue();
 
         ScheduledTasksStorageWrapper.callTriggerPendingScheduledCrossOrderedTasks();
 
@@ -64,18 +90,14 @@ library NominalValueStorageWrapper {
         nvData_.nominalValueDecimals = _nominalValueDecimals;
     }
 
-    function migrateBondNominalValue() internal {
-        if (
-            BondStorageWrapper.getDeprecatedNominalValue() > 0 ||
-            BondStorageWrapper.getDeprecatedNominalValueDecimals() > 0
-        ) BondStorageWrapper.clearNominalValue();
-    }
-
-    function migrateEquityNominalValue() internal {
-        if (
-            EquityStorageWrapper.getDeprecatedNominalValue() > 0 ||
-            EquityStorageWrapper.getDeprecatedNominalValueDecimals() > 0
-        ) EquityStorageWrapper.clearNominalValue();
+    /**
+     * @notice Writes the ISO 4217 currency code to the dedicated storage slot.
+     * @dev No migration is performed: legacy bond/equity `bytes3 currency` fields are NOT
+     *      aggregated into `getNominalValueCurrency`, so they cannot collide here.
+     * @param _nominalValueCurrency New ISO 4217 currency code as `bytes3`.
+     */
+    function setNominalValueCurrency(bytes3 _nominalValueCurrency) internal {
+        _nominalValueStorage().nominalValueCurrency = _nominalValueCurrency;
     }
 
     function getNominalValue() internal view returns (uint256) {
@@ -92,8 +114,58 @@ library NominalValueStorageWrapper {
             EquityStorageWrapper.getDeprecatedNominalValueDecimals();
     }
 
+    /**
+     * @notice Reads the ISO 4217 currency code from the dedicated storage slot.
+     * @dev Unlike `getNominalValue` and `getNominalValueDecimals`, this getter does NOT aggregate
+     *      legacy bond/equity `bytes3 currency` fields — those represent the issuer's reporting
+     *      currency, a different concept from the nominal-value-attached currency owned here.
+     * @return The ISO 4217 currency code as `bytes3`; `0x000000` when unset.
+     */
+    function getNominalValueCurrency() internal view returns (bytes3) {
+        return _nominalValueStorage().nominalValueCurrency;
+    }
+
     function isNominalValueInitialized() internal view returns (bool) {
         return _nominalValueStorage().initialized;
+    }
+
+    /**
+     * @notice Clears legacy nominal value slots on both bond and equity storage, if populated.
+     * @dev DEPRECATED – MIGRATION: remove this helper (and its two single-domain delegates) once
+     *      every on-chain token has been migrated off the deprecated `BondDataStorage.nominalValue`
+     *      and `EquityDataStorage.nominalValue` fields. Invoked at the start of every
+     *      `setNominalValue` and (transitively) `initializeNominalValue` call so the aggregating
+     *      getters never return legacy + dedicated state simultaneously.
+     */
+    function _migrateLegacyNominalValue() private {
+        _migrateBondNominalValue();
+        _migrateEquityNominalValue();
+    }
+
+    /**
+     * @notice Clears the deprecated nominal value fields on `BondDataStorage`, if populated.
+     * @dev Guarded by a non-zero check on the legacy amount and decimals to avoid a redundant
+     *      SSTORE when the migration has already run for this token. Called as part of
+     *      `_migrateLegacyNominalValue`.
+     */
+    function _migrateBondNominalValue() private {
+        if (
+            BondStorageWrapper.getDeprecatedNominalValue() > 0 ||
+            BondStorageWrapper.getDeprecatedNominalValueDecimals() > 0
+        ) BondStorageWrapper.clearNominalValue();
+    }
+
+    /**
+     * @notice Clears the deprecated nominal value fields on `EquityDataStorage`, if populated.
+     * @dev Guarded by a non-zero check on the legacy amount and decimals to avoid a redundant
+     *      SSTORE when the migration has already run for this token. Called as part of
+     *      `_migrateLegacyNominalValue`.
+     */
+    function _migrateEquityNominalValue() private {
+        if (
+            EquityStorageWrapper.getDeprecatedNominalValue() > 0 ||
+            EquityStorageWrapper.getDeprecatedNominalValueDecimals() > 0
+        ) EquityStorageWrapper.clearNominalValue();
     }
 
     function _nominalValueStorage() private pure returns (NominalValueDataStorage storage nvData_) {

--- a/packages/ats/contracts/contracts/facets/layer_2/nominalValue/INominalValue.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/nominalValue/INominalValue.sol
@@ -1,12 +1,107 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
+/**
+ * @title INominalValue
+ * @author Asset Tokenization Studio Team
+ * @notice External surface for the nominal value capability: declares the per-token nominal value
+ *         (amount, decimals, ISO 4217 currency code) and the events emitted when those fields are
+ *         initialised or mutated.
+ * @dev Implemented by `NominalValueFacet` via the abstract `NominalValue` writer. Events are
+ *      declared here (writer interface) per the project's event-emission rule; the abstract is
+ *      the sole emit site for each event. Currency uses `bytes3` to hold an ISO 4217 alphabetic
+ *      code (e.g. `0x555344` for "USD"), matching the convention shared with bond/equity details.
+ */
 interface INominalValue {
+    /**
+     * @notice Emitted once when the nominal value capability is initialised on a token.
+     * @dev Fires exclusively from `initializeNominalValue` after the storage write succeeds.
+     *      Subsequent value or currency updates emit `NominalValueSet` / `NominalValueCurrencySet`
+     *      instead, never this event.
+     * @param operator The account that invoked initialisation (deployer or upgrade caller).
+     * @param nominalValue The initial nominal value amount.
+     * @param nominalValueDecimals The number of decimals applied to `nominalValue`.
+     * @param nominalValueCurrency ISO 4217 currency code as `bytes3`; `0x000000` means "unset".
+     */
+    event NominalValueInitialized(
+        address indexed operator,
+        uint256 nominalValue,
+        uint8 nominalValueDecimals,
+        bytes3 nominalValueCurrency
+    );
+
+    /**
+     * @notice Emitted when the nominal value amount or its decimals are updated post-initialisation.
+     * @dev Fires from `setNominalValue`, and also from the legacy-bootstrap branch of
+     *      `setNominalValue` that auto-initialises uninitialised tokens during migration.
+     * @param operator The caller authorised by `NOMINAL_VALUE_ROLE`.
+     * @param nominalValue The new nominal value amount.
+     * @param nominalValueDecimals The new decimals applied to `nominalValue`.
+     */
     event NominalValueSet(address indexed operator, uint256 nominalValue, uint8 nominalValueDecimals);
 
-    // solhint-disable-next-line func-name-mixedcase
-    function initialize_NominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals) external;
+    /**
+     * @notice Emitted when the ISO 4217 currency code of the nominal value is updated.
+     * @dev Fires exclusively from `setNominalValueCurrency`; initialisation goes through
+     *      `NominalValueInitialized` instead.
+     * @param operator The caller authorised by `NOMINAL_VALUE_ROLE`.
+     * @param nominalValueCurrency The new ISO 4217 currency code as `bytes3`.
+     */
+    event NominalValueCurrencySet(address indexed operator, bytes3 nominalValueCurrency);
+
+    /**
+     * @notice Initialises the nominal value capability with amount, decimals, and currency.
+     * @dev Callable once per token; subsequent calls revert with `AlreadyInitialized` via the
+     *      `onlyNotNominalValueInitialized` modifier on the implementation. The factory calls this
+     *      automatically when deploying bonds and equities, forwarding the currency from the
+     *      bond/equity details so newly-deployed tokens land with the field populated.
+     * @param _nominalValue Initial nominal value amount.
+     * @param _nominalValueDecimals Number of decimals applied to `_nominalValue`.
+     * @param _nominalValueCurrency ISO 4217 currency code as `bytes3`; pass `0x000000` to leave unset.
+     */
+    function initializeNominalValue(
+        uint256 _nominalValue,
+        uint8 _nominalValueDecimals,
+        bytes3 _nominalValueCurrency
+    ) external;
+
+    /**
+     * @notice Updates the nominal value amount and its decimals.
+     * @dev Restricted to holders of `NOMINAL_VALUE_ROLE`. For tokens deployed before this facet
+     *      existed, the call also bootstraps the dedicated storage from legacy bond/equity slots
+     *      (passing `bytes3(0)` as currency) so the capability becomes initialised on first use.
+     * @param _nominalValue New nominal value amount.
+     * @param _nominalValueDecimals New decimals applied to `_nominalValue`.
+     */
     function setNominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals) external;
+
+    /**
+     * @notice Updates the ISO 4217 currency code attached to the nominal value.
+     * @dev Restricted to holders of `NOMINAL_VALUE_ROLE`. Does not touch the value/decimals;
+     *      callers must update those separately via `setNominalValue` if both change.
+     * @param _nominalValueCurrency New ISO 4217 currency code as `bytes3`.
+     */
+    function setNominalValueCurrency(bytes3 _nominalValueCurrency) external;
+
+    /**
+     * @notice Returns the nominal value amount, aggregating dedicated storage with legacy
+     *         bond/equity slots for backward compatibility.
+     * @return The current nominal value amount.
+     */
     function getNominalValue() external view returns (uint256);
+
+    /**
+     * @notice Returns the decimals applied to the nominal value, aggregating dedicated storage
+     *         with legacy bond/equity slots.
+     * @return The current decimals applied to `getNominalValue`.
+     */
     function getNominalValueDecimals() external view returns (uint8);
+
+    /**
+     * @notice Returns the ISO 4217 currency code attached to the nominal value.
+     * @dev Reads only the dedicated storage slot; legacy `bytes3 currency` fields on
+     *      `BondDataStorage` / `EquityDataStorage` are NOT aggregated here.
+     * @return The current ISO 4217 currency code as `bytes3`; `0x000000` means "unset".
+     */
+    function getNominalValueCurrency() external view returns (bytes3);
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValue.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValue.sol
@@ -4,39 +4,72 @@ pragma solidity >=0.8.0 <0.9.0;
 import { INominalValue } from "./INominalValue.sol";
 import { NOMINAL_VALUE_ROLE } from "../../../constants/roles.sol";
 import { Modifiers } from "../../../services/Modifiers.sol";
-import { _checkNotInitialized } from "../../../services/InitializationErrors.sol";
 import { NominalValueStorageWrapper } from "../../../domain/asset/nominalValue/NominalValueStorageWrapper.sol";
 import { EvmAccessors } from "../../../infrastructure/utils/EvmAccessors.sol";
 
+/**
+ * @title NominalValue
+ * @author Asset Tokenization Studio Team
+ * @notice Writer abstract for the nominal value capability; sole emit site for the events
+ *         declared on `INominalValue`.
+ * @dev Concrete facet `NominalValueFacet` registers the external selectors. Storage operations
+ *      delegate to `NominalValueStorageWrapper`, which holds the dedicated slot and the legacy
+ *      bond/equity aggregation logic.
+ */
 abstract contract NominalValue is INominalValue, Modifiers {
-    // solhint-disable-next-line func-name-mixedcase
-    function initialize_NominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals) external override {
-        _checkNotInitialized(NominalValueStorageWrapper.isNominalValueInitialized());
-        NominalValueStorageWrapper.initializeNominalValue(_nominalValue, _nominalValueDecimals);
-        emit NominalValueSet(EvmAccessors.getMsgSender(), _nominalValue, _nominalValueDecimals);
+    /// @inheritdoc INominalValue
+    function initializeNominalValue(
+        uint256 _nominalValue,
+        uint8 _nominalValueDecimals,
+        bytes3 _nominalValueCurrency
+    ) external override onlyNotNominalValueInitialized {
+        NominalValueStorageWrapper.initializeNominalValue(_nominalValue, _nominalValueDecimals, _nominalValueCurrency);
+        emit NominalValueInitialized(
+            EvmAccessors.getMsgSender(),
+            _nominalValue,
+            _nominalValueDecimals,
+            _nominalValueCurrency
+        );
     }
 
-    /// @dev Sets the nominal value. Migration of deprecated bond/equity fields
-    /// is handled internally by setNominalValue.
-    /// MIGRATION: Once all legacy tokens have been migrated, remove the
-    /// isNominalValueInitialized check, leaving only:
-    ///   setNominalValue(_nominalValue, _nominalValueDecimals);
+    /**
+     * @inheritdoc INominalValue
+     * @dev Legacy-bootstrap branch: when called on a token deployed before this facet existed,
+     *      the dedicated storage is uninitialised; this method auto-initialises it with
+     *      `bytes3(0)` as currency so subsequent reads work, then proceeds with the migration +
+     *      value/decimals write. MIGRATION: once all legacy tokens have been migrated, drop the
+     *      `isNominalValueInitialized` guard and leave only the
+     *      `setNominalValue(_nominalValue, _nominalValueDecimals)` call.
+     */
     function setNominalValue(
         uint256 _nominalValue,
         uint8 _nominalValueDecimals
     ) external override onlyRole(NOMINAL_VALUE_ROLE) {
         if (!NominalValueStorageWrapper.isNominalValueInitialized()) {
-            NominalValueStorageWrapper.initializeNominalValue(_nominalValue, _nominalValueDecimals);
+            NominalValueStorageWrapper.initializeNominalValue(_nominalValue, _nominalValueDecimals, bytes3(0));
         }
         NominalValueStorageWrapper.setNominalValue(_nominalValue, _nominalValueDecimals);
         emit NominalValueSet(EvmAccessors.getMsgSender(), _nominalValue, _nominalValueDecimals);
     }
 
+    /// @inheritdoc INominalValue
+    function setNominalValueCurrency(bytes3 _nominalValueCurrency) external override onlyRole(NOMINAL_VALUE_ROLE) {
+        NominalValueStorageWrapper.setNominalValueCurrency(_nominalValueCurrency);
+        emit NominalValueCurrencySet(EvmAccessors.getMsgSender(), _nominalValueCurrency);
+    }
+
+    /// @inheritdoc INominalValue
     function getNominalValue() external view override returns (uint256) {
         return NominalValueStorageWrapper.getNominalValue();
     }
 
+    /// @inheritdoc INominalValue
     function getNominalValueDecimals() external view override returns (uint8) {
         return NominalValueStorageWrapper.getNominalValueDecimals();
+    }
+
+    /// @inheritdoc INominalValue
+    function getNominalValueCurrency() external view override returns (bytes3) {
+        return NominalValueStorageWrapper.getNominalValueCurrency();
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValueFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValueFacet.sol
@@ -6,23 +6,39 @@ import { INominalValue } from "./INominalValue.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
 import { _NOMINAL_VALUE_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
+/**
+ * @title NominalValueFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes the nominal value capability (`INominalValue`) on a token.
+ * @dev Implements `IStaticFunctionSelectors` so the BusinessLogicResolver can register the facet's
+ *      selectors against the deterministic resolver key declared in `constants/resolverKeys.sol`.
+ */
 contract NominalValueFacet is NominalValue, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _NOMINAL_VALUE_RESOLVER_KEY;
     }
 
+    /// @inheritdoc IStaticFunctionSelectors
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](4);
-        uint256 selectorIndex;
-        staticFunctionSelectors_[selectorIndex++] = this.getNominalValue.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getNominalValueDecimals.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_NominalValue.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setNominalValue.selector;
+        uint256 selectorIndex = 6;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.setNominalValueCurrency.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.setNominalValue.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.initializeNominalValue.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getNominalValueDecimals.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getNominalValueCurrency.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getNominalValue.selector;
+        }
     }
 
+    /// @inheritdoc IStaticFunctionSelectors
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(INominalValue).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(INominalValue).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValueFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/nominalValue/NominalValueFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { NominalValue } from "./NominalValue.sol";
 import { INominalValue } from "./INominalValue.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _NOMINAL_VALUE_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 /**
@@ -20,25 +21,20 @@ contract NominalValueFacet is NominalValue, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 6;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.setNominalValueCurrency.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setNominalValue.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.initializeNominalValue.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getNominalValueDecimals.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getNominalValueCurrency.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getNominalValue.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getNominalValue.selector,
+                this.getNominalValueCurrency.selector,
+                this.getNominalValueDecimals.selector,
+                this.initializeNominalValue.selector,
+                this.setNominalValue.selector,
+                this.setNominalValueCurrency.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(INominalValue).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(INominalValue).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/factory/Factory.sol
+++ b/packages/ats/contracts/contracts/factory/Factory.sol
@@ -146,10 +146,11 @@ contract Factory is IFactory {
             _factoryRegulationData.additionalSecurityData
         );
 
-        _tryInitialize_NominalValue(
+        _tryInitializeNominalValue(
             equityAddress_,
             _equityData.equityDetails.nominalValue,
-            _equityData.equityDetails.nominalValueDecimals
+            _equityData.equityDetails.nominalValueDecimals,
+            _equityData.equityDetails.currency
         );
 
         emit EquityDeployed(EvmAccessors.getMsgSender(), equityAddress_, _equityData, _factoryRegulationData);
@@ -274,10 +275,11 @@ contract Factory is IFactory {
         // Initialize proceed recipients (ProceedRecipientsFacet may not be present)
         _tryInitialize_ProceedRecipients(bondAddress_, _bondData.proceedRecipients, _bondData.proceedRecipientsData);
 
-        _tryInitialize_NominalValue(
+        _tryInitializeNominalValue(
             bondAddress_,
             _bondData.bondDetails.nominalValue,
-            _bondData.bondDetails.nominalValueDecimals
+            _bondData.bondDetails.nominalValueDecimals,
+            _bondData.bondDetails.currency
         );
     }
 
@@ -498,12 +500,19 @@ contract Factory is IFactory {
         }
     }
 
-    function _tryInitialize_NominalValue(
+    function _tryInitializeNominalValue(
         address securityAddress_,
         uint256 nominalValue,
-        uint8 nominalValueDecimals
+        uint8 nominalValueDecimals,
+        bytes3 nominalValueCurrency
     ) private {
-        try INominalValue(securityAddress_).initialize_NominalValue(nominalValue, nominalValueDecimals) {
+        try
+            INominalValue(securityAddress_).initializeNominalValue(
+                nominalValue,
+                nominalValueDecimals,
+                nominalValueCurrency
+            )
+        {
             // success
         } catch {
             // facet not present - skip initialization

--- a/packages/ats/contracts/contracts/infrastructure/proxy/Bytes4Builder.sol
+++ b/packages/ats/contracts/contracts/infrastructure/proxy/Bytes4Builder.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/**
+ * @title Bytes4Builder
+ * @author Asset Tokenization Studio Team
+ * @notice Library of overloaded `build` helpers that allocate and populate a `bytes4[]
+ *         memory` array of fixed length, intended for use by `IStaticFunctionSelectors`
+ *         implementations when reporting selectors or interface ids to the resolver.
+ * @dev Solidity does not allow `[a, b, c]` (a fixed-size `bytesN[N] memory` literal) to be
+ *      implicitly returned as a dynamic `bytes4[] memory`; these `internal pure` overloads
+ *      provide the missing one-liner construction without the descending `--selectorIndex`
+ *      boilerplate that facets otherwise carry. The compiler inlines each call, so the only
+ *      runtime cost is argument marshalling onto the stack.
+ *
+ *      Overloads are provided for 1 through 6 elements. Facets needing larger arrays should
+ *      fall back to the manual descending-loop form rather than padding this library with
+ *      ever-wider overloads — the readability win flattens once N grows past the cap.
+ */
+library Bytes4Builder {
+    /**
+     * @notice Returns a `bytes4[] memory` of length 1 containing `a`.
+     * @param a Element at index 0.
+     * @return r Newly allocated 1-element array.
+     */
+    function build(bytes4 a) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](1);
+        r[0] = a;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 2 containing `a, b` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @return r Newly allocated 2-element array.
+     */
+    function build(bytes4 a, bytes4 b) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](2);
+        r[0] = a;
+        r[1] = b;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 3 containing `a, b, c` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @return r Newly allocated 3-element array.
+     */
+    function build(bytes4 a, bytes4 b, bytes4 c) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](3);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 4 containing `a, b, c, d` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @return r Newly allocated 4-element array.
+     */
+    function build(bytes4 a, bytes4 b, bytes4 c, bytes4 d) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](4);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 5 containing `a, b, c, d, e` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @return r Newly allocated 5-element array.
+     */
+    function build(bytes4 a, bytes4 b, bytes4 c, bytes4 d, bytes4 e) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](5);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 6 containing `a, b, c, d, e, f` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @return r Newly allocated 6-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](6);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+    }
+}

--- a/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
@@ -16,6 +16,7 @@ import { InterestRateModifiers } from "./InterestRateModifiers.sol";
 import { KpisModifiers } from "./KpisModifiers.sol";
 import { LockModifiers } from "./LockModifiers.sol";
 import { MaturityModifiers } from "./MaturityModifiers.sol";
+import { NominalValueModifiers } from "./NominalValueModifiers.sol";
 import { ProceedRecipientModifiers } from "./ProceedRecipientModifiers.sol";
 import { StateModifiers } from "./StateModifiers.sol";
 import { AmortizationModifiers } from "./AmortizationModifiers.sol";
@@ -43,6 +44,7 @@ import { LoansPortfolioModifiers } from "./LoansPortfolioModifiers.sol";
  * - KpisModifiers: Kpis validation
  * - LockModifiers: Lock validation
  * - MaturityModifiers: Maturity validation
+ * - NominalValueModifiers: Nominal value initialization validation
  * - ProceedRecipientModifiers: Proceed recipients validation
  * - StateModifiers: State validation
  *
@@ -66,6 +68,7 @@ abstract contract AssetModifiers is
     LockModifiers,
     LoansPortfolioModifiers,
     MaturityModifiers,
+    NominalValueModifiers,
     ProceedRecipientModifiers,
     StateModifiers
 {

--- a/packages/ats/contracts/contracts/services/asset/NominalValueModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/NominalValueModifiers.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { NominalValueStorageWrapper } from "../../domain/asset/nominalValue/NominalValueStorageWrapper.sol";
+import { _checkNotInitialized } from "../InitializationErrors.sol";
+
+/**
+ * @title NominalValueModifiers
+ * @notice Abstract contract providing nominal value-related modifiers
+ * @dev Provides modifiers for nominal value state validation using _check* pattern
+ *      from NominalValueStorageWrapper
+ * @author Asset Tokenization Studio Team
+ */
+abstract contract NominalValueModifiers {
+    /**
+     * @notice Modifier to ensure nominal value has not been initialized
+     * @dev Reverts with AlreadyInitialized if nominal value is already initialized
+     */
+    modifier onlyNotNominalValueInitialized() {
+        _checkNotInitialized(NominalValueStorageWrapper.isNominalValueInitialized());
+        _;
+    }
+}

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T10:44:55.115Z
+ * Generated: 2026-05-12T11:02:01.532Z
  * Facets: 124
  * Infrastructure: 2
  *
@@ -9479,6 +9479,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 
   NominalValueFacet: {
     name: "NominalValueFacet",
+    description: "Diamond facet that exposes the nominal value capability (`INominalValue`) on a token.",
     resolverKey: {
       name: "_NOMINAL_VALUE_RESOLVER_KEY",
       value: "0x48903d4da8b1f0a5e9a9874be74ec5d2f8043d4d5b65cc093173c3dae103df8f",
@@ -9491,6 +9492,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xbd4ff0a9",
       },
       {
+        name: "getNominalValueCurrency",
+        signature: {
+          full: "function getNominalValueCurrency() view returns (bytes3)",
+          canonical: "getNominalValueCurrency()",
+        },
+        selector: "0x416b5554",
+      },
+      {
         name: "getNominalValueDecimals",
         signature: {
           full: "function getNominalValueDecimals() view returns (uint8)",
@@ -9499,12 +9508,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x27e4bb51",
       },
       {
-        name: "initialize_NominalValue",
+        name: "initializeNominalValue",
         signature: {
-          full: "function initialize_NominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals)",
-          canonical: "initialize_NominalValue(uint256,uint8)",
+          full: "function initializeNominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals, bytes3 _nominalValueCurrency)",
+          canonical: "initializeNominalValue(uint256,uint8,bytes3)",
         },
-        selector: "0x0c0e65af",
+        selector: "0x1bc79e1d",
       },
       {
         name: "setNominalValue",
@@ -9514,8 +9523,32 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x40ba1a0d",
       },
+      {
+        name: "setNominalValueCurrency",
+        signature: {
+          full: "function setNominalValueCurrency(bytes3 _nominalValueCurrency)",
+          canonical: "setNominalValueCurrency(bytes3)",
+        },
+        selector: "0x1c941c77",
+      },
     ],
     events: [
+      {
+        name: "NominalValueCurrencySet",
+        signature: {
+          full: "event NominalValueCurrencySet(address indexed operator, bytes3 nominalValueCurrency)",
+          canonical: "NominalValueCurrencySet(address,bytes3)",
+        },
+        topic0: "0x121154ad7f7eb7b91da8448a24fd91b473ce28adcb1c5127257918f37b4a3508",
+      },
+      {
+        name: "NominalValueInitialized",
+        signature: {
+          full: "event NominalValueInitialized(address indexed operator, uint256 nominalValue, uint8 nominalValueDecimals, bytes3 nominalValueCurrency)",
+          canonical: "NominalValueInitialized(address,uint256,uint8,bytes3)",
+        },
+        topic0: "0x9a822fe5a63dc100e6c6c4e0c1bfcc813c9343a12c7adbaf651b92b91fbcf2db",
+      },
       {
         name: "NominalValueSet",
         signature: {

--- a/packages/ats/contracts/test/contracts/integration/layer_2/nominalValue/nominalValueMigration.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/nominalValue/nominalValueMigration.test.ts
@@ -5,8 +5,8 @@ import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import { type ResolverProxy, type IAsset, type NominalValueMigrationFacetTest } from "@contract-types";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { BOND_CONFIG_ID, EQUITY_CONFIG_ID, ATS_ROLES } from "@scripts";
-import { deployBondTokenFixture, deployEquityTokenFixture } from "@test";
+import { ATS_ROLES, BOND_CONFIG_ID, CURRENCIES, EQUITY_CONFIG_ID } from "@scripts";
+import { deployBondTokenFixture, deployEquityTokenFixture, EVENT_NAMES, TEST_NOMINAL_VALUES } from "@test";
 
 async function addMigrationFacetToDiamond(base: Awaited<ReturnType<typeof deployBondTokenFixture>>, configId: string) {
   const { blr, deployer, diamond: baseDiamond } = base;
@@ -81,7 +81,7 @@ describe("NominalValue Migration Tests", () => {
     it("GIVEN a bond with initialized nominalValue WHEN legacy bond storage is checked THEN deprecated fields are cleared", async () => {
       const [legacyValue, legacyDecimals] = await migrationFacet.getLegacyBondNominalValue();
 
-      // After initialize_NominalValue (called by factory), deprecated fields should be cleared
+      // After initializeNominalValue (called by factory), deprecated fields should be cleared
       expect(legacyValue).to.equal(0);
       expect(legacyDecimals).to.equal(0);
     });
@@ -158,7 +158,7 @@ describe("NominalValue Migration Tests", () => {
     it("GIVEN an equity with initialized nominalValue WHEN legacy equity storage is checked THEN deprecated fields are cleared", async () => {
       const [legacyValue, legacyDecimals] = await migrationFacet.getLegacyEquityNominalValue();
 
-      // After initialize_NominalValue (called by factory), deprecated fields should be cleared
+      // After initializeNominalValue (called by factory), deprecated fields should be cleared
       expect(legacyValue).to.equal(0);
       expect(legacyDecimals).to.equal(0);
     });
@@ -274,30 +274,46 @@ describe("NominalValue Migration Tests", () => {
       await loadFixture(deployBondWithMigrationFacet);
     });
 
-    it("GIVEN an already initialized nominalValue WHEN initialize_NominalValue is called THEN reverts with AlreadyInitialized", async () => {
-      await expect(asset.initialize_NominalValue(200, 4)).to.be.revertedWithCustomError(asset, "AlreadyInitialized");
+    it("GIVEN an already initialized nominalValue WHEN initializeNominalValue is called THEN reverts with AlreadyInitialized", async () => {
+      await expect(
+        asset.initializeNominalValue(200, 4, TEST_NOMINAL_VALUES.CURRENCY_ZERO),
+      ).to.be.revertedWithCustomError(asset, "AlreadyInitialized");
     });
 
-    it("GIVEN an uninitialized nominalValue WHEN setNominalValue is called THEN it initializes and sets value", async () => {
+    it("GIVEN an uninitialized nominalValue WHEN setNominalValue is called THEN it initializes and sets value with no currency", async () => {
       // Reset initialized flag to simulate a legacy token
       await migrationFacet.resetNominalValueInitialized();
 
-      // setNominalValue should trigger _initialize_NominalValue internally
+      // setNominalValue should trigger initializeNominalValue internally with bytes3(0) currency
       await asset.connect(signer_A).setNominalValue(600, 5);
 
       expect(await asset.getNominalValue()).to.equal(600);
       expect(await asset.getNominalValueDecimals()).to.equal(5);
+      expect(await asset.getNominalValueCurrency()).to.equal(TEST_NOMINAL_VALUES.CURRENCY_ZERO);
+    });
+
+    it("GIVEN an uninitialized nominalValue WHEN initializeNominalValue is called THEN emits NominalValueInitialized with all 3 args", async () => {
+      // Reset initialized flag so initializeNominalValue can run again
+      await migrationFacet.resetNominalValueInitialized();
+
+      await expect(asset.connect(signer_A).initializeNominalValue(1234, 5, CURRENCIES.EUR))
+        .to.emit(asset, EVENT_NAMES.NOMINAL_VALUE_INITIALIZED)
+        .withArgs(signer_A.address, 1234, 5, CURRENCIES.EUR);
+
+      expect(await asset.getNominalValue()).to.equal(1234);
+      expect(await asset.getNominalValueDecimals()).to.equal(5);
+      expect(await asset.getNominalValueCurrency()).to.equal(CURRENCIES.EUR);
     });
   });
 
   describe("NominalValueFacet Static Selectors", () => {
-    it("GIVEN the NominalValueFacet WHEN getStaticFunctionSelectors is called THEN returns 4 selectors", async () => {
+    it("GIVEN the NominalValueFacet WHEN getStaticFunctionSelectors is called THEN returns 6 selectors", async () => {
       const factory = await ethers.getContractFactory("NominalValueFacet");
       const facet = await factory.deploy();
       await facet.waitForDeployment();
 
       const selectors = await facet.getStaticFunctionSelectors();
-      expect(selectors.length).to.equal(4);
+      expect(selectors.length).to.equal(6);
     });
 
     it("GIVEN the NominalValueFacet WHEN getStaticInterfaceIds is called THEN returns 1 interface id", async () => {
@@ -349,6 +365,57 @@ describe("NominalValue Migration Tests", () => {
 
     it("GIVEN a user without _NOMINAL_VALUE_ROLE WHEN setNominalValue THEN reverts with AccountHasNoRole", async () => {
       await expect(asset.connect(signer_B).setNominalValue(500, 4)).to.be.rejectedWith("AccountHasNoRole");
+    });
+
+    it("GIVEN a user with _NOMINAL_VALUE_ROLE WHEN setNominalValueCurrency THEN succeeds", async () => {
+      await asset.connect(signer_A).setNominalValueCurrency(CURRENCIES.EUR);
+
+      expect(await asset.getNominalValueCurrency()).to.equal(CURRENCIES.EUR);
+    });
+
+    it("GIVEN a user without _NOMINAL_VALUE_ROLE WHEN setNominalValueCurrency THEN reverts with AccountHasNoRole", async () => {
+      await expect(asset.connect(signer_B).setNominalValueCurrency(CURRENCIES.EUR)).to.be.rejectedWith(
+        "AccountHasNoRole",
+      );
+    });
+  });
+
+  describe("NominalValue Currency", () => {
+    let diamond: ResolverProxy;
+    let signer_A: HardhatEthersSigner;
+
+    let asset: IAsset;
+
+    async function deployBondFixture() {
+      const base = await deployBondTokenFixture();
+
+      diamond = base.diamond;
+      signer_A = base.deployer;
+
+      asset = await ethers.getContractAt("IAsset", diamond.target, signer_A);
+    }
+
+    beforeEach(async () => {
+      await loadFixture(deployBondFixture);
+    });
+
+    it("GIVEN a freshly-deployed bond WHEN getNominalValueCurrency THEN returns the currency forwarded by the factory", async () => {
+      // Factory wires bondDetails.currency through _tryInitializeNominalValue; default fixture uses USD.
+      expect(await asset.getNominalValueCurrency()).to.equal(CURRENCIES.USD);
+    });
+
+    it("GIVEN a bond WHEN setNominalValueCurrency is called THEN it overwrites the stored currency and emits NominalValueCurrencySet", async () => {
+      await expect(asset.connect(signer_A).setNominalValueCurrency(CURRENCIES.GBP))
+        .to.emit(asset, EVENT_NAMES.NOMINAL_VALUE_CURRENCY_SET)
+        .withArgs(signer_A.address, CURRENCIES.GBP);
+
+      expect(await asset.getNominalValueCurrency()).to.equal(CURRENCIES.GBP);
+    });
+
+    it("GIVEN a freshly-deployed bond WHEN setNominalValue is called THEN currency is preserved", async () => {
+      await asset.connect(signer_A).setNominalValue(999, 6);
+
+      expect(await asset.getNominalValueCurrency()).to.equal(CURRENCIES.USD);
     });
   });
 

--- a/packages/ats/contracts/test/fixtures/tokens/loan.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/loan.fixture.ts
@@ -302,9 +302,10 @@ export async function deployLoanTokenFixture({
   await externalKycListManagementFacet.initializeExternalKycLists([]);
   await erc20VotesFacet.initialize_ERC20Votes(securityData.erc20VotesActivated);
   await erc3643ManagementFacet.initialize_ERC3643(ZeroAddress, ZeroAddress);
-  await nominalValueFacet.initialize_NominalValue(
+  await nominalValueFacet.initializeNominalValue(
     loanParams?.nominalValue ?? DEFAULT_LOAN_PARAMS.nominalValue,
     loanParams?.nominalValueDecimals ?? DEFAULT_LOAN_PARAMS.nominalValueDecimals,
+    loanParams?.loanInit?.currency ?? DEFAULT_LOAN_PARAMS.currency,
   );
 
   await loanFacet.initialize_Loan(

--- a/packages/ats/contracts/test/fixtures/tokens/loansPortfolio.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/loansPortfolio.fixture.ts
@@ -48,7 +48,7 @@ import {
 
 import { decodeEvent } from "@scripts/infrastructure";
 import { DeepPartial } from "@scripts";
-import { getRegulationData, getSecurityData } from "@test";
+import { getRegulationData, getSecurityData, TEST_NOMINAL_VALUES } from "@test";
 
 type LoansPortfolioDefaultParamsType = ILoansPortfolio.LoansPortfolioDetailsDataStruct & {
   nominalValue: bigint;
@@ -175,9 +175,11 @@ export async function deployLoansPortfolioTokenFixture({
   await externalKycListManagementFacet.initializeExternalKycLists([]);
   await erc20VotesFacet.initialize_ERC20Votes(false);
   await erc3643ManagementFacet.initialize_ERC3643(ZeroAddress, ZeroAddress);
-  await nominalValueFacet.initialize_NominalValue(
+  // Loan portfolios don't carry a per-token currency; pass bytes3(0).
+  await nominalValueFacet.initializeNominalValue(
     loanPortfolioDetails.nominalValue,
     loanPortfolioDetails.nominalValueDecimals,
+    TEST_NOMINAL_VALUES.CURRENCY_ZERO,
   );
   await loanPortfolioFacet.initializeLoansPortfolio(
     {

--- a/packages/ats/contracts/test/helpers/constants.ts
+++ b/packages/ats/contracts/test/helpers/constants.ts
@@ -249,6 +249,21 @@ export const TEST_CONTRACT_IDS = {
 // ============================================================================
 
 /**
+ * Common empty (all-zero) bytes values, parameterised by width.
+ *
+ * ethers v6 ships only `ZeroAddress` (20 bytes) and `ZeroHash` (32 bytes); this
+ * registry covers the widths the contracts use that ethers doesn't expose, so
+ * tests and fixtures can avoid raw hex literals.
+ *
+ * Add new widths here when a test or fixture needs them — keep them generic
+ * (no domain wording) so unrelated tests can reuse them.
+ */
+export const EMPTY_BYTES = {
+  /** bytes3(0) — used by ISO 4217 currency-like fields. */
+  BYTES3: "0x000000",
+} as const;
+
+/**
  * Valid and invalid bytes32 values for validation tests.
  */
 export const TEST_BYTES32 = {
@@ -960,6 +975,9 @@ export const TEST_NOMINAL_VALUES = {
 
   /** Max supply for tokens */
   MAX_SUPPLY: "1000000000000000000000000",
+
+  /** bytes3(0) — represents "no currency set" for nominalValueCurrency. Alias of `EMPTY_BYTES.BYTES3`. */
+  CURRENCY_ZERO: EMPTY_BYTES.BYTES3,
 } as const;
 
 // ============================================================================
@@ -1285,4 +1303,10 @@ export const EVENT_NAMES = {
   PROTECTED_CLEARED_TRANSFER_BY_PARTITION: "ProtectedClearedTransferByPartition",
   /** Emitted by `ProtectedClearingHoldByPartitionFacet.protectedClearingCreateHoldByPartition`. */
   PROTECTED_CLEARED_HOLD_BY_PARTITION: "ProtectedClearedHoldByPartition",
+  /** Emitted by `NominalValue.initializeNominalValue`. */
+  NOMINAL_VALUE_INITIALIZED: "NominalValueInitialized",
+  /** Emitted by `NominalValue.setNominalValue` (and by the bootstrap path inside `setNominalValue` for legacy tokens). */
+  NOMINAL_VALUE_SET: "NominalValueSet",
+  /** Emitted by `NominalValue.setNominalValueCurrency`. */
+  NOMINAL_VALUE_CURRENCY_SET: "NominalValueCurrencySet",
 } as const;

--- a/packages/ats/sdk/__tests__/fixtures/nominalValue/NominalValueFixture.ts
+++ b/packages/ats/sdk/__tests__/fixtures/nominalValue/NominalValueFixture.ts
@@ -1,18 +1,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { Faker } from "@faker-js/faker";
 import { createFixture } from "../config";
 import { HederaIdPropsFixture } from "../shared/DataFixture";
 import { SetNominalValueCommand } from "@command/security/nominalValue/setNominalValue/SetNominalValueCommand";
+import { SetNominalValueCurrencyCommand } from "@command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommand";
 import { GetNominalValueQuery } from "@query/security/nominalValue/getNominalValue/GetNominalValueQuery";
 import { GetNominalValueDecimalsQuery } from "@query/security/nominalValue/getNominalValueDecimals/GetNominalValueDecimalsQuery";
+import { GetNominalValueCurrencyQuery } from "@query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQuery";
 import SetNominalValueRequest from "@port/in/request/security/operations/nominalValue/SetNominalValueRequest";
+import SetNominalValueCurrencyRequest from "@port/in/request/security/operations/nominalValue/SetNominalValueCurrencyRequest";
 import GetNominalValueRequest from "@port/in/request/security/operations/nominalValue/GetNominalValueRequest";
 import GetNominalValueDecimalsRequest from "@port/in/request/security/operations/nominalValue/GetNominalValueDecimalsRequest";
+import GetNominalValueCurrencyRequest from "@port/in/request/security/operations/nominalValue/GetNominalValueCurrencyRequest";
+
+// bytes3 ISO 4217 currency code: "0x" + 6 hex chars (3 bytes).
+const fakeCurrencyCode = (faker: Faker) => faker.string.hexadecimal({ length: 6, prefix: "0x", casing: "lower" });
 
 export const SetNominalValueCommandFixture = createFixture<SetNominalValueCommand>((command) => {
   command.securityId.as(() => HederaIdPropsFixture.create().value);
   command.nominalValue.faker((faker) => faker.number.int({ min: 1, max: 1000000 }).toString());
   command.nominalValueDecimals.faker((faker) => faker.number.int({ min: 0, max: 18 }));
+});
+
+export const SetNominalValueCurrencyCommandFixture = createFixture<SetNominalValueCurrencyCommand>((command) => {
+  command.securityId.as(() => HederaIdPropsFixture.create().value);
+  command.nominalValueCurrency.faker(fakeCurrencyCode);
 });
 
 export const GetNominalValueQueryFixture = createFixture<GetNominalValueQuery>((query) => {
@@ -23,10 +36,19 @@ export const GetNominalValueDecimalsQueryFixture = createFixture<GetNominalValue
   query.securityId.as(() => HederaIdPropsFixture.create().value);
 });
 
+export const GetNominalValueCurrencyQueryFixture = createFixture<GetNominalValueCurrencyQuery>((query) => {
+  query.securityId.as(() => HederaIdPropsFixture.create().value);
+});
+
 export const SetNominalValueRequestFixture = createFixture<SetNominalValueRequest>((request) => {
   request.securityId.as(() => HederaIdPropsFixture.create().value);
   request.nominalValue.faker((faker) => faker.number.int({ min: 1, max: 1000000 }).toString());
   request.nominalValueDecimals.faker((faker) => faker.number.int({ min: 0, max: 18 }));
+});
+
+export const SetNominalValueCurrencyRequestFixture = createFixture<SetNominalValueCurrencyRequest>((request) => {
+  request.securityId.as(() => HederaIdPropsFixture.create().value);
+  request.nominalValueCurrency.faker(fakeCurrencyCode);
 });
 
 export const GetNominalValueRequestFixture = createFixture<GetNominalValueRequest>((request) => {
@@ -34,5 +56,9 @@ export const GetNominalValueRequestFixture = createFixture<GetNominalValueReques
 });
 
 export const GetNominalValueDecimalsRequestFixture = createFixture<GetNominalValueDecimalsRequest>((request) => {
+  request.securityId.as(() => HederaIdPropsFixture.create().value);
+});
+
+export const GetNominalValueCurrencyRequestFixture = createFixture<GetNominalValueCurrencyRequest>((request) => {
   request.securityId.as(() => HederaIdPropsFixture.create().value);
 });

--- a/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommand.ts
+++ b/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommand.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Command } from "@core/command/Command";
+import { CommandResponse } from "@core/command/CommandResponse";
+
+export class SetNominalValueCurrencyCommandResponse implements CommandResponse {
+  constructor(
+    public readonly payload: boolean,
+    public readonly transactionId: string,
+  ) {}
+}
+
+export class SetNominalValueCurrencyCommand extends Command<SetNominalValueCurrencyCommandResponse> {
+  constructor(
+    public readonly securityId: string,
+    public readonly nominalValueCurrency: string,
+  ) {
+    super();
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommandHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommandHandler.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ICommandHandler } from "@core/command/CommandHandler";
+import { CommandHandler } from "@core/decorator/CommandHandlerDecorator";
+import AccountService from "@service/account/AccountService";
+import {
+  SetNominalValueCurrencyCommand,
+  SetNominalValueCurrencyCommandResponse,
+} from "./SetNominalValueCurrencyCommand";
+import TransactionService from "@service/transaction/TransactionService";
+import { lazyInject } from "@core/decorator/LazyInjectDecorator";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import { SecurityRole } from "@domain/context/security/SecurityRole";
+import ValidationService from "@service/validation/ValidationService";
+import ContractService from "@service/contract/ContractService";
+import { SetNominalValueCurrencyCommandError } from "./error/SetNominalValueCurrencyCommandError";
+
+@CommandHandler(SetNominalValueCurrencyCommand)
+export class SetNominalValueCurrencyCommandHandler implements ICommandHandler<SetNominalValueCurrencyCommand> {
+  constructor(
+    @lazyInject(AccountService)
+    private readonly accountService: AccountService,
+    @lazyInject(TransactionService)
+    private readonly transactionService: TransactionService,
+    @lazyInject(ValidationService)
+    private readonly validationService: ValidationService,
+    @lazyInject(ContractService)
+    private readonly contractService: ContractService,
+  ) {}
+
+  async execute(command: SetNominalValueCurrencyCommand): Promise<SetNominalValueCurrencyCommandResponse> {
+    try {
+      const { securityId, nominalValueCurrency } = command;
+      const handler = this.transactionService.getHandler();
+      const account = this.accountService.getCurrentAccount();
+
+      const securityEvmAddress: EvmAddress = await this.contractService.getContractEvmAddress(securityId);
+
+      await this.validationService.checkPause(securityId);
+
+      await this.validationService.checkRole(SecurityRole._NOMINAL_VALUE_ROLE, account.id.toString(), securityId);
+
+      const res = await handler.setNominalValueCurrency(securityEvmAddress, nominalValueCurrency, securityId);
+
+      return Promise.resolve(new SetNominalValueCurrencyCommandResponse(res.error === undefined, res.id!));
+    } catch (error) {
+      throw new SetNominalValueCurrencyCommandError(error as Error);
+    }
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommandHandler.unit.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import TransactionService from "@service/transaction/TransactionService";
+import { createMock } from "@golevelup/ts-jest";
+import AccountService from "@service/account/AccountService";
+import {
+  ErrorMsgFixture,
+  EvmAddressPropsFixture,
+  HederaIdPropsFixture,
+  TransactionIdFixture,
+} from "@test/fixtures/shared/DataFixture";
+import ContractService from "@service/contract/ContractService";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import ValidationService from "@service/validation/ValidationService";
+import Account from "@domain/context/account/Account";
+import { SecurityRole } from "@domain/context/security/SecurityRole";
+import {
+  SetNominalValueCurrencyCommand,
+  SetNominalValueCurrencyCommandResponse,
+} from "./SetNominalValueCurrencyCommand";
+import { SetNominalValueCurrencyCommandHandler } from "./SetNominalValueCurrencyCommandHandler";
+import { SetNominalValueCurrencyCommandFixture } from "@test/fixtures/nominalValue/NominalValueFixture";
+import { SetNominalValueCurrencyCommandError } from "./error/SetNominalValueCurrencyCommandError";
+import { ErrorCode } from "@core/error/BaseError";
+import { SecurityPaused } from "@domain/context/security/error/operations/SecurityPaused";
+import { NotGrantedRole } from "@domain/context/security/error/operations/NotGrantedRole";
+
+describe("SetNominalValueCurrencyCommandHandler", () => {
+  let handler: SetNominalValueCurrencyCommandHandler;
+  let command: SetNominalValueCurrencyCommand;
+
+  const transactionServiceMock = createMock<TransactionService>();
+  const validationServiceMock = createMock<ValidationService>();
+  const accountServiceMock = createMock<AccountService>();
+  const contractServiceMock = createMock<ContractService>();
+
+  const evmAddress = new EvmAddress(EvmAddressPropsFixture.create().value);
+  const account = new Account({
+    id: HederaIdPropsFixture.create().value,
+    evmAddress: EvmAddressPropsFixture.create().value,
+  });
+  const transactionId = TransactionIdFixture.create().id;
+  const errorMsg = ErrorMsgFixture.create().msg;
+
+  beforeEach(() => {
+    handler = new SetNominalValueCurrencyCommandHandler(
+      accountServiceMock,
+      transactionServiceMock,
+      validationServiceMock,
+      contractServiceMock,
+    );
+    command = SetNominalValueCurrencyCommandFixture.create();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("execute", () => {
+    it("throws SetNominalValueCurrencyCommandError when security is paused", async () => {
+      const fakeError = new SecurityPaused();
+
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(evmAddress);
+      accountServiceMock.getCurrentAccount.mockReturnValue(account);
+      validationServiceMock.checkPause.mockRejectedValue(fakeError);
+
+      const resultPromise = handler.execute(command);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(SetNominalValueCurrencyCommandError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(
+          `An error occurred while setting nominal value currency: ${fakeError.message}`,
+        ),
+        errorCode: ErrorCode.SecurityPaused,
+      });
+
+      expect(validationServiceMock.checkPause).toHaveBeenCalledWith(command.securityId);
+    });
+
+    it("throws SetNominalValueCurrencyCommandError when account does not have NOMINAL_VALUE_ROLE", async () => {
+      const fakeError = new NotGrantedRole(SecurityRole._NOMINAL_VALUE_ROLE);
+
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(evmAddress);
+      accountServiceMock.getCurrentAccount.mockReturnValue(account);
+      validationServiceMock.checkPause.mockResolvedValue(undefined);
+      validationServiceMock.checkRole.mockRejectedValue(fakeError);
+
+      const resultPromise = handler.execute(command);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(SetNominalValueCurrencyCommandError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(
+          `An error occurred while setting nominal value currency: ${fakeError.message}`,
+        ),
+        errorCode: ErrorCode.RoleNotAssigned,
+      });
+
+      expect(validationServiceMock.checkRole).toHaveBeenCalledWith(
+        SecurityRole._NOMINAL_VALUE_ROLE,
+        account.id.toString(),
+        command.securityId,
+      );
+    });
+
+    it("throws SetNominalValueCurrencyCommandError when command fails with uncaught error", async () => {
+      const fakeError = new Error(errorMsg);
+
+      contractServiceMock.getContractEvmAddress.mockRejectedValue(fakeError);
+
+      const resultPromise = handler.execute(command);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(SetNominalValueCurrencyCommandError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(`An error occurred while setting nominal value currency: ${errorMsg}`),
+        errorCode: ErrorCode.UncaughtCommandError,
+      });
+    });
+
+    it("should successfully set nominal value currency", async () => {
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(evmAddress);
+      accountServiceMock.getCurrentAccount.mockReturnValue(account);
+      validationServiceMock.checkPause.mockResolvedValue(undefined);
+      validationServiceMock.checkRole.mockResolvedValue(undefined);
+      transactionServiceMock.getHandler().setNominalValueCurrency.mockResolvedValue({
+        id: transactionId,
+      });
+
+      const result = await handler.execute(command);
+
+      expect(result).toBeInstanceOf(SetNominalValueCurrencyCommandResponse);
+      expect(result.payload).toBe(true);
+      expect(result.transactionId).toBe(transactionId);
+
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledTimes(1);
+      expect(validationServiceMock.checkPause).toHaveBeenCalledTimes(1);
+      expect(validationServiceMock.checkRole).toHaveBeenCalledTimes(1);
+      expect(accountServiceMock.getCurrentAccount).toHaveBeenCalledTimes(1);
+      expect(transactionServiceMock.getHandler().setNominalValueCurrency).toHaveBeenCalledTimes(1);
+
+      expect(validationServiceMock.checkPause).toHaveBeenCalledWith(command.securityId);
+      expect(validationServiceMock.checkRole).toHaveBeenCalledWith(
+        SecurityRole._NOMINAL_VALUE_ROLE,
+        account.id.toString(),
+        command.securityId,
+      );
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(command.securityId);
+      expect(transactionServiceMock.getHandler().setNominalValueCurrency).toHaveBeenCalledWith(
+        evmAddress,
+        command.nominalValueCurrency,
+        command.securityId,
+      );
+    });
+  });
+});

--- a/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/error/SetNominalValueCurrencyCommandError.ts
+++ b/packages/ats/sdk/src/app/usecase/command/security/nominalValue/setNominalValueCurrency/error/SetNominalValueCurrencyCommandError.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { CommandError } from "@command/error/CommandError";
+import BaseError from "@core/error/BaseError";
+
+export class SetNominalValueCurrencyCommandError extends CommandError {
+  constructor(error: Error) {
+    const msg = `An error occurred while setting nominal value currency: ${error.message}`;
+    super(msg, error instanceof BaseError ? error.errorCode : undefined);
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQuery.ts
+++ b/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQuery.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Query } from "@core/query/Query";
+import { QueryResponse } from "@core/query/QueryResponse";
+
+export class GetNominalValueCurrencyQueryResponse implements QueryResponse {
+  constructor(public readonly payload: string) {}
+}
+
+export class GetNominalValueCurrencyQuery extends Query<GetNominalValueCurrencyQueryResponse> {
+  constructor(public readonly securityId: string) {
+    super();
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQueryHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQueryHandler.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { GetNominalValueCurrencyQuery, GetNominalValueCurrencyQueryResponse } from "./GetNominalValueCurrencyQuery";
+import { QueryHandler } from "@core/decorator/QueryHandlerDecorator";
+import { IQueryHandler } from "@core/query/QueryHandler";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import { lazyInject } from "@core/decorator/LazyInjectDecorator";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import ContractService from "@service/contract/ContractService";
+import { GetNominalValueCurrencyQueryError } from "./error/GetNominalValueCurrencyQueryError";
+
+@QueryHandler(GetNominalValueCurrencyQuery)
+export class GetNominalValueCurrencyQueryHandler implements IQueryHandler<GetNominalValueCurrencyQuery> {
+  constructor(
+    @lazyInject(RPCQueryAdapter)
+    private readonly queryAdapter: RPCQueryAdapter,
+    @lazyInject(ContractService)
+    private readonly contractService: ContractService,
+  ) {}
+
+  async execute(query: GetNominalValueCurrencyQuery): Promise<GetNominalValueCurrencyQueryResponse> {
+    try {
+      const { securityId } = query;
+
+      const securityEvmAddress: EvmAddress = await this.contractService.getContractEvmAddress(securityId);
+      const res = await this.queryAdapter.getNominalValueCurrency(securityEvmAddress);
+      return new GetNominalValueCurrencyQueryResponse(res);
+    } catch (error) {
+      throw new GetNominalValueCurrencyQueryError(error as Error);
+    }
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQueryHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQueryHandler.unit.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMock } from "@golevelup/ts-jest";
+import { ErrorMsgFixture, EvmAddressPropsFixture } from "@test/fixtures/shared/DataFixture";
+import { ErrorCode } from "@core/error/BaseError";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import ContractService from "@service/contract/ContractService";
+import { GetNominalValueCurrencyQuery, GetNominalValueCurrencyQueryResponse } from "./GetNominalValueCurrencyQuery";
+import { GetNominalValueCurrencyQueryHandler } from "./GetNominalValueCurrencyQueryHandler";
+import { GetNominalValueCurrencyQueryFixture } from "@test/fixtures/nominalValue/NominalValueFixture";
+import { GetNominalValueCurrencyQueryError } from "./error/GetNominalValueCurrencyQueryError";
+
+describe("GetNominalValueCurrencyQueryHandler", () => {
+  let handler: GetNominalValueCurrencyQueryHandler;
+  let query: GetNominalValueCurrencyQuery;
+
+  const queryAdapterServiceMock = createMock<RPCQueryAdapter>();
+  const contractServiceMock = createMock<ContractService>();
+
+  const evmAddress = new EvmAddress(EvmAddressPropsFixture.create().value);
+  const errorMsg = ErrorMsgFixture.create().msg;
+
+  beforeEach(() => {
+    handler = new GetNominalValueCurrencyQueryHandler(queryAdapterServiceMock, contractServiceMock);
+    query = GetNominalValueCurrencyQueryFixture.create();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("execute", () => {
+    it("throws GetNominalValueCurrencyQueryError when query fails with uncaught error", async () => {
+      const fakeError = new Error(errorMsg);
+
+      contractServiceMock.getContractEvmAddress.mockRejectedValue(fakeError);
+
+      const resultPromise = handler.execute(query);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(GetNominalValueCurrencyQueryError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(`An error occurred while querying nominal value currency: ${errorMsg}`),
+        errorCode: ErrorCode.UncaughtQueryError,
+      });
+    });
+
+    it("should successfully get nominal value currency", async () => {
+      const currency = "0x555344"; // USD
+
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(evmAddress);
+      queryAdapterServiceMock.getNominalValueCurrency.mockResolvedValueOnce(currency);
+
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(GetNominalValueCurrencyQueryResponse);
+      expect(result.payload).toBe(currency);
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledTimes(1);
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(query.securityId);
+      expect(queryAdapterServiceMock.getNominalValueCurrency).toHaveBeenCalledWith(evmAddress);
+    });
+  });
+});

--- a/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/error/GetNominalValueCurrencyQueryError.ts
+++ b/packages/ats/sdk/src/app/usecase/query/security/nominalValue/getNominalValueCurrency/error/GetNominalValueCurrencyQueryError.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { QueryError } from "@query/error/QueryError";
+import BaseError from "@core/error/BaseError";
+
+export class GetNominalValueCurrencyQueryError extends QueryError {
+  constructor(error: Error) {
+    const msg = `An error occurred while querying nominal value currency: ${error.message}`;
+    super(msg, error instanceof BaseError ? error.errorCode : undefined);
+  }
+}

--- a/packages/ats/sdk/src/core/Constants.ts
+++ b/packages/ats/sdk/src/core/Constants.ts
@@ -131,6 +131,7 @@ export const GAS = {
   SET_NAME: 7000000,
   SET_SYMBOL: 7000000,
   SET_NOMINAL_VALUE: 7000000,
+  SET_NOMINAL_VALUE_CURRENCY: 7000000,
   FREEZE_PARTIAL_TOKENS: 7000000,
   UNFREEZE_PARTIAL_TOKENS: 7000000,
   SET_ADDRESS_FROZEN: 700000,
@@ -175,6 +176,7 @@ export const CANCEL_COUPON_EVENT = "CouponCancelled";
 export const CANCEL_VOTING_EVENT = "VotingCancelled";
 export const SET_SCHEDULED_BALANCE_ADJUSTMENT_EVENT = "ScheduledBalanceAdjustmentSet";
 export const NOMINAL_VALUE_SET_EVENT = "NominalValueSet";
+export const NOMINAL_VALUE_CURRENCY_SET_EVENT = "NominalValueCurrencySet";
 export const CANCEL_SCHEDULED_BALANCE_ADJUSTMENT_EVENT = "ScheduledBalanceAdjustmentCancelled";
 export const SET_AMORTIZATION_EVENT = "AmortizationSet";
 export const CANCEL_AMORTIZATION_EVENT = "AmortizationCancelled";

--- a/packages/ats/sdk/src/core/injectable/security/InjectableNominalValue.ts
+++ b/packages/ats/sdk/src/core/injectable/security/InjectableNominalValue.ts
@@ -2,13 +2,19 @@
 
 import { TOKENS } from "../Tokens";
 import { SetNominalValueCommandHandler } from "@command/security/nominalValue/setNominalValue/SetNominalValueCommandHandler";
+import { SetNominalValueCurrencyCommandHandler } from "@command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommandHandler";
 import { GetNominalValueQueryHandler } from "@query/security/nominalValue/getNominalValue/GetNominalValueQueryHandler";
 import { GetNominalValueDecimalsQueryHandler } from "@query/security/nominalValue/getNominalValueDecimals/GetNominalValueDecimalsQueryHandler";
+import { GetNominalValueCurrencyQueryHandler } from "@query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQueryHandler";
 
 export const COMMAND_HANDLERS_NOMINAL_VALUE = [
   {
     token: TOKENS.COMMAND_HANDLER,
     useClass: SetNominalValueCommandHandler,
+  },
+  {
+    token: TOKENS.COMMAND_HANDLER,
+    useClass: SetNominalValueCurrencyCommandHandler,
   },
 ];
 
@@ -20,5 +26,9 @@ export const QUERY_HANDLERS_NOMINAL_VALUE = [
   {
     token: TOKENS.QUERY_HANDLER,
     useClass: GetNominalValueDecimalsQueryHandler,
+  },
+  {
+    token: TOKENS.QUERY_HANDLER,
+    useClass: GetNominalValueCurrencyQueryHandler,
   },
 ];

--- a/packages/ats/sdk/src/port/in/request/index.ts
+++ b/packages/ats/sdk/src/port/in/request/index.ts
@@ -155,8 +155,10 @@ import GetKycStatusMockRequest from "./security/externalKycLists/mock/GetKycStat
 import SetNameRequest from "./security/operations/tokeMetadata/SetNameRequest";
 import SetSymbolRequest from "./security/operations/tokeMetadata/SetSymbolRequest";
 import SetNominalValueRequest from "./security/operations/nominalValue/SetNominalValueRequest";
+import SetNominalValueCurrencyRequest from "./security/operations/nominalValue/SetNominalValueCurrencyRequest";
 import GetNominalValueRequest from "./security/operations/nominalValue/GetNominalValueRequest";
 import GetNominalValueDecimalsRequest from "./security/operations/nominalValue/GetNominalValueDecimalsRequest";
+import GetNominalValueCurrencyRequest from "./security/operations/nominalValue/GetNominalValueCurrencyRequest";
 import SetAmortizationRequest from "./security/amortization/SetAmortizationRequest";
 import CancelAmortizationRequest from "./security/amortization/CancelAmortizationRequest";
 import SetAmortizationHoldRequest from "./security/amortization/SetAmortizationHoldRequest";
@@ -468,8 +470,10 @@ export {
   CancelScheduledBalanceAdjustmentRequest,
   CancelVotingRequest,
   SetNominalValueRequest,
+  SetNominalValueCurrencyRequest,
   GetNominalValueRequest,
   GetNominalValueDecimalsRequest,
+  GetNominalValueCurrencyRequest,
   SetAmortizationRequest,
   CancelAmortizationRequest,
   SetAmortizationHoldRequest,

--- a/packages/ats/sdk/src/port/in/request/security/operations/nominalValue/GetNominalValueCurrencyRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/security/operations/nominalValue/GetNominalValueCurrencyRequest.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import FormatValidation from "@port/in/request/FormatValidation";
+
+export default class GetNominalValueCurrencyRequest extends ValidatedRequest<GetNominalValueCurrencyRequest> {
+  securityId: string;
+
+  constructor({ securityId }: { securityId: string }) {
+    super({
+      securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
+    });
+
+    this.securityId = securityId;
+  }
+}

--- a/packages/ats/sdk/src/port/in/request/security/operations/nominalValue/SetNominalValueCurrencyRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/security/operations/nominalValue/SetNominalValueCurrencyRequest.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import FormatValidation from "@port/in/request/FormatValidation";
+
+export default class SetNominalValueCurrencyRequest extends ValidatedRequest<SetNominalValueCurrencyRequest> {
+  securityId: string;
+  nominalValueCurrency: string;
+
+  constructor({ securityId, nominalValueCurrency }: { securityId: string; nominalValueCurrency: string }) {
+    super({
+      securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
+      nominalValueCurrency: FormatValidation.checkBytes3Format(),
+    });
+
+    this.securityId = securityId;
+    this.nominalValueCurrency = nominalValueCurrency;
+  }
+}

--- a/packages/ats/sdk/src/port/in/security/nominalValue/NominalValue.ts
+++ b/packages/ats/sdk/src/port/in/security/nominalValue/NominalValue.ts
@@ -3,17 +3,25 @@
 import { LogError } from "@core/decorator/LogErrorDecorator";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import { SetNominalValueCommand } from "@command/security/nominalValue/setNominalValue/SetNominalValueCommand";
+import { SetNominalValueCurrencyCommand } from "@command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommand";
 import { GetNominalValueQuery } from "@query/security/nominalValue/getNominalValue/GetNominalValueQuery";
 import { GetNominalValueDecimalsQuery } from "@query/security/nominalValue/getNominalValueDecimals/GetNominalValueDecimalsQuery";
+import { GetNominalValueCurrencyQuery } from "@query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQuery";
 import { BaseSecurityInPort } from "../BaseSecurityInPort";
 import SetNominalValueRequest from "../../request/security/operations/nominalValue/SetNominalValueRequest";
+import SetNominalValueCurrencyRequest from "../../request/security/operations/nominalValue/SetNominalValueCurrencyRequest";
 import GetNominalValueRequest from "../../request/security/operations/nominalValue/GetNominalValueRequest";
 import GetNominalValueDecimalsRequest from "../../request/security/operations/nominalValue/GetNominalValueDecimalsRequest";
+import GetNominalValueCurrencyRequest from "../../request/security/operations/nominalValue/GetNominalValueCurrencyRequest";
 
 export interface ISecurityInPortNominalValue {
   setNominalValue(request: SetNominalValueRequest): Promise<{ payload: boolean; transactionId: string }>;
+  setNominalValueCurrency(
+    request: SetNominalValueCurrencyRequest,
+  ): Promise<{ payload: boolean; transactionId: string }>;
   getNominalValue(request: GetNominalValueRequest): Promise<string>;
   getNominalValueDecimals(request: GetNominalValueDecimalsRequest): Promise<number>;
+  getNominalValueCurrency(request: GetNominalValueCurrencyRequest): Promise<string>;
 }
 
 export class SecurityInPortNominalValue extends BaseSecurityInPort implements ISecurityInPortNominalValue {
@@ -23,6 +31,16 @@ export class SecurityInPortNominalValue extends BaseSecurityInPort implements IS
     ValidatedRequest.handleValidation("SetNominalValueRequest", request);
 
     return await this.commandBus.execute(new SetNominalValueCommand(securityId, nominalValue, nominalValueDecimals));
+  }
+
+  @LogError
+  async setNominalValueCurrency(
+    request: SetNominalValueCurrencyRequest,
+  ): Promise<{ payload: boolean; transactionId: string }> {
+    const { securityId, nominalValueCurrency } = request;
+    ValidatedRequest.handleValidation("SetNominalValueCurrencyRequest", request);
+
+    return await this.commandBus.execute(new SetNominalValueCurrencyCommand(securityId, nominalValueCurrency));
   }
 
   @LogError
@@ -39,5 +57,13 @@ export class SecurityInPortNominalValue extends BaseSecurityInPort implements IS
     ValidatedRequest.handleValidation("GetNominalValueDecimalsRequest", request);
 
     return (await this.queryBus.execute(new GetNominalValueDecimalsQuery(securityId))).payload;
+  }
+
+  @LogError
+  async getNominalValueCurrency(request: GetNominalValueCurrencyRequest): Promise<string> {
+    const { securityId } = request;
+    ValidatedRequest.handleValidation("GetNominalValueCurrencyRequest", request);
+
+    return (await this.queryBus.execute(new GetNominalValueCurrencyQuery(securityId))).payload;
   }
 }

--- a/packages/ats/sdk/src/port/in/security/nominalValue/NominalValue.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/security/nominalValue/NominalValue.unit.test.ts
@@ -11,13 +11,23 @@ import { TransactionIdFixture } from "@test/fixtures/shared/DataFixture";
 import Security from "@port/in/security/Security";
 import {
   SetNominalValueRequestFixture,
+  SetNominalValueCurrencyRequestFixture,
   GetNominalValueRequestFixture,
   GetNominalValueDecimalsRequestFixture,
+  GetNominalValueCurrencyRequestFixture,
 } from "@test/fixtures/nominalValue/NominalValueFixture";
-import { SetNominalValueRequest, GetNominalValueRequest, GetNominalValueDecimalsRequest } from "../../request";
+import {
+  SetNominalValueRequest,
+  SetNominalValueCurrencyRequest,
+  GetNominalValueRequest,
+  GetNominalValueDecimalsRequest,
+  GetNominalValueCurrencyRequest,
+} from "../../request";
 import { SetNominalValueCommand } from "@command/security/nominalValue/setNominalValue/SetNominalValueCommand";
+import { SetNominalValueCurrencyCommand } from "@command/security/nominalValue/setNominalValueCurrency/SetNominalValueCurrencyCommand";
 import { GetNominalValueQuery } from "@query/security/nominalValue/getNominalValue/GetNominalValueQuery";
 import { GetNominalValueDecimalsQuery } from "@query/security/nominalValue/getNominalValueDecimals/GetNominalValueDecimalsQuery";
+import { GetNominalValueCurrencyQuery } from "@query/security/nominalValue/getNominalValueCurrency/GetNominalValueCurrencyQuery";
 import BigDecimal from "@domain/context/shared/BigDecimal";
 
 describe("NominalValue", () => {
@@ -180,6 +190,126 @@ describe("NominalValue", () => {
       });
 
       await expect(Security.getNominalValueDecimals(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("setNominalValueCurrency", () => {
+    const setNominalValueCurrencyRequest = new SetNominalValueCurrencyRequest(
+      SetNominalValueCurrencyRequestFixture.create(),
+    );
+
+    const expectedResponse = {
+      payload: true,
+      transactionId: transactionId,
+    };
+
+    it("should set nominal value currency successfully", async () => {
+      commandBusMock.execute.mockResolvedValue(expectedResponse);
+
+      const result = await Security.setNominalValueCurrency(setNominalValueCurrencyRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(
+        "SetNominalValueCurrencyRequest",
+        setNominalValueCurrencyRequest,
+      );
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new SetNominalValueCurrencyCommand(
+          setNominalValueCurrencyRequest.securityId,
+          setNominalValueCurrencyRequest.nominalValueCurrency,
+        ),
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+
+    it("should throw an error if command execution fails", async () => {
+      const error = new Error("Command execution failed");
+      commandBusMock.execute.mockRejectedValue(error);
+
+      await expect(Security.setNominalValueCurrency(setNominalValueCurrencyRequest)).rejects.toThrow(
+        "Command execution failed",
+      );
+
+      expect(commandBusMock.execute).toHaveBeenCalledWith(
+        new SetNominalValueCurrencyCommand(
+          setNominalValueCurrencyRequest.securityId,
+          setNominalValueCurrencyRequest.nominalValueCurrency,
+        ),
+      );
+    });
+
+    it("should throw ValidationError if securityId is invalid", async () => {
+      const invalidRequest = new SetNominalValueCurrencyRequest({
+        ...SetNominalValueCurrencyRequestFixture.create({ securityId: "invalid" }),
+      });
+
+      await expect(Security.setNominalValueCurrency(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ValidationError if nominalValueCurrency is empty", async () => {
+      const invalidRequest = new SetNominalValueCurrencyRequest({
+        ...SetNominalValueCurrencyRequestFixture.create({ nominalValueCurrency: "" }),
+      });
+
+      await expect(Security.setNominalValueCurrency(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ValidationError if nominalValueCurrency is a non-bytes3 string (e.g. ASCII 'USD')", async () => {
+      const invalidRequest = new SetNominalValueCurrencyRequest({
+        ...SetNominalValueCurrencyRequestFixture.create({ nominalValueCurrency: "USD" }),
+      });
+
+      await expect(Security.setNominalValueCurrency(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw ValidationError if nominalValueCurrency hex is too long", async () => {
+      const invalidRequest = new SetNominalValueCurrencyRequest({
+        ...SetNominalValueCurrencyRequestFixture.create({ nominalValueCurrency: "0x55534455" }),
+      });
+
+      await expect(Security.setNominalValueCurrency(invalidRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("getNominalValueCurrency", () => {
+    const getNominalValueCurrencyRequest = new GetNominalValueCurrencyRequest(
+      GetNominalValueCurrencyRequestFixture.create(),
+    );
+
+    it("should get nominal value currency successfully", async () => {
+      const currency = "0x555344"; // USD
+      queryBusMock.execute.mockResolvedValue({ payload: currency });
+
+      const result = await Security.getNominalValueCurrency(getNominalValueCurrencyRequest);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith(
+        "GetNominalValueCurrencyRequest",
+        getNominalValueCurrencyRequest,
+      );
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetNominalValueCurrencyQuery(getNominalValueCurrencyRequest.securityId),
+      );
+      expect(result).toBe(currency);
+    });
+
+    it("should throw an error if query execution fails", async () => {
+      const error = new Error("Query execution failed");
+      queryBusMock.execute.mockRejectedValue(error);
+
+      await expect(Security.getNominalValueCurrency(getNominalValueCurrencyRequest)).rejects.toThrow(
+        "Query execution failed",
+      );
+
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new GetNominalValueCurrencyQuery(getNominalValueCurrencyRequest.securityId),
+      );
+    });
+
+    it("should throw ValidationError if securityId is invalid", async () => {
+      const invalidRequest = new GetNominalValueCurrencyRequest({
+        ...GetNominalValueCurrencyRequestFixture.create({ securityId: "invalid" }),
+      });
+
+      await expect(Security.getNominalValueCurrency(invalidRequest)).rejects.toThrow(ValidationError);
     });
   });
 });

--- a/packages/ats/sdk/src/port/out/TransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/TransactionAdapter.ts
@@ -884,6 +884,11 @@ interface INominalValueTransactionAdapter {
     nominalValueDecimals: number,
     securityId?: ContractId | string,
   ): Promise<TransactionResponse>;
+  setNominalValueCurrency(
+    security: EvmAddress,
+    nominalValueCurrency: string,
+    securityId?: ContractId | string,
+  ): Promise<TransactionResponse>;
 }
 
 export interface IAmortizationTransactionAdapter {
@@ -1845,6 +1850,12 @@ export default abstract class TransactionAdapter
     security: EvmAddress,
     nominalValue: string,
     nominalValueDecimals: number,
+    securityId?: ContractId | string,
+  ): Promise<TransactionResponse>;
+
+  abstract setNominalValueCurrency(
+    security: EvmAddress,
+    nominalValueCurrency: string,
     securityId?: ContractId | string,
   ): Promise<TransactionResponse>;
 

--- a/packages/ats/sdk/src/port/out/hs/BaseHederaTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/hs/BaseHederaTransactionAdapter.ts
@@ -746,6 +746,12 @@ export abstract class BaseHederaTransactionAdapter extends TransactionAdapter im
     return this.securityMetadataOps.setNominalValue(...args);
   }
 
+  async setNominalValueCurrency(
+    ...args: Parameters<SecurityMetadataOperations["setNominalValueCurrency"]>
+  ): Promise<TransactionResponse> {
+    return this.securityMetadataOps.setNominalValueCurrency(...args);
+  }
+
   async setDocument(...args: Parameters<SecurityMetadataOperations["setDocument"]>): Promise<TransactionResponse> {
     return this.securityMetadataOps.setDocument(...args);
   }

--- a/packages/ats/sdk/src/port/out/hs/operations/SecurityMetadataOperations.ts
+++ b/packages/ats/sdk/src/port/out/hs/operations/SecurityMetadataOperations.ts
@@ -362,4 +362,19 @@ export class SecurityMetadataOperations {
       GAS.SET_NOMINAL_VALUE,
     );
   }
+
+  async setNominalValueCurrency(
+    security: EvmAddress,
+    nominalValueCurrency: string,
+    securityId: ContractId | string,
+  ): Promise<TransactionResponse> {
+    LogService.logTrace(`Setting nominal value currency for security: ${security.toString()}`);
+    return this.executor.executeContractCall(
+      securityId.toString(),
+      IAsset__factory.createInterface(),
+      "setNominalValueCurrency",
+      [nominalValueCurrency],
+      GAS.SET_NOMINAL_VALUE_CURRENCY,
+    );
+  }
 }

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -1620,6 +1620,12 @@ export class RPCQueryAdapter {
     return Number(result);
   }
 
+  async getNominalValueCurrency(address: EvmAddress): Promise<string> {
+    LogService.logTrace(`Getting nominal value currency for security: ${address.toString()}`);
+    const result = await this.connect(IAsset__factory, address.toString()).getNominalValueCurrency();
+    return result;
+  }
+
   async getAmortization(address: EvmAddress, amortizationId: number): Promise<RegisteredAmortization> {
     LogService.logTrace(`Getting amortization: ${amortizationId}`);
 

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -14,6 +14,7 @@ import {
   CANCEL_VOTING_EVENT,
   EVM_ZERO_ADDRESS,
   GAS,
+  NOMINAL_VALUE_CURRENCY_SET_EVENT,
   NOMINAL_VALUE_SET_EVENT,
   RELEASE_AMORTIZATION_HOLD_EVENT,
   SET_AMORTIZATION_EVENT,
@@ -2716,6 +2717,21 @@ export class RPCTransactionAdapter extends TransactionAdapter {
       [nominalValue, nominalValueDecimals],
       GAS.SET_NOMINAL_VALUE,
       NOMINAL_VALUE_SET_EVENT,
+    );
+  }
+
+  async setNominalValueCurrency(
+    security: EvmAddress,
+    nominalValueCurrency: string,
+  ): Promise<TransactionResponse> {
+    LogService.logTrace(`Setting nominal value currency for security: ${security.toString()}`);
+
+    return this.executeTransaction(
+      IAsset__factory.connect(security.toString(), this.getSignerOrProvider()),
+      "setNominalValueCurrency",
+      [nominalValueCurrency],
+      GAS.SET_NOMINAL_VALUE_CURRENCY,
+      NOMINAL_VALUE_CURRENCY_SET_EVENT,
     );
   }
 


### PR DESCRIPTION
## Description

Extends the `NominalValue` facet with a per-token ISO 4217 `bytes3` currency. Adds `setNominalValueCurrency` / `getNominalValueCurrency`, widens `initializeNominalValue` to accept the currency, renames the old `initialize_NominalValue` to drop the solhint disable. Two new writer-owned events (`NominalValueInitialized`, `NominalValueCurrencySet`); existing `NominalValueSet` semantics unchanged. `Factory._tryInitializeNominalValue` forwards `bondDetails.currency` / `equityDetails.currency` so newly-deployed tokens land with the field set. New `NominalValueModifiers` + `onlyNotNominalValueInitialized` matches the project-wide initialiser pattern. SDK gains a symmetric command/query surface with `bytes3` format validation. Ticket: [BBND-1730](https://iobuilders.atlassian.net/browse/BBND-1730).

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

### Test Results (if any)

**Automated:**
- `npm run ats:contracts:test` → **2931 passing / 3 pending / 0 failing** (+6 over baseline of 2925).
- `npm run ats:sdk:test` for nominalValue suites → **33 passing / 0 failing** (6 suites: SetNominalValueCurrencyCommandHandler, GetNominalValueCurrencyQueryHandler, NominalValue port, plus the 3 existing nominalValue suites still green).
- `npx solhint --config solhint.config.js` on every touched contract file → **0 errors** (4 pre-existing `gas-indexed-events` warnings on event params).
- `npx hardhat compile` clean; `atsRegistry.data.ts` regenerated with exactly the expected delta (2 new selectors + rename + 2 new events).

**Manual sanity (local Hardhat):** Deploy a bond with `currency = 0x555344` ("USD"); `getNominalValueCurrency()` returns `0x555344`; `setNominalValueCurrency(0x455552)` ("EUR") flips it and emits `NominalValueCurrencySet`.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed
- [x] Linters - No New Warnings
- [x] Local Tests Pass
- [x] Effective Tests Added
- [ ] Documentation Updated
- [ ] No reduction of Coverage