### PR TITLE
refactor(contracts): [BBND-1731] rename KpiLinkedRate facet externals

### DIFF
--- a/.changeset/maf-rename-kpi-linked-rate.md
+++ b/.changeset/maf-rename-kpi-linked-rate.md
@@ -1,0 +1,15 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+refactor(KpiLinkedRate): rename facet externals to disambiguate from `SustainabilityPerformanceTargetRate` (BBND-1731). The four `get`/`set` methods get a `KpiLinkedRate` prefix and the initialiser is camel-cased:
+
+- `getImpactData` → `getKpiLinkedRateImpactData`
+- `getInterestRate` → `getKpiLinkedRateInterestRate`
+- `setImpactData` → `setKpiLinkedRateImpactData`
+- `setInterestRate` → `setKpiLinkedRateInterestRate`
+- `initialize_KpiLinkedRate` → `initializeKpiLinkedRate`
+
+Events (`InterestRateUpdated`, `ImpactDataUpdated`) and shared structs (`InterestRate`, `ImpactData` on `IKpiLinkedRateErrors`) are unchanged. Selectors change because the canonical signatures change — external integrators calling the old method names on a `KpiLinkedRate`-bearing diamond must migrate to the prefixed names. SDK adapter call-sites (`RPCQueryAdapter`, `RPCTransactionAdapter`) are updated to bridge the rename internally; the SDK port-in API is unchanged.
+
+Also fixes a latent bug in `tasks/compile.ts` `erc3643-clone-interfaces`: the regen was dropping the `is IKpiLinkedRateErrors` hierarchy from the T-REX shadow on every ABI-changing regen, leaving `InterestRate`/`ImpactData` out of scope. `IKpiLinkedRate` is now declared with `removeImports: false, removeHierarchy: false` and a companion `IKpiLinkedRateErrors` shadow is cloned.

--- a/.changeset/maf-rename-kpi-linked-rate.md
+++ b/.changeset/maf-rename-kpi-linked-rate.md
@@ -12,4 +12,8 @@ refactor(KpiLinkedRate): rename facet externals to disambiguate from `Sustainabi
 
 Events (`InterestRateUpdated`, `ImpactDataUpdated`) and shared structs (`InterestRate`, `ImpactData` on `IKpiLinkedRateErrors`) are unchanged. Selectors change because the canonical signatures change — external integrators calling the old method names on a `KpiLinkedRate`-bearing diamond must migrate to the prefixed names. SDK adapter call-sites (`RPCQueryAdapter`, `RPCTransactionAdapter`) are updated to bridge the rename internally; the SDK port-in API is unchanged.
 
+`IKpiLinkedRate` is now inherited by `IAsset`. The historical exclusion existed because `IKpiLinkedRate` and `ISustainabilityPerformanceTargetRate` collided on four selectors; with the rename above, the collision is gone and KPI-linked rate joins the umbrella. `ISustainabilityPerformanceTargetRate` remains excluded pending its own rename ticket. Consumers (integration tests, SDK RPC adapters) now type the diamond handle as `IAsset` instead of the facet interface.
+
+`KpiLinkedRateFacet` adopts the `Bytes4Builder.build(...)` helpers introduced by `a75de2c9` for both `getStaticFunctionSelectors` and `getStaticInterfaceIds`, replacing the descending `--selectorIndex` boilerplate. Output is byte-identical.
+
 Also fixes a latent bug in `tasks/compile.ts` `erc3643-clone-interfaces`: the regen was dropping the `is IKpiLinkedRateErrors` hierarchy from the T-REX shadow on every ABI-changing regen, leaving `InterestRate`/`ImpactData` out of scope. `IKpiLinkedRate` is now declared with `removeImports: false, removeHierarchy: false` and a companion `IKpiLinkedRateErrors` shadow is cloned.

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -45,15 +45,16 @@ import { IExternalKycList } from "./layer_1/externalKycList/IExternalKycList.sol
 import { IExternalKycListManagement } from "./externalKycListManagement/IExternalKycListManagement.sol";
 import { IExternalPauseManagement } from "./externalPauseManagement/IExternalPauseManagement.sol";
 import { IFixedRate } from "./layer_2/interestRate/fixedRate/IFixedRate.sol";
+import { IKpiLinkedRate } from "./layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol";
 
 // Layer 2
 import { IOperatorHoldByPartition } from "./operatorHoldByPartition/IOperatorHoldByPartition.sol";
 import { IHoldByPartition } from "./holdByPartition/IHoldByPartition.sol";
 import { IKyc } from "./layer_1/kyc/IKyc.sol";
-// IKpiLinkedRate and ISustainabilityPerformanceTargetRate are excluded: both define
-// getInterestRate() with incompatible return types (different InterestRate structs),
-// which cannot be reconciled in a single Solidity interface. Use those typed instances
-// directly when testing KPI-linked or SPTR interest rate facets.
+// ISustainabilityPerformanceTargetRate is excluded: its getInterestRate, setInterestRate,
+// getImpactData, setImpactData selectors still collide with the legacy (pre-rename) names.
+// It will be re-included once its own rename ticket runs. KPI-linked rate is now part of
+// IAsset following BBND-1731.
 import { ILoan } from "./layer_2/loan/ILoan.sol";
 import { INominalValue } from "./layer_2/nominalValue/INominalValue.sol";
 import { INominalValueAtSnapshot } from "./nominalValueAtSnapshot/INominalValueAtSnapshot.sol";
@@ -156,7 +157,7 @@ import { IOperatorByPartition } from "./operatorByPartition/IOperatorByPartition
  *      sub-interfaces. IERC20Votes includes IERC5805 and IVotes. Solidity C3 linearisation
  *      handles the resulting diamond inheritance without conflicts.
  *
- *      Note: IKpiLinkedRate and ISustainabilityPerformanceTargetRate are intentionally excluded
+ *      Note: ISustainabilityPerformanceTargetRate is intentionally excluded
  *      due to an irreconcilable function selector conflict on getInterestRate(). Consumers that
  *      need the KPI-linked or SPTR surface must use those typed interfaces directly.
  */
@@ -225,6 +226,7 @@ interface IAsset is
     ILockAtSnapshotByPartition,
     ILockAtSnapshot,
     IMaturityByPartition,
+    IKpiLinkedRate,
     IFixedRate,
     // Scheduled Tasks
     ICouponListing,

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
@@ -9,12 +9,11 @@ interface IKpiLinkedRate is IKpiLinkedRateErrors {
 
     error InterestRateIsKpiLinked();
 
-    // solhint-disable-next-line func-name-mixedcase
-    function initialize_KpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
+    function initializeKpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
 
-    function setInterestRate(InterestRate calldata _newInterestRate) external;
-    function setImpactData(ImpactData calldata _newImpactData) external;
+    function setKpiLinkedRateInterestRate(InterestRate calldata _newInterestRate) external;
+    function setKpiLinkedRateImpactData(ImpactData calldata _newImpactData) external;
 
-    function getInterestRate() external view returns (InterestRate memory interestRate_);
-    function getImpactData() external view returns (ImpactData memory impactData_);
+    function getKpiLinkedRateInterestRate() external view returns (InterestRate memory interestRate_);
+    function getKpiLinkedRateImpactData() external view returns (ImpactData memory impactData_);
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRate.sol
@@ -7,8 +7,6 @@ interface IKpiLinkedRate is IKpiLinkedRateErrors {
     event InterestRateUpdated(address indexed operator, InterestRate newInterestRate);
     event ImpactDataUpdated(address indexed operator, ImpactData newImpactData);
 
-    error InterestRateIsKpiLinked();
-
     function initializeKpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
 
     function setKpiLinkedRateInterestRate(InterestRate calldata _newInterestRate) external;

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRate.sol
@@ -9,8 +9,7 @@ import { Modifiers } from "../../../../services/Modifiers.sol";
 import { EvmAccessors } from "../../../../infrastructure/utils/EvmAccessors.sol";
 
 contract KpiLinkedRate is IKpiLinkedRate, Modifiers {
-    // solhint-disable-next-line func-name-mixedcase
-    function initialize_KpiLinkedRate(
+    function initializeKpiLinkedRate(
         InterestRate calldata _interestRate,
         ImpactData calldata _impactData
     ) external override onlyNotKpiLinkedRateInitialized {
@@ -19,7 +18,7 @@ contract KpiLinkedRate is IKpiLinkedRate, Modifiers {
         InterestRateStorageWrapper.kpiLinkedRateStorage().initialized = true;
     }
 
-    function setInterestRate(
+    function setKpiLinkedRateInterestRate(
         InterestRate calldata _newInterestRate
     ) external onlyUnpaused onlyRole(INTEREST_RATE_MANAGER_ROLE) onlyValidInterestRate(_newInterestRate) {
         ScheduledTasksStorageWrapper.callTriggerPendingScheduledCrossOrderedTasks();
@@ -27,7 +26,7 @@ contract KpiLinkedRate is IKpiLinkedRate, Modifiers {
         emit InterestRateUpdated(EvmAccessors.getMsgSender(), _newInterestRate);
     }
 
-    function setImpactData(
+    function setKpiLinkedRateImpactData(
         ImpactData calldata _newImpactData
     ) external onlyUnpaused onlyRole(INTEREST_RATE_MANAGER_ROLE) onlyValidImpactData(_newImpactData) {
         ScheduledTasksStorageWrapper.callTriggerPendingScheduledCrossOrderedTasks();
@@ -35,11 +34,11 @@ contract KpiLinkedRate is IKpiLinkedRate, Modifiers {
         emit ImpactDataUpdated(EvmAccessors.getMsgSender(), _newImpactData);
     }
 
-    function getInterestRate() external view returns (InterestRate memory interestRate_) {
+    function getKpiLinkedRateInterestRate() external view returns (InterestRate memory interestRate_) {
         interestRate_ = InterestRateStorageWrapper.getInterestRate();
     }
 
-    function getImpactData() external view returns (ImpactData memory impactData_) {
+    function getKpiLinkedRateImpactData() external view returns (ImpactData memory impactData_) {
         impactData_ = InterestRateStorageWrapper.getImpactData();
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
@@ -3,30 +3,38 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IKpiLinkedRate } from "./IKpiLinkedRate.sol";
 import { _KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { KpiLinkedRate } from "./KpiLinkedRate.sol";
 
+/**
+ * @title KpiLinkedRateFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that exposes the KPI-linked interest rate capability
+ *         (`IKpiLinkedRate`) on a token.
+ * @dev Implements `IStaticFunctionSelectors` so the BusinessLogicResolver can register
+ *      the facet's selectors against the deterministic resolver key declared in
+ *      `constants/resolverKeys.sol`.
+ */
 contract KpiLinkedRateFacet is KpiLinkedRate, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
     function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
         staticResolverKey_ = _KPI_LINKED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.initializeKpiLinkedRate.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setKpiLinkedRateInterestRate.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setKpiLinkedRateImpactData.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getKpiLinkedRateInterestRate.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getKpiLinkedRateImpactData.selector;
-        }
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getKpiLinkedRateImpactData.selector,
+                this.getKpiLinkedRateInterestRate.selector,
+                this.initializeKpiLinkedRate.selector,
+                this.setKpiLinkedRateImpactData.selector,
+                this.setKpiLinkedRateInterestRate.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IKpiLinkedRate).interfaceId;
-        }
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IKpiLinkedRate).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
@@ -11,18 +11,22 @@ contract KpiLinkedRateFacet is KpiLinkedRate, IStaticFunctionSelectors {
     }
 
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_KpiLinkedRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setImpactData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getImpactData.selector;
+        uint256 selectorIndex = 5;
+        staticFunctionSelectors_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticFunctionSelectors_[--selectorIndex] = this.initializeKpiLinkedRate.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.setKpiLinkedRateInterestRate.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.setKpiLinkedRateImpactData.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getKpiLinkedRateInterestRate.selector;
+            staticFunctionSelectors_[--selectorIndex] = this.getKpiLinkedRateImpactData.selector;
+        }
     }
 
     function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IKpiLinkedRate).interfaceId;
+        uint256 selectorIndex = 1;
+        staticInterfaceIds_ = new bytes4[](selectorIndex);
+        unchecked {
+            staticInterfaceIds_[--selectorIndex] = type(IKpiLinkedRate).interfaceId;
+        }
     }
 }

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
@@ -6,7 +6,7 @@
 // Edits to this file will be silently overwritten.
 pragma solidity ^0.8.17;
 
-import { IKpiLinkedRateErrors } from "../../../facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRateErrors.sol";
+import { TRexIKpiLinkedRateErrors as IKpiLinkedRateErrors } from "./IKpiLinkedRateErrors.sol";
 
 interface TRexIKpiLinkedRate is IKpiLinkedRateErrors {
     event InterestRateUpdated(address indexed operator, InterestRate newInterestRate);
@@ -14,12 +14,11 @@ interface TRexIKpiLinkedRate is IKpiLinkedRateErrors {
 
     error InterestRateIsKpiLinked();
 
-    // solhint-disable-next-line func-name-mixedcase
-    function initialize_KpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
+    function initializeKpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
 
-    function setInterestRate(InterestRate calldata _newInterestRate) external;
-    function setImpactData(ImpactData calldata _newImpactData) external;
+    function setKpiLinkedRateInterestRate(InterestRate calldata _newInterestRate) external;
+    function setKpiLinkedRateImpactData(ImpactData calldata _newImpactData) external;
 
-    function getInterestRate() external view returns (InterestRate memory interestRate_);
-    function getImpactData() external view returns (ImpactData memory impactData_);
+    function getKpiLinkedRateInterestRate() external view returns (InterestRate memory interestRate_);
+    function getKpiLinkedRateImpactData() external view returns (ImpactData memory impactData_);
 }

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRate.sol
@@ -12,8 +12,6 @@ interface TRexIKpiLinkedRate is IKpiLinkedRateErrors {
     event InterestRateUpdated(address indexed operator, InterestRate newInterestRate);
     event ImpactDataUpdated(address indexed operator, ImpactData newImpactData);
 
-    error InterestRateIsKpiLinked();
-
     function initializeKpiLinkedRate(InterestRate calldata _interestRate, ImpactData calldata _impactData) external;
 
     function setKpiLinkedRateInterestRate(InterestRate calldata _newInterestRate) external;

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRateErrors.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IKpiLinkedRateErrors.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// AUTO-GENERATED — DO NOT EDIT.
+// Source: contracts/facets/layer_2/interestRate/kpiLinkedRate/IKpiLinkedRateErrors.sol
+// Regenerated on every `npx hardhat compile` by the
+// `erc3643-clone-interfaces` task in `tasks/compile.ts`.
+// Edits to this file will be silently overwritten.
+pragma solidity ^0.8.17;
+
+/**
+ * @title IKpiLinkedRateErrors
+ * @notice Interface for KPI Linked Rate shared structs and error definitions
+ * @dev Separated from IKpiLinkedRate to expose errors through IAsset
+ *      without including IKpiLinkedRate's function selectors
+ */
+interface TRexIKpiLinkedRateErrors {
+    /// @notice Interest rate structure for KPI-linked rate calculations
+    struct InterestRate {
+        uint256 maxRate;
+        uint256 baseRate;
+        uint256 minRate;
+        uint256 startPeriod;
+        uint256 startRate;
+        uint256 missedPenalty;
+        uint256 reportPeriod;
+        uint8 rateDecimals;
+    }
+
+    /// @notice Impact data structure for KPI-linked rate adjustments
+    struct ImpactData {
+        uint256 maxDeviationCap;
+        uint256 baseLine;
+        uint256 maxDeviationFloor;
+        uint8 impactDataDecimals;
+        uint256 adjustmentPrecision;
+    }
+
+    /// @notice Raised when KPI-linked rate interest rate values are invalid
+    /// @param interestRate The invalid interest rate values
+    error WrongInterestRateValues(InterestRate interestRate);
+
+    /// @notice Raised when KPI-linked rate impact data values are invalid
+    /// @param impactData The invalid impact data values
+    error WrongImpactDataValues(ImpactData impactData);
+}

--- a/packages/ats/contracts/contracts/factory/Factory.sol
+++ b/packages/ats/contracts/contracts/factory/Factory.sol
@@ -287,7 +287,7 @@ contract Factory is IFactory {
         bondAddress_ = _deployBond(_data.bondData, _data.factoryRegulationData, SecurityType.BondKpiLinkedRate);
 
         // Initialize KPI linked rate (KpiLinkedRateFacet may not be present)
-        _tryInitialize_KpiLinkedRate(bondAddress_, _data.interestRate, _data.impactData);
+        _tryInitializeKpiLinkedRate(bondAddress_, _data.interestRate, _data.impactData);
     }
 
     function _deployBondSustainabilityPerformanceTargetRate(
@@ -450,12 +450,12 @@ contract Factory is IFactory {
         }
     }
 
-    function _tryInitialize_KpiLinkedRate(
+    function _tryInitializeKpiLinkedRate(
         address securityAddress_,
         IKpiLinkedRate.InterestRate calldata interestRate,
         IKpiLinkedRate.ImpactData calldata impactData
     ) private {
-        try IKpiLinkedRate(securityAddress_).initialize_KpiLinkedRate(interestRate, impactData) {
+        try IKpiLinkedRate(securityAddress_).initializeKpiLinkedRate(interestRate, impactData) {
             // success
         } catch {
             // facet not present - skip initialization

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T11:33:01.323Z
+ * Generated: 2026-05-12T11:44:06.758Z
  * Facets: 124
  * Infrastructure: 2
  *
@@ -7583,6 +7583,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 
   KpiLinkedRateFacet: {
     name: "KpiLinkedRateFacet",
+    description: "Diamond facet that exposes the KPI-linked interest rate capability (`IKpiLinkedRate`) on a token.",
     resolverKey: {
       name: "_KPI_LINKED_RATE_RESOLVER_KEY",
       value: "0x92999bd0329d03e46274ce7743ebe0060df95286df4fa7b354937b7d21757d22",
@@ -7670,11 +7671,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "AlreadyInitialized",
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
-      },
-      {
-        name: "InterestRateIsKpiLinked",
-        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
-        selector: "0x68eba14f",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T11:02:01.532Z
+ * Generated: 2026-05-12T11:33:01.323Z
  * Facets: 124
  * Infrastructure: 2
  *
@@ -7590,45 +7590,45 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     inheritance: ["KpiLinkedRate", "IStaticFunctionSelectors"],
     methods: [
       {
-        name: "getImpactData",
+        name: "getKpiLinkedRateImpactData",
         signature: {
-          full: "function getImpactData() view returns ((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData_)",
-          canonical: "getImpactData()",
+          full: "function getKpiLinkedRateImpactData() view returns ((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData_)",
+          canonical: "getKpiLinkedRateImpactData()",
         },
-        selector: "0x24bffca8",
+        selector: "0x8e0ae3e7",
       },
       {
-        name: "getInterestRate",
+        name: "getKpiLinkedRateInterestRate",
         signature: {
-          full: "function getInterestRate() view returns ((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate_)",
-          canonical: "getInterestRate()",
+          full: "function getKpiLinkedRateInterestRate() view returns ((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate_)",
+          canonical: "getKpiLinkedRateInterestRate()",
         },
-        selector: "0x5257b566",
+        selector: "0x11cce521",
       },
       {
-        name: "initialize_KpiLinkedRate",
+        name: "initializeKpiLinkedRate",
         signature: {
-          full: "function initialize_KpiLinkedRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _impactData)",
+          full: "function initializeKpiLinkedRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _impactData)",
           canonical:
-            "initialize_KpiLinkedRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256))",
+            "initializeKpiLinkedRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256))",
         },
-        selector: "0x0b7c89d7",
+        selector: "0x4d1b66be",
       },
       {
-        name: "setImpactData",
+        name: "setKpiLinkedRateImpactData",
         signature: {
-          full: "function setImpactData((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _newImpactData)",
-          canonical: "setImpactData((uint256,uint256,uint256,uint8,uint256))",
+          full: "function setKpiLinkedRateImpactData((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _newImpactData)",
+          canonical: "setKpiLinkedRateImpactData((uint256,uint256,uint256,uint8,uint256))",
         },
-        selector: "0x9ce6e100",
+        selector: "0x5c993888",
       },
       {
-        name: "setInterestRate",
+        name: "setKpiLinkedRateInterestRate",
         signature: {
-          full: "function setInterestRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _newInterestRate)",
-          canonical: "setInterestRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
+          full: "function setKpiLinkedRateInterestRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _newInterestRate)",
+          canonical: "setKpiLinkedRateInterestRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
         },
-        selector: "0x9a833a5b",
+        selector: "0x6b4bbb7a",
       },
     ],
     events: [

--- a/packages/ats/contracts/tasks/compile.ts
+++ b/packages/ats/contracts/tasks/compile.ts
@@ -91,7 +91,8 @@ task("erc3643-clone-interfaces", async (_, hre) => {
     { original: "ICore", removeImports: false },
     // Coupon Interest Rates interfaces
     { original: "IFixedRate" },
-    { original: "IKpiLinkedRate" },
+    { original: "IKpiLinkedRateErrors" },
+    { original: "IKpiLinkedRate", removeImports: false, removeHierarchy: false },
     {
       original: "ICouponListing",
       removeImports: false,

--- a/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
@@ -1289,12 +1289,12 @@ describe("Factory Tests", () => {
 
       // Verify KPI linked rate was set
       const kpiLinkedRateFacet = await ethers.getContractAt("KpiLinkedRate", bondAddress);
-      const interestRate = await kpiLinkedRateFacet.getInterestRate();
+      const interestRate = await kpiLinkedRateFacet.getKpiLinkedRateInterestRate();
       expect(interestRate.maxRate).to.equal(bondKpiLinkedRateData.interestRate.maxRate);
       expect(interestRate.baseRate).to.equal(bondKpiLinkedRateData.interestRate.baseRate);
       expect(interestRate.minRate).to.equal(bondKpiLinkedRateData.interestRate.minRate);
 
-      const impactData = await kpiLinkedRateFacet.getImpactData();
+      const impactData = await kpiLinkedRateFacet.getKpiLinkedRateImpactData();
       expect(impactData.maxDeviationCap).to.equal(bondKpiLinkedRateData.impactData.maxDeviationCap);
       expect(impactData.baseLine).to.equal(bondKpiLinkedRateData.impactData.baseLine);
       expect(impactData.maxDeviationFloor).to.equal(bondKpiLinkedRateData.impactData.maxDeviationFloor);

--- a/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/factory/factory.test.ts
@@ -1288,13 +1288,13 @@ describe("Factory Tests", () => {
       const bondAddress = decoded.bondAddress;
 
       // Verify KPI linked rate was set
-      const kpiLinkedRateFacet = await ethers.getContractAt("KpiLinkedRate", bondAddress);
-      const interestRate = await kpiLinkedRateFacet.getKpiLinkedRateInterestRate();
+      const asset = await ethers.getContractAt("IAsset", bondAddress);
+      const interestRate = await asset.getKpiLinkedRateInterestRate();
       expect(interestRate.maxRate).to.equal(bondKpiLinkedRateData.interestRate.maxRate);
       expect(interestRate.baseRate).to.equal(bondKpiLinkedRateData.interestRate.baseRate);
       expect(interestRate.minRate).to.equal(bondKpiLinkedRateData.interestRate.minRate);
 
-      const impactData = await kpiLinkedRateFacet.getKpiLinkedRateImpactData();
+      const impactData = await asset.getKpiLinkedRateImpactData();
       expect(impactData.maxDeviationCap).to.equal(bondKpiLinkedRateData.impactData.maxDeviationCap);
       expect(impactData.baseLine).to.equal(bondKpiLinkedRateData.impactData.baseLine);
       expect(impactData.maxDeviationFloor).to.equal(bondKpiLinkedRateData.impactData.maxDeviationFloor);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
@@ -128,8 +128,8 @@ describe("Bond KpiLinked Rate Tests", () => {
       adjustmentPrecision: 2,
     };
 
-    await kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate);
-    await kpiLinkedRateFacet.connect(signer_A).setImpactData(newImpactData);
+    await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
+    await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData(newImpactData);
   }
 
   async function checkCouponPostValues(
@@ -333,7 +333,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       newInterestRate.missedPenalty = previousCouponRate;
       newInterestRate.rateDecimals = previousCouponRateDecimals + 1;
 
-      await kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate);
+      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       updateCouponDates();
 
@@ -356,7 +356,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       newInterestRate.missedPenalty = previousCouponRate_2;
       newInterestRate.rateDecimals = previousCouponRateDecimals_2 - 1;
 
-      await kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate);
+      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       updateCouponDates();
 
@@ -378,7 +378,7 @@ describe("Bond KpiLinked Rate Tests", () => {
     it("GIVEN a kpiLinked rate bond WHEN no report is found but missing penalty is too high THEN transaction success and rate is max rate", async () => {
       await setKpiConfiguration(-10);
       newInterestRate.missedPenalty = newInterestRate.maxRate + 100;
-      await kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate);
+      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       // Test missed penalty when there is a single coupon
       await asset.connect(signer_A).setCoupon(couponData);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/bond/kpiLinkedRate/bondKpiLinkedRate.test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { ResolverProxy, KpiLinkedRateFacetTimeTravel, IAsset } from "@contract-types";
+import { ResolverProxy, IAsset } from "@contract-types";
 import { dateToUnixTimestamp, ATS_ROLES, TIME_PERIODS_S } from "@scripts";
 import { SecurityType } from "@scripts/domain";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
@@ -45,7 +45,6 @@ describe("Bond KpiLinked Rate Tests", () => {
   let signer_C: HardhatEthersSigner;
 
   let asset: IAsset;
-  let kpiLinkedRateFacet: KpiLinkedRateFacetTimeTravel;
 
   let couponData = {
     recordDate: couponRecordDateInSeconds.toString(),
@@ -91,8 +90,6 @@ describe("Bond KpiLinked Rate Tests", () => {
       },
     ]);
 
-    kpiLinkedRateFacet = await ethers.getContractAt("KpiLinkedRateFacetTimeTravel", diamond.target, signer_A);
-
     await asset.connect(signer_A).issue(signer_A.address, amount, "0x");
     await asset.connect(signer_A).addProceedRecipient(signer_B.address, "0x");
     await asset.connect(signer_A).addProceedRecipient(signer_C.address, "0x");
@@ -128,8 +125,8 @@ describe("Bond KpiLinked Rate Tests", () => {
       adjustmentPrecision: 2,
     };
 
-    await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
-    await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData(newImpactData);
+    await asset.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
+    await asset.connect(signer_A).setKpiLinkedRateImpactData(newImpactData);
   }
 
   async function checkCouponPostValues(
@@ -333,7 +330,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       newInterestRate.missedPenalty = previousCouponRate;
       newInterestRate.rateDecimals = previousCouponRateDecimals + 1;
 
-      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
+      await asset.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       updateCouponDates();
 
@@ -356,7 +353,7 @@ describe("Bond KpiLinked Rate Tests", () => {
       newInterestRate.missedPenalty = previousCouponRate_2;
       newInterestRate.rateDecimals = previousCouponRateDecimals_2 - 1;
 
-      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
+      await asset.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       updateCouponDates();
 
@@ -378,7 +375,7 @@ describe("Bond KpiLinked Rate Tests", () => {
     it("GIVEN a kpiLinked rate bond WHEN no report is found but missing penalty is too high THEN transaction success and rate is max rate", async () => {
       await setKpiConfiguration(-10);
       newInterestRate.missedPenalty = newInterestRate.maxRate + 100;
-      await kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
+      await asset.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate);
 
       // Test missed penalty when there is a single coupon
       await asset.connect(signer_A).setCoupon(couponData);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { type ResolverProxy, type IAsset, KpiLinkedRate } from "@contract-types";
+import { type ResolverProxy, type IAsset } from "@contract-types";
 import { ATS_ROLES } from "@scripts";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { DEFAULT_BOND_KPI_LINKED_RATE_PARAMS, deployBondKpiLinkedRateTokenFixture } from "@test";
@@ -15,7 +15,6 @@ describe("Kpi Linked Rate Tests", () => {
   let signer_B: HardhatEthersSigner;
   let signer_C: HardhatEthersSigner;
 
-  let kpiLinkedRateFacet: KpiLinkedRate;
   let asset: IAsset;
 
   async function deploySecurityFixtureMultiPartition() {
@@ -36,8 +35,6 @@ describe("Kpi Linked Rate Tests", () => {
         members: [signer_A.address],
       },
     ]);
-
-    kpiLinkedRateFacet = await ethers.getContractAt("KpiLinkedRate", diamond.target, signer_A);
   }
 
   beforeEach(async () => {
@@ -46,7 +43,7 @@ describe("Kpi Linked Rate Tests", () => {
 
   it("GIVEN an initialized contract WHEN trying to initialize it again THEN transaction fails with AlreadyInitialized", async () => {
     await expect(
-      kpiLinkedRateFacet.initializeKpiLinkedRate(
+      asset.initializeKpiLinkedRate(
         {
           maxRate: 3,
           baseRate: 2,
@@ -77,7 +74,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
+        asset.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 3,
           baseRate: 2,
           minRate: 1,
@@ -93,7 +90,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
+        asset.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 300,
@@ -108,7 +105,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN an account without interest rate manager role WHEN setInterestRate THEN transaction fails with AccountHasNoRole", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_C).setKpiLinkedRateInterestRate({
+        asset.connect(signer_C).setKpiLinkedRateInterestRate({
           maxRate: 3,
           baseRate: 2,
           minRate: 1,
@@ -124,7 +121,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN an account without interest rate manager role WHEN setImpactData THEN transaction fails with AccountHasNoRole", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_C).setKpiLinkedRateImpactData({
+        asset.connect(signer_C).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 300,
@@ -139,7 +136,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Min Rate larger than Base Rate WHEN setInterestRate THEN transaction fails with WrongInterestRateValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
+        asset.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 4,
           baseRate: 2,
           minRate: 3,
@@ -155,7 +152,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Base Rate larger than Max Rate WHEN setInterestRate THEN transaction fails with WrongInterestRateValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
+        asset.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 4,
           baseRate: 5,
           minRate: 3,
@@ -180,8 +177,8 @@ describe("Kpi Linked Rate Tests", () => {
         rateDecimals: DEFAULT_BOND_KPI_LINKED_RATE_PARAMS.rateDecimals + 1,
       };
 
-      await expect(kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate))
-        .to.emit(kpiLinkedRateFacet, "InterestRateUpdated")
+      await expect(asset.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate))
+        .to.emit(asset, "InterestRateUpdated")
         .withArgs(signer_A.address, [
           newInterestRate.maxRate,
           newInterestRate.baseRate,
@@ -193,7 +190,7 @@ describe("Kpi Linked Rate Tests", () => {
           newInterestRate.rateDecimals,
         ]);
 
-      const interestRate = await kpiLinkedRateFacet.getKpiLinkedRateInterestRate();
+      const interestRate = await asset.getKpiLinkedRateInterestRate();
 
       expect(interestRate.maxRate).to.equal(newInterestRate.maxRate);
       expect(interestRate.baseRate).to.equal(newInterestRate.baseRate);
@@ -210,7 +207,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Max deviation floor larger than Base Line WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
+        asset.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 800,
@@ -223,7 +220,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Base Line larger than Max Deviation Cap WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
+        asset.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 7000,
           maxDeviationFloor: 800,
@@ -242,8 +239,8 @@ describe("Kpi Linked Rate Tests", () => {
         adjustmentPrecision: DEFAULT_BOND_KPI_LINKED_RATE_PARAMS.adjustmentPrecision + 1,
       };
 
-      await expect(kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData(newImpactData))
-        .to.emit(kpiLinkedRateFacet, "ImpactDataUpdated")
+      await expect(asset.connect(signer_A).setKpiLinkedRateImpactData(newImpactData))
+        .to.emit(asset, "ImpactDataUpdated")
         .withArgs(signer_A.address, [
           newImpactData.maxDeviationCap,
           newImpactData.baseLine,
@@ -252,7 +249,7 @@ describe("Kpi Linked Rate Tests", () => {
           newImpactData.adjustmentPrecision,
         ]);
 
-      const impactData = await kpiLinkedRateFacet.getKpiLinkedRateImpactData();
+      const impactData = await asset.getKpiLinkedRateImpactData();
 
       expect(impactData.maxDeviationCap).to.equal(newImpactData.maxDeviationCap);
       expect(impactData.baseLine).to.equal(newImpactData.baseLine);

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -46,7 +46,7 @@ describe("Kpi Linked Rate Tests", () => {
 
   it("GIVEN an initialized contract WHEN trying to initialize it again THEN transaction fails with AlreadyInitialized", async () => {
     await expect(
-      kpiLinkedRateFacet.initialize_KpiLinkedRate(
+      kpiLinkedRateFacet.initializeKpiLinkedRate(
         {
           maxRate: 3,
           baseRate: 2,
@@ -77,7 +77,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN a paused Token WHEN setInterestRate THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setInterestRate({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 3,
           baseRate: 2,
           minRate: 1,
@@ -93,7 +93,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN a paused Token WHEN setImpactData THEN transaction fails with IsPaused", async () => {
       // transfer with data fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setImpactData({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 300,
@@ -108,7 +108,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN an account without interest rate manager role WHEN setInterestRate THEN transaction fails with AccountHasNoRole", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_C).setInterestRate({
+        kpiLinkedRateFacet.connect(signer_C).setKpiLinkedRateInterestRate({
           maxRate: 3,
           baseRate: 2,
           minRate: 1,
@@ -124,7 +124,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN an account without interest rate manager role WHEN setImpactData THEN transaction fails with AccountHasNoRole", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_C).setImpactData({
+        kpiLinkedRateFacet.connect(signer_C).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 300,
@@ -139,7 +139,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Min Rate larger than Base Rate WHEN setInterestRate THEN transaction fails with WrongInterestRateValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setInterestRate({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 4,
           baseRate: 2,
           minRate: 3,
@@ -155,7 +155,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Base Rate larger than Max Rate WHEN setInterestRate THEN transaction fails with WrongInterestRateValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setInterestRate({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate({
           maxRate: 4,
           baseRate: 5,
           minRate: 3,
@@ -180,7 +180,7 @@ describe("Kpi Linked Rate Tests", () => {
         rateDecimals: DEFAULT_BOND_KPI_LINKED_RATE_PARAMS.rateDecimals + 1,
       };
 
-      await expect(kpiLinkedRateFacet.connect(signer_A).setInterestRate(newInterestRate))
+      await expect(kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateInterestRate(newInterestRate))
         .to.emit(kpiLinkedRateFacet, "InterestRateUpdated")
         .withArgs(signer_A.address, [
           newInterestRate.maxRate,
@@ -193,7 +193,7 @@ describe("Kpi Linked Rate Tests", () => {
           newInterestRate.rateDecimals,
         ]);
 
-      const interestRate = await kpiLinkedRateFacet.getInterestRate();
+      const interestRate = await kpiLinkedRateFacet.getKpiLinkedRateInterestRate();
 
       expect(interestRate.maxRate).to.equal(newInterestRate.maxRate);
       expect(interestRate.baseRate).to.equal(newInterestRate.baseRate);
@@ -210,7 +210,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Max deviation floor larger than Base Line WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setImpactData({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 800,
@@ -223,7 +223,7 @@ describe("Kpi Linked Rate Tests", () => {
     it("GIVEN Base Line larger than Max Deviation Cap WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       // add to list fails
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setImpactData({
+        kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 7000,
           maxDeviationFloor: 800,
@@ -242,7 +242,7 @@ describe("Kpi Linked Rate Tests", () => {
         adjustmentPrecision: DEFAULT_BOND_KPI_LINKED_RATE_PARAMS.adjustmentPrecision + 1,
       };
 
-      await expect(kpiLinkedRateFacet.connect(signer_A).setImpactData(newImpactData))
+      await expect(kpiLinkedRateFacet.connect(signer_A).setKpiLinkedRateImpactData(newImpactData))
         .to.emit(kpiLinkedRateFacet, "ImpactDataUpdated")
         .withArgs(signer_A.address, [
           newImpactData.maxDeviationCap,
@@ -252,7 +252,7 @@ describe("Kpi Linked Rate Tests", () => {
           newImpactData.adjustmentPrecision,
         ]);
 
-      const impactData = await kpiLinkedRateFacet.getImpactData();
+      const impactData = await kpiLinkedRateFacet.getKpiLinkedRateImpactData();
 
       expect(impactData.maxDeviationCap).to.equal(newImpactData.maxDeviationCap);
       expect(impactData.baseLine).to.equal(newImpactData.baseLine);

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -1544,7 +1544,7 @@ export class RPCQueryAdapter {
     address: EvmAddress,
   ): Promise<[bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint]> {
     LogService.logTrace(`Getting interest rate for security: ${address.toString()}`);
-    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getInterestRate();
+    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getKpiLinkedRateInterestRate();
     return [
       result.maxRate,
       result.baseRate,
@@ -1576,7 +1576,7 @@ export class RPCQueryAdapter {
 
   async getImpactData(address: EvmAddress): Promise<[bigint, bigint, bigint, number, bigint]> {
     LogService.logTrace(`Getting impact data for the security: ${address.toString()}`);
-    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getImpactData();
+    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getKpiLinkedRateImpactData();
     return [
       result.maxDeviationCap,
       result.baseLine,

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -29,7 +29,6 @@ import {
   MockedExternalPause__factory,
   MockedWhitelist__factory,
   TREXFactoryAts__factory,
-  KpiLinkedRate__factory,
 } from "@hashgraph/asset-tokenization-contracts";
 import { ScheduledSnapshot } from "@domain/context/security/ScheduledSnapshot";
 import { VotingRights } from "@domain/context/equity/VotingRights";
@@ -1544,7 +1543,7 @@ export class RPCQueryAdapter {
     address: EvmAddress,
   ): Promise<[bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint]> {
     LogService.logTrace(`Getting interest rate for security: ${address.toString()}`);
-    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getKpiLinkedRateInterestRate();
+    const result = await this.connect(IAsset__factory, address.toString()).getKpiLinkedRateInterestRate();
     return [
       result.maxRate,
       result.baseRate,
@@ -1576,7 +1575,7 @@ export class RPCQueryAdapter {
 
   async getImpactData(address: EvmAddress): Promise<[bigint, bigint, bigint, number, bigint]> {
     LogService.logTrace(`Getting impact data for the security: ${address.toString()}`);
-    const result = await this.connect(KpiLinkedRate__factory, address.toString()).getKpiLinkedRateImpactData();
+    const result = await this.connect(IAsset__factory, address.toString()).getKpiLinkedRateImpactData();
     return [
       result.maxDeviationCap,
       result.baseLine,

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -61,7 +61,6 @@ import TransactionResponse from "@domain/context/transaction/TransactionResponse
 import { SecurityDataBuilder } from "@domain/context/util/SecurityDataBuilder";
 import {
   IAsset__factory,
-  KpiLinkedRate__factory,
   Factory__factory,
   MockedBlacklist__factory,
   MockedExternalKycList__factory,
@@ -2629,7 +2628,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
   ): Promise<TransactionResponse> {
     LogService.logTrace(`Setting Interest Rate for security ${security.toString()}`);
     return this.executeTransaction(
-      KpiLinkedRate__factory.connect(security.toString(), this.getSignerOrProvider()),
+      IAsset__factory.connect(security.toString(), this.getSignerOrProvider()),
       "setKpiLinkedRateInterestRate",
       [
         {
@@ -2658,7 +2657,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
   ): Promise<TransactionResponse> {
     LogService.logTrace(`Setting Impact Data for security ${security.toString()}`);
     return this.executeTransaction(
-      KpiLinkedRate__factory.connect(security.toString(), this.getSignerOrProvider()),
+      IAsset__factory.connect(security.toString(), this.getSignerOrProvider()),
       "setKpiLinkedRateImpactData",
       [
         {

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -2630,7 +2630,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     LogService.logTrace(`Setting Interest Rate for security ${security.toString()}`);
     return this.executeTransaction(
       KpiLinkedRate__factory.connect(security.toString(), this.getSignerOrProvider()),
-      "setInterestRate",
+      "setKpiLinkedRateInterestRate",
       [
         {
           maxRate: maxRate.toBigInt(),
@@ -2659,7 +2659,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     LogService.logTrace(`Setting Impact Data for security ${security.toString()}`);
     return this.executeTransaction(
       KpiLinkedRate__factory.connect(security.toString(), this.getSignerOrProvider()),
-      "setImpactData",
+      "setKpiLinkedRateImpactData",
       [
         {
           maxDeviationCap: maxDeviationCap.toBigInt(),


### PR DESCRIPTION
## Description

[BBND-1731](https://iobuilders.atlassian.net/browse/BBND-1731)

Renames the four externals on the `KpiLinkedRate` facet and camel-cases its initialiser so it no longer collides with `SustainabilityPerformanceTargetRate` on the same diamond and `IAsset` umbrella:

- `getImpactData` → `getKpiLinkedRateImpactData`
- `getInterestRate` → `getKpiLinkedRateInterestRate`
- `setImpactData` → `setKpiLinkedRateImpactData`
- `setInterestRate` → `setKpiLinkedRateInterestRate`
- `initialize_KpiLinkedRate` → `initializeKpiLinkedRate`

Events (`InterestRateUpdated`, `ImpactDataUpdated`) and shared structs (`InterestRate`, `ImpactData` on `IKpiLinkedRateErrors`) are unchanged. Selectors change because the canonical signatures change — this is a breaking ABI change for external integrators, surfaced via the `major` bump in `.changeset/maf-rename-kpi-linked-rate.md`.

Additional related changes in this PR:

- `KpiLinkedRateFacet` selector registry migrated to the descending `unchecked { staticFunctionSelectors_[--selectorIndex] = ... }` pattern per `.claude/rules/20-solidity/conventions.md` §2.
- Latent bug fixed in `tasks/compile.ts` `erc3643-clone-interfaces` task. The regen was dropping the `is IKpiLinkedRateErrors` hierarchy from the T-REX shadow on every ABI-changing regen (masked by ABI-equality skip). Now declares `IKpiLinkedRate` with preserved imports/hierarchy and clones a companion `IKpiLinkedRateErrors` shadow.
- SDK `RPCQueryAdapter` and `RPCTransactionAdapter` updated to bridge the rename internally; SDK port-in API is unchanged.

The historical exclusion comment on `IAsset.sol` (lines 53, 158) noting that both facets define conflicting methods is now slightly stale; a follow-up will add `IKpiLinkedRate` to `IAsset` now that selectors are disambiguated.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

Local verification on this branch:

- `npm run ats:contracts:test` → **2929 passing / 3 pending** (identical to baseline).
- `npm run ats:contracts:lint` → 0 errors, 3158 warnings (6 fewer than baseline; `solhint-disable func-name-mixedcase` lines removed by the camelCase rename).
- `npm run ats:contracts:format` → clean.
- `npm run ats:sdk:build` → clean (after running `npm run ats:contracts:build` to refresh `packages/ats/contracts/build/typechain-types/`).
- `npm run ats:sdk:test` → only the 5 documented env-required custodial-adapter suites fail (DFNS, AWSKMS, Fireblocks, Kyc, Security = 26 tests), matching the documented baseline. All KpiLinkedRate-specific SDK suites pass.

Integration tests for `KpiLinkedRate` (`kpiLinkedRate.test.ts`, `bondKpiLinkedRate.test.ts`, `factory.test.ts`) updated to call the renamed methods; all pass.

### Test Results

```
contracts:  2929 passing, 3 pending, 0 failing
contracts lint: 0 errors, 3158 warnings (baseline: 3164)
sdk build: clean
sdk tests: 1866 passing, 26 failing (env-required custodial-adapter baseline, unchanged)
```

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅