### PR TITLE
fix: [FIND-120] Burn/Redeem and Transfer of Full Free Balance Removes Holder from Registry Despite Encumbered Tokens

### DIFF
--- a/.changeset/find-120-holder-removal-encumbered-tokens.md
+++ b/.changeset/find-120-holder-removal-encumbered-tokens.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-120: holder incorrectly removed from registry when burning or transferring all free tokens while encumbered tokens (locked/held/cleared/frozen) remain. Replace `_balanceOfAdjustedAt` with `_getTotalBalanceForAdjustedAt` in `ERC1410StorageWrapper.beforeTokenTransfer` for both burn and transfer paths. Update `deployOrchestratorLibraries` deployment order so `ClearingReadOps` is deployed before `TokenCoreOps`, which now depends on it transitively.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -405,11 +405,11 @@ library ERC1410StorageWrapper {
             // burn | redeem
             SnapshotsStorageWrapper.updateAccountSnapshot(from, partition);
             SnapshotsStorageWrapper.updateTotalSupplySnapshot(partition);
-            if (
-                amount > 0 &&
-                AdjustBalancesStorageWrapper.balanceOfAdjustedAt(from, TimeTravelStorageWrapper.getBlockTimestamp()) ==
-                amount
-            ) removeFrom = true;
+            uint256 totalFrom = ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
+                from,
+                TimeTravelStorageWrapper.getBlockTimestamp()
+            );
+            if (amount > 0 && totalFrom == amount) removeFrom = true;
         }
         // transfer
         else {
@@ -417,11 +417,11 @@ library ERC1410StorageWrapper {
             SnapshotsStorageWrapper.updateAccountSnapshot(to, partition);
             // balanceOf instead of balanceOfAdjusted because we are comparing it to 0
             if (amount > 0 && ERC20StorageWrapper.balanceOf(to) == 0) addTo = true;
-            if (
-                amount > 0 &&
-                AdjustBalancesStorageWrapper.balanceOfAdjustedAt(from, TimeTravelStorageWrapper.getBlockTimestamp()) ==
-                amount
-            ) removeFrom = true;
+            uint256 totalFrom = ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
+                from,
+                TimeTravelStorageWrapper.getBlockTimestamp()
+            );
+            if (amount > 0 && totalFrom == amount) removeFrom = true;
         }
 
         if (!(addTo || removeFrom)) return;

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -405,11 +405,14 @@ library ERC1410StorageWrapper {
             // burn | redeem
             SnapshotsStorageWrapper.updateAccountSnapshot(from, partition);
             SnapshotsStorageWrapper.updateTotalSupplySnapshot(partition);
-            uint256 totalFrom = ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
-                from,
-                TimeTravelStorageWrapper.getBlockTimestamp()
-            );
-            if (amount > 0 && totalFrom == amount) removeFrom = true;
+            if (
+                amount > 0 &&
+                ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
+                    from,
+                    TimeTravelStorageWrapper.getBlockTimestamp()
+                ) ==
+                amount
+            ) removeFrom = true;
         }
         // transfer
         else {
@@ -417,11 +420,14 @@ library ERC1410StorageWrapper {
             SnapshotsStorageWrapper.updateAccountSnapshot(to, partition);
             // balanceOf instead of balanceOfAdjusted because we are comparing it to 0
             if (amount > 0 && ERC20StorageWrapper.balanceOf(to) == 0) addTo = true;
-            uint256 totalFrom = ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
-                from,
-                TimeTravelStorageWrapper.getBlockTimestamp()
-            );
-            if (amount > 0 && totalFrom == amount) removeFrom = true;
+            if (
+                amount > 0 &&
+                ERC3643StorageWrapper.getTotalBalanceForAdjustedAt(
+                    from,
+                    TimeTravelStorageWrapper.getBlockTimestamp()
+                ) ==
+                amount
+            ) removeFrom = true;
         }
 
         if (!(addTo || removeFrom)) return;

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-07T13:43:18.807Z
+ * Generated: 2026-05-11T12:11:47.401Z
  * Facets: 122
  * Infrastructure: 2
  *
@@ -8775,7 +8775,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8579befe",
       },
     ],
-    factory: (signer) => new MaturityByPartitionFacet__factory(signer),
+    factory: (signer) => new MaturityByPartitionFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   MaturityFacet: {
@@ -8938,7 +8938,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8579befe",
       },
     ],
-    factory: (signer) => new MaturityFacet__factory(signer),
+    factory: (signer) => new MaturityFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   MetadataFacet: {
@@ -11768,8 +11768,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xf9f9bcf9",
       },
     ],
-    factory: (signer) => new RecoveryFacet__factory(signer),
-    timeTravelFactory: (signer) => new RecoveryFacetTimeTravel__factory(signer),
+    factory: (signer) => new RecoveryFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) => new RecoveryFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   ScheduledCrossOrderedTasksFacet: {
@@ -12725,7 +12725,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockByPartitionFacet__factory(signer),
+    factory: (signer) => new TransferAndLockByPartitionFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockFacet: {
@@ -12858,8 +12858,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockFixedRateFacet: {
@@ -12992,8 +12993,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockFixedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockFixedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockFixedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockKpiLinkedRateFacet: {
@@ -13126,8 +13128,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockKpiLinkedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockKpiLinkedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockKpiLinkedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockSustainabilityPerformanceTargetRateFacet: {
@@ -13260,9 +13263,16 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockSustainabilityPerformanceTargetRateFacet__factory(signer),
+    factory: (signer) =>
+      new TransferAndLockSustainabilityPerformanceTargetRateFacet__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
     timeTravelFactory: (signer) =>
-      new TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
+      new TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
   },
 
   TransferByPartitionFacet: {

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-11T12:11:47.401Z
+ * Generated: 2026-05-11T13:02:03.461Z
  * Facets: 122
  * Infrastructure: 2
  *
@@ -1391,6 +1391,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         topic0: "0x7fa523c84ab8d7fc5b72f08b9e46dbbf10c39e119a075b3e317002d14bc9f436",
       },
       {
+        name: "DelegateVotesChanged",
+        signature: {
+          full: "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+          canonical: "DelegateVotesChanged(address,uint256,uint256)",
+        },
+        topic0: "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+      },
+      {
         name: "TokensFrozen",
         signature: {
           full: "event TokensFrozen(address indexed account, uint256 amount, bytes32 partition)",
@@ -1424,6 +1432,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     errors: [
+      {
+        name: "AbafChangeForBlockForbidden",
+        signature: {
+          full: "error AbafChangeForBlockForbidden(uint256 blockNumber)",
+          canonical: "AbafChangeForBlockForbidden(uint256)",
+        },
+        selector: "0x5a2afdff",
+      },
       {
         name: "AccessControlRequired",
         signature: {
@@ -1492,6 +1508,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
       },
       {
         name: "WalletRecovered",
@@ -6466,6 +6487,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         topic0: "0x7fa523c84ab8d7fc5b72f08b9e46dbbf10c39e119a075b3e317002d14bc9f436",
       },
       {
+        name: "DelegateVotesChanged",
+        signature: {
+          full: "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+          canonical: "DelegateVotesChanged(address,uint256,uint256)",
+        },
+        topic0: "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+      },
+      {
         name: "TokensFrozen",
         signature: {
           full: "event TokensFrozen(address indexed account, uint256 amount, bytes32 partition)",
@@ -6499,6 +6528,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     errors: [
+      {
+        name: "AbafChangeForBlockForbidden",
+        signature: {
+          full: "error AbafChangeForBlockForbidden(uint256 blockNumber)",
+          canonical: "AbafChangeForBlockForbidden(uint256)",
+        },
+        selector: "0x5a2afdff",
+      },
       {
         name: "AccessControlRequired",
         signature: {
@@ -6557,6 +6594,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
       },
       {
         name: "WalletRecovered",
@@ -6749,6 +6791,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         topic0: "0x9c351ddf8b7b71a1ce0a58696d6128d479e0988ce349f51a44e84241addffca8",
       },
       {
+        name: "DelegateVotesChanged",
+        signature: {
+          full: "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+          canonical: "DelegateVotesChanged(address,uint256,uint256)",
+        },
+        topic0: "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+      },
+      {
         name: "HeldByPartition",
         signature: {
           full: "event HeldByPartition(address indexed operator, address indexed tokenHolder, bytes32 partition, uint256 holdId, (uint256 amount, uint256 expirationTimestamp, address escrow, address to, bytes data) hold, bytes operatorData)",
@@ -6825,6 +6875,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     errors: [
+      {
+        name: "AbafChangeForBlockForbidden",
+        signature: {
+          full: "error AbafChangeForBlockForbidden(uint256 blockNumber)",
+          canonical: "AbafChangeForBlockForbidden(uint256)",
+        },
+        selector: "0x5a2afdff",
+      },
       {
         name: "AccessControlRequired",
         signature: {
@@ -6927,6 +6985,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
       },
       {
         name: "WalletRecovered",
@@ -8310,6 +8373,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     events: [
       {
+        name: "DelegateVotesChanged",
+        signature: {
+          full: "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+          canonical: "DelegateVotesChanged(address,uint256,uint256)",
+        },
+        topic0: "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+      },
+      {
         name: "LockByPartitionReleased",
         signature: {
           full: "event LockByPartitionReleased(address indexed operator, address indexed tokenHolder, bytes32 indexed partition, uint256 lockId)",
@@ -8343,6 +8414,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     errors: [
+      {
+        name: "AbafChangeForBlockForbidden",
+        signature: {
+          full: "error AbafChangeForBlockForbidden(uint256 blockNumber)",
+          canonical: "AbafChangeForBlockForbidden(uint256)",
+        },
+        selector: "0x5a2afdff",
+      },
       {
         name: "AccessControlRequired",
         signature: {
@@ -8401,6 +8480,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
       },
       {
         name: "WalletRecovered",
@@ -8498,6 +8582,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     events: [
       {
+        name: "DelegateVotesChanged",
+        signature: {
+          full: "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+          canonical: "DelegateVotesChanged(address,uint256,uint256)",
+        },
+        topic0: "0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724",
+      },
+      {
         name: "LockByPartitionReleased",
         signature: {
           full: "event LockByPartitionReleased(address indexed operator, address indexed tokenHolder, bytes32 indexed partition, uint256 lockId)",
@@ -8531,6 +8623,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
     ],
     errors: [
+      {
+        name: "AbafChangeForBlockForbidden",
+        signature: {
+          full: "error AbafChangeForBlockForbidden(uint256 blockNumber)",
+          canonical: "AbafChangeForBlockForbidden(uint256)",
+        },
+        selector: "0x5a2afdff",
+      },
       {
         name: "AccessControlRequired",
         signature: {
@@ -8602,6 +8702,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "SnapshotIdNull",
         signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
         selector: "0xf128004d",
+      },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
       },
       {
         name: "WalletRecovered",

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T10:34:16.642Z
- * Facets: 123
+ * Generated: 2026-05-12T10:44:55.115Z
+ * Facets: 124
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -102,6 +102,7 @@ import {
   MetadataFacet__factory,
   MintByPartitionFacet__factory,
   MintFacet__factory,
+  NominalValueAtSnapshotFacet__factory,
   NominalValueFacet__factory,
   NoncesFacet__factory,
   OperatorByPartitionFacet__factory,
@@ -4425,7 +4426,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       {
         name: "getCouponFor",
         signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, uint256 nominalValue, uint256 nominalValueDecimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
           canonical: "getCouponFor(uint256,address)",
         },
         selector: "0xbba7b56d",
@@ -4645,7 +4646,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       {
         name: "getCouponsFor",
         signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] holders_)",
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint8 decimals, uint256 nominalValue, uint256 nominalValueDecimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] holders_)",
           canonical: "getCouponsFor(uint256,uint256,uint256)",
         },
         selector: "0x7327ad90",
@@ -9432,6 +9433,50 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     factory: (signer) => new MintFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
   },
 
+  NominalValueAtSnapshotFacet: {
+    name: "NominalValueAtSnapshotFacet",
+    description: "NominalValueAtSnapshotFacet",
+    resolverKey: {
+      name: "_NOMINAL_VALUE_AT_SNAPSHOT_RESOLVER_KEY",
+      value: "0xa9eb978fb9b2f23119fbe6dc3a3f6010398d58b37b5221961eaa584486c8c6fb",
+    },
+    inheritance: ["NominalValueAtSnapshot", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "nominalValueAtSnapshot",
+        signature: {
+          full: "function nominalValueAtSnapshot(uint256 _snapshotID) view returns (uint256 nominalValue_)",
+          canonical: "nominalValueAtSnapshot(uint256)",
+        },
+        selector: "0x526ce5ee",
+      },
+      {
+        name: "nominalValueDecimalsAtSnapshot",
+        signature: {
+          full: "function nominalValueDecimalsAtSnapshot(uint256 _snapshotID) view returns (uint8 nominalValueDecimals_)",
+          canonical: "nominalValueDecimalsAtSnapshot(uint256)",
+        },
+        selector: "0x1fed7107",
+      },
+    ],
+    errors: [
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+    ],
+    factory: (signer) => new NominalValueAtSnapshotFacet__factory(signer),
+  },
+
   NominalValueFacet: {
     name: "NominalValueFacet",
     resolverKey: {
@@ -13995,7 +14040,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 123 as const;
+export const TOTAL_FACETS = 124 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-11T13:02:03.461Z
- * Facets: 122
+ * Generated: 2026-05-12T10:34:16.642Z
+ * Facets: 123
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -77,6 +77,7 @@ import {
   ExternalControlListManagementFacet__factory,
   ExternalKycListManagementFacet__factory,
   ExternalPauseManagementFacet__factory,
+  FactoryFacet__factory,
   FixedRateFacet__factory,
   FreezeAtSnapshotByPartitionFacet__factory,
   FreezeAtSnapshotFacet__factory,
@@ -6277,6 +6278,195 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     ],
     factory: (signer) => new ExternalPauseManagementFacet__factory(signer),
     timeTravelFactory: (signer) => new ExternalPauseManagementFacetTimeTravel__factory(signer),
+  },
+
+  FactoryFacet: {
+    name: "FactoryFacet",
+    description:
+      "Diamond facet that exposes all Factory selectors under a single `_FACTORY_RESOLVER_KEY` for use as a ResolverProxy facet.",
+    resolverKey: {
+      name: "_FACTORY_RESOLVER_KEY",
+      value: "0xa5472d34be801f744a73bce4e1851e67767286307e3203726a3261b280a667b3",
+    },
+    inheritance: ["Factory", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "deployBond",
+        signature: {
+          full: "function deployBond(((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) _bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) _factoryRegulationData) returns (address bondAddress_)",
+          canonical:
+            "deployBond(((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)))",
+        },
+        selector: "0x5133f0e0",
+      },
+      {
+        name: "deployBondFixedRate",
+        signature: {
+          full: "function deployBondFixedRate((((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 rate, uint8 rateDecimals) fixedRateData) _bondFixedRateData) returns (address bondAddress_)",
+          canonical:
+            "deployBondFixedRate((((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint8)))",
+        },
+        selector: "0x7c55cfdc",
+      },
+      {
+        name: "deployBondKpiLinkedRate",
+        signature: {
+          full: "function deployBondKpiLinkedRate((((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData) _bondKpiLinkedRateData) returns (address bondAddress_)",
+          canonical:
+            "deployBondKpiLinkedRate((((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256)))",
+        },
+        selector: "0x06e6effc",
+      },
+      {
+        name: "deployBondSustainabilityPerformanceTargetRate",
+        signature: {
+          full: "function deployBondSustainabilityPerformanceTargetRate((((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 baseRate, uint256 startPeriod, uint256 startRate, uint8 rateDecimals) interestRate, (uint256 baseLine, uint8 baseLineMode, uint256 deltaRate, uint8 impactDataMode)[] impactData, address[] projects) _bondSustainabilityPerformanceTargetRateData) returns (address bondAddress_)",
+          canonical:
+            "deployBondSustainabilityPerformanceTargetRate((((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint256,uint256,uint8),(uint256,uint8,uint256,uint8)[],address[]))",
+        },
+        selector: "0x5bdc1ceb",
+      },
+      {
+        name: "deployEquity",
+        signature: {
+          full: "function deployEquity(((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bool votingRight, bool informationRight, bool liquidationRight, bool subscriptionRight, bool conversionRight, bool redemptionRight, bool putRight, uint8 dividendRight, bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals) equityDetails) _equityData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) _factoryRegulationData) returns (address equityAddress_)",
+          canonical:
+            "deployEquity(((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bool,bool,bool,bool,bool,bool,bool,uint8,bytes3,uint256,uint8)),(uint8,uint8,(bool,string,string)))",
+        },
+        selector: "0xfb3c59d8",
+      },
+      {
+        name: "deployProxy",
+        signature: {
+          full: "function deployProxy(address _resolver, bytes32 _configKey, uint256 _version, (bytes32 role, address[] members)[] _rbacs) returns (address proxyAddress_)",
+          canonical: "deployProxy(address,bytes32,uint256,(bytes32,address[])[])",
+        },
+        selector: "0x8d0672db",
+      },
+      {
+        name: "getAppliedRegulationData",
+        signature: {
+          full: "function getAppliedRegulationData(uint8 _regulationType, uint8 _regulationSubType) pure returns ((uint8 regulationType, uint8 regulationSubType, uint256 dealSize, uint8 accreditedInvestors, uint256 maxNonAccreditedInvestors, uint8 manualInvestorVerification, uint8 internationalInvestors, uint8 resaleHoldPeriod) regulationData_)",
+          canonical: "getAppliedRegulationData(uint8,uint8)",
+        },
+        selector: "0x7b5208d0",
+      },
+    ],
+    events: [
+      {
+        name: "BondDeployed",
+        signature: {
+          full: "event BondDeployed(address indexed deployer, address bondAddress, ((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) regulationData)",
+          canonical:
+            "BondDeployed(address,address,((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)))",
+        },
+        topic0: "0x01d3e27a30d468a96e49f71ff84af896733789c198ff030dae07d2d9ae9e9f17",
+      },
+      {
+        name: "BondFixedRateDeployed",
+        signature: {
+          full: "event BondFixedRateDeployed(address indexed deployer, address bondAddress, (((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 rate, uint8 rateDecimals) fixedRateData) bondFixedRateData)",
+          canonical:
+            "BondFixedRateDeployed(address,address,(((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint8)))",
+        },
+        topic0: "0x7760a5a38dddb73a76a698ab856ee89aa872213a7df0adfbca3c176f2cb74b23",
+      },
+      {
+        name: "BondKpiLinkedRateDeployed",
+        signature: {
+          full: "event BondKpiLinkedRateDeployed(address indexed deployer, address bondAddress, (((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData) bondKpiLinkedRateData)",
+          canonical:
+            "BondKpiLinkedRateDeployed(address,address,(((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256)))",
+        },
+        topic0: "0x45915a0104ea5671b1651c88183b8d6175450f67c9ad1462ed080594e0b10ec6",
+      },
+      {
+        name: "BondSustainabilityPerformanceTargetRateDeployed",
+        signature: {
+          full: "event BondSustainabilityPerformanceTargetRateDeployed(address indexed deployer, address bondAddress, (((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals, uint256 startingDate, uint256 maturityDate) bondDetails, address[] proceedRecipients, bytes[] proceedRecipientsData) bondData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) factoryRegulationData, (uint256 baseRate, uint256 startPeriod, uint256 startRate, uint8 rateDecimals) interestRate, (uint256 baseLine, uint8 baseLineMode, uint256 deltaRate, uint8 impactDataMode)[] impactData, address[] projects) bondSustainabilityPerformanceTargetRateData)",
+          canonical:
+            "BondSustainabilityPerformanceTargetRateDeployed(address,address,(((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bytes3,uint256,uint8,uint256,uint256),address[],bytes[]),(uint8,uint8,(bool,string,string)),(uint256,uint256,uint256,uint8),(uint256,uint8,uint256,uint8)[],address[]))",
+        },
+        topic0: "0x7b0542f2e963c32efb54f91877cf0e1b675a89541e6dacf56cc26990d1534cda",
+      },
+      {
+        name: "EquityDeployed",
+        signature: {
+          full: "event EquityDeployed(address indexed deployer, address equityAddress, ((bool arePartitionsProtected, bool isMultiPartition, address resolver, (bytes32 key, uint256 version) resolverProxyConfiguration, (bytes32 role, address[] members)[] rbacs, bool isControllable, bool isWhiteList, uint256 maxSupply, (string name, string symbol, string isin, uint8 decimals) erc20MetadataInfo, bool clearingActive, bool internalKycActivated, address[] externalPauses, address[] externalControlLists, address[] externalKycLists, bool erc20VotesActivated, address compliance, address identityRegistry) security, (bool votingRight, bool informationRight, bool liquidationRight, bool subscriptionRight, bool conversionRight, bool redemptionRight, bool putRight, uint8 dividendRight, bytes3 currency, uint256 nominalValue, uint8 nominalValueDecimals) equityDetails) equityData, (uint8 regulationType, uint8 regulationSubType, (bool countriesControlListType, string listOfCountries, string info) additionalSecurityData) regulationData)",
+          canonical:
+            "EquityDeployed(address,address,((bool,bool,address,(bytes32,uint256),(bytes32,address[])[],bool,bool,uint256,(string,string,string,uint8),bool,bool,address[],address[],address[],bool,address,address),(bool,bool,bool,bool,bool,bool,bool,uint8,bytes3,uint256,uint8)),(uint8,uint8,(bool,string,string)))",
+        },
+        topic0: "0x59f510d04f090e1185bc91d7647b595294572073ef9f4754e7604b2a8af1e5f2",
+      },
+      {
+        name: "ProxyDeployed",
+        signature: {
+          full: "event ProxyDeployed(address indexed proxyAddress, address resolver, bytes32 configKey, uint256 version, (bytes32 role, address[] members)[] rbac)",
+          canonical: "ProxyDeployed(address,address,bytes32,uint256,(bytes32,address[])[])",
+        },
+        topic0: "0x03b5b4bc23cb6eb6351f669151e62cc3d9c419885402adf41cb4c17fa9031966",
+      },
+    ],
+    errors: [
+      {
+        name: "EmptyResolver",
+        signature: { full: "error EmptyResolver(address resolver)", canonical: "EmptyResolver(address)" },
+        selector: "0x840a2011",
+      },
+      {
+        name: "NoInitialAdmins",
+        signature: { full: "error NoInitialAdmins()", canonical: "NoInitialAdmins()" },
+        selector: "0x0b845f7f",
+      },
+      {
+        name: "RegulationTypeAndSubTypeForbidden",
+        signature: {
+          full: "error RegulationTypeAndSubTypeForbidden(uint8 regulationType, uint8 regulationSubType)",
+          canonical: "RegulationTypeAndSubTypeForbidden(uint8,uint8)",
+        },
+        selector: "0xfcaaa691",
+      },
+      {
+        name: "WrongDates",
+        signature: {
+          full: "error WrongDates(uint256 firstDate, uint256 secondDate)",
+          canonical: "WrongDates(uint256,uint256)",
+        },
+        selector: "0x1c94559c",
+      },
+      {
+        name: "WrongImpactDataValues",
+        signature: {
+          full: "error WrongImpactDataValues((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData)",
+          canonical: "WrongImpactDataValues((uint256,uint256,uint256,uint8,uint256))",
+        },
+        selector: "0xa60b6cba",
+      },
+      {
+        name: "WrongInterestRateValues",
+        signature: {
+          full: "error WrongInterestRateValues((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate)",
+          canonical: "WrongInterestRateValues((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
+        },
+        selector: "0x570cf0d3",
+      },
+      {
+        name: "WrongISIN",
+        signature: { full: "error WrongISIN(string isin)", canonical: "WrongISIN(string)" },
+        selector: "0xdf749cc5",
+      },
+      {
+        name: "WrongISINChecksum",
+        signature: { full: "error WrongISINChecksum(string isin)", canonical: "WrongISINChecksum(string)" },
+        selector: "0x342c92db",
+      },
+      {
+        name: "WrongTimestamp",
+        signature: { full: "error WrongTimestamp(uint256 timeStamp)", canonical: "WrongTimestamp(uint256)" },
+        selector: "0xdcf61246",
+      },
+    ],
+    factory: (signer) => new FactoryFacet__factory(signer),
   },
 
   FixedRateFacet: {
@@ -13805,7 +13995,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 122 as const;
+export const TOTAL_FACETS = 123 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -222,8 +222,10 @@ export function toTypeChainLibraryAddresses(addresses?: OrchestratorLibraryAddre
  * Deploy all orchestrator libraries in correct dependency order.
  *
  * Deployment order:
- * 1. TokenCoreOps, HoldOps, ClearingReadOps (no dependencies)
- * 2. ClearingOps (depends on TokenCoreOps)
+ * 1. ClearingReadOps, HoldOps (no dependencies)
+ * 2. TokenCoreOps (depends on ClearingReadOps)
+ * 3. ClearingOps (depends on TokenCoreOps and HoldOps)
+ * 4. ClearingProtectedOps (depends on ClearingOps)
  *
  * After deployment, automatically calls `setOrchestratorLibraryAddresses()`.
  *
@@ -242,24 +244,26 @@ export async function deployOrchestratorLibraries(signer: Signer): Promise<Orche
 
   info("   Deploying orchestrator libraries...");
 
-  // Phase 1: Deploy libraries with no dependencies sequentially.
+  // Phase 1: Deploy ClearingReadOps and HoldOps (no dependencies).
   // Parallel deployment via Promise.all causes nonce collisions on the Hiero Solo
-  // JSON-RPC relay: all three deploy() calls fetch eth_getTransactionCount before
-  // any transaction lands, so they all receive the same nonce and two of them stall
-  // indefinitely waiting for a receipt that never arrives.
-  const tokenCoreOps = await (await new TokenCoreOps__factory(signer).deploy()).waitForDeployment();
-  const tokenCoreOpsAddr = await tokenCoreOps.getAddress();
-  info(`   ✓ TokenCoreOps deployed at ${tokenCoreOpsAddr}`);
+  // JSON-RPC relay, so we deploy sequentially.
+  const clearingReadOps = await (await new ClearingReadOps__factory(signer).deploy()).waitForDeployment();
+  const clearingReadOpsAddr = await clearingReadOps.getAddress();
+  info(`   ✓ ClearingReadOps deployed at ${clearingReadOpsAddr}`);
 
   const holdOps = await (await new HoldOps__factory(signer).deploy()).waitForDeployment();
   const holdOpsAddr = await holdOps.getAddress();
   info(`   ✓ HoldOps deployed at ${holdOpsAddr}`);
 
-  const clearingReadOps = await (await new ClearingReadOps__factory(signer).deploy()).waitForDeployment();
-  const clearingReadOpsAddr = await clearingReadOps.getAddress();
-  info(`   ✓ ClearingReadOps deployed at ${clearingReadOpsAddr}`);
+  // Phase 2: Deploy TokenCoreOps (depends on ClearingReadOps — getTotalBalanceForAdjustedAt
+  // calls ClearingReadOps.getClearedAmountForAdjustedAt via DELEGATECALL).
+  const tokenCoreOps = await (
+    await new TokenCoreOps__factory({ [LIBRARY_KEYS.clearingReadOps]: clearingReadOpsAddr } as any, signer).deploy()
+  ).waitForDeployment();
+  const tokenCoreOpsAddr = await tokenCoreOps.getAddress();
+  info(`   ✓ TokenCoreOps deployed at ${tokenCoreOpsAddr}`);
 
-  // Phase 2: Deploy ClearingOps (depends on TokenCoreOps and HoldOps)
+  // Phase 3: Deploy ClearingOps (depends on TokenCoreOps and HoldOps)
   const clearingOps = await new ClearingOps__factory(
     {
       [LIBRARY_KEYS.tokenCoreOps]: tokenCoreOpsAddr,
@@ -272,7 +276,7 @@ export async function deployOrchestratorLibraries(signer: Signer): Promise<Orche
   const clearingOpsAddr = await clearingOps.getAddress();
   info(`   ✓ ClearingOps deployed at ${clearingOpsAddr}`);
 
-  // Phase 3: Deploy ClearingProtectedOps (depends on ClearingOps via internal calls)
+  // Phase 4: Deploy ClearingProtectedOps (depends on ClearingOps via internal calls)
   const clearingProtectedOps = await new ClearingProtectedOps__factory(
     {
       [LIBRARY_KEYS.clearingOps]: clearingOpsAddr,

--- a/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
 import { type ResolverProxy, type IAsset } from "@contract-types";
-import { DEFAULT_PARTITION, ATS_ROLES, ZERO } from "@scripts";
+import { DEFAULT_PARTITION, ATS_ROLES, ZERO, EMPTY_HEX_BYTES } from "@scripts";
 import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 
@@ -354,6 +354,59 @@ describe("SecurityHoldersFacet Tests", () => {
       const holders = await asset.getSecurityHolders(0, 10);
       expect(holders).to.include(signer_B.address);
       expect(await asset.balanceOf(signer_B.address)).to.equal(tokenAmount);
+    });
+  });
+
+  describe("holder registry integrity with encumbered tokens (FIND-120)", () => {
+    beforeEach(async () => {
+      await asset.connect(signer_A).grantRole(ATS_ROLES.LOCKER_ROLE, signer_A.address);
+    });
+
+    it("GIVEN a holder with locked tokens WHEN burning all free tokens via redeemByPartition THEN holder remains in registry", async () => {
+      const totalAmount = 1000n;
+      const lockedAmount = 900n;
+      const freeAmount = totalAmount - lockedAmount;
+
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_B.address,
+        value: totalAmount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).lock(lockedAmount, signer_B.address, MAX_UINT256);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+
+      await asset.connect(signer_B).redeemByPartition(DEFAULT_PARTITION, freeAmount, EMPTY_HEX_BYTES);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+      const holders = await asset.getSecurityHolders(0, 10);
+      expect(holders).to.include(signer_B.address);
+    });
+
+    it("GIVEN a holder with locked tokens WHEN transferring all free tokens THEN holder remains in registry", async () => {
+      const totalAmount = 1000n;
+      const lockedAmount = 900n;
+      const freeAmount = totalAmount - lockedAmount;
+
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_B.address,
+        value: totalAmount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_A).lock(lockedAmount, signer_B.address, MAX_UINT256);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+
+      await asset.connect(signer_B).transfer(signer_C.address, freeAmount);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(2);
+      const holders = await asset.getSecurityHolders(0, 10);
+      expect(holders).to.include(signer_B.address);
+      expect(holders).to.include(signer_C.address);
     });
   });
 });


### PR DESCRIPTION
This pull request introduces several important changes to the orchestration and registry logic for the ATS contracts, as well as enhancements to the test suite to ensure correct holder registry behavior when tokens are encumbered (locked). The main themes are improvements to dependency wiring for facet factories, changes to orchestrator library deployment order and dependency injection, and the addition of regression tests for holder registry integrity.

**Dependency Injection and Library Wiring Improvements:**

* Updated all facet factory and time travel factory initializations in `atsRegistry.data.ts` to inject the `clearingReadOps` library dependency, ensuring that all facets relying on this library are correctly wired. This affects multiple facets including `MaturityByPartitionFacet`, `MaturityFacet`, `RecoveryFacet`, `TransferAndLockByPartitionFacet`, and others. [[1]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L8778-R8778) [[2]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L8941-R8941) [[3]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L11771-R11772) [[4]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L12728-R12728) [[5]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L12861-R12863) [[6]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L12995-R12998) [[7]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L13129-R13133) [[8]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949L13263-R13275)

* Changed the orchestrator library deployment order in `orchestratorLibraries.ts` to deploy `ClearingReadOps` first (as it is now a dependency for `TokenCoreOps`), followed by `HoldOps`, `TokenCoreOps`, `ClearingOps`, and finally `ClearingProtectedOps`. This ensures correct dependency resolution during deployment. [[1]](diffhunk://#diff-551ff395ba567fc3d477a0d465e11500b994052a85b5d2985a152abb80098831L225-R228) [[2]](diffhunk://#diff-551ff395ba567fc3d477a0d465e11500b994052a85b5d2985a152abb80098831L245-R266) [[3]](diffhunk://#diff-551ff395ba567fc3d477a0d465e11500b994052a85b5d2985a152abb80098831L275-R279)

**Holder Registry and Balance Logic:**

* In `ERC1410StorageWrapper.sol`, updated the logic for determining when to remove a holder from the registry by using `ERC3643StorageWrapper.getTotalBalanceForAdjustedAt` instead of `AdjustBalancesStorageWrapper.balanceOfAdjustedAt`, ensuring that holders with locked (encumbered) tokens are not incorrectly removed from the registry.

**Testing Improvements:**

* Added new regression tests in `SecurityHolders.test.ts` to verify that holders with locked tokens are not removed from the holder registry when all free tokens are burned or transferred, addressing issue FIND-120.
* Minor import update in `SecurityHolders.test.ts` to include `EMPTY_HEX_BYTES` from `@scripts`.

**Other:**

* Updated the generated timestamp in `atsRegistry.data.ts` to reflect the latest changes.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
