### PR TITLE
fix: [FIND-123] Zero-Amount Hold Execution Creates Partition That Blocks fullRedeemAtMaturity

### DIFF
--- a/.changeset/fix-find-120-zero-amount-hold-dos.md
+++ b/.changeset/fix-find-120-zero-amount-hold-dos.md
@@ -1,0 +1,17 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-120: zero-amount hold execution creates ghost partition, permanently blocking `fullRedeemAtMaturity`.
+
+`HoldStorageWrapper.createHoldByPartition` accepted `_hold.amount == 0` without validation. When such a hold was executed against a recipient who did not yet hold the relevant partition, `_transferHoldBalance` called `ERC1410StorageWrapper.addPartitionToOnly(0, _to, partition)`, writing a `Partition(0, partition)` entry into the recipient's partition array. At maturity, `Maturity.fullRedeemAtMaturity` iterated all partitions of the token holder, encountered the ghost entry with balance 0, and reverted via `_checkUnexpectedError` — permanently blocking redemption for that address.
+
+`ClearingOps.clearingHoldCreationCreation` was exposed to the same vector: a zero-amount clearing hold would also produce a ghost partition upon approval.
+
+The fix applies two complementary layers of defence:
+
+- **Root cause — hold and clearing-hold creation**: `HoldStorageWrapper.checkNonZeroHoldAmount` is a new internal pure function that reverts with `IHoldTypes.InvalidHoldAmount` when the amount is zero. `createHoldByPartition` calls it at entry, and `ClearingOps.clearingHoldCreationCreation` delegates to it via `HoldStorageWrapper`, keeping the guard in a single place.
+- **Defence in depth — maturity redemption**: `fullRedeemAtMaturity` no longer reverts on a zero-balance partition; it now skips it with `if (balance != 0)`, making the function resilient to any ghost partition that may already exist in storage.
+- **Hygiene guards**: `LockStorageWrapper.lockByPartition` rejects `amount == 0` with `ILockTypes.InvalidLockAmount`; `ERC3643StorageWrapper.freezeTokensByPartition` rejects `_amount == 0` with `IFreeze.InvalidFreezeAmount`. Neither operation can produce a ghost partition, but accepting a zero amount is semantically invalid and creates unnecessary storage noise.
+
+New errors added: `IHoldTypes.InvalidHoldAmount`, `ILockTypes.InvalidLockAmount`, `IFreeze.InvalidFreezeAmount`.

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -512,11 +512,6 @@ library HoldStorageWrapper {
         return _escrow == _hold.escrow;
     }
 
-    /**
-     * @notice Reverts with `InvalidHoldAmount` when `_amount` is zero.
-     * @dev Called at the start of `createHoldByPartition` and reused by `ClearingOps`
-     *      for clearing-hold creation, keeping the guard in a single place.
-     */
     function checkNonZeroHoldAmount(uint256 _amount) internal pure {
         if (_amount == 0) revert IHoldTypes.InvalidHoldAmount();
     }

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -52,6 +52,8 @@ library HoldStorageWrapper {
         bytes memory _operatorData,
         ThirdPartyType _thirdPartyType
     ) internal returns (bool success_, uint256 holdId_) {
+        checkNonZeroHoldAmount(_hold.amount);
+
         _prepareHoldCreation(_partition, _from);
 
         uint256 abaf = updateTotalHold(_partition, _from);
@@ -508,6 +510,15 @@ library HoldStorageWrapper {
 
     function isEscrow(IHoldTypes.Hold memory _hold, address _escrow) internal pure returns (bool) {
         return _escrow == _hold.escrow;
+    }
+
+    /**
+     * @notice Reverts with `InvalidHoldAmount` when `_amount` is zero.
+     * @dev Called at the start of `createHoldByPartition` and reused by `ClearingOps`
+     *      for clearing-hold creation, keeping the guard in a single place.
+     */
+    function checkNonZeroHoldAmount(uint256 _amount) internal pure {
+        if (_amount == 0) revert IHoldTypes.InvalidHoldAmount();
     }
 
     function checkHoldAmount(uint256 _amount, IHoldTypes.HoldData memory holdData) internal pure {

--- a/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
@@ -40,7 +40,7 @@ library LockStorageWrapper {
         uint256 expirationTimestamp,
         address operator
     ) internal returns (bool success_, uint256 lockId_) {
-        if (amount == 0) revert ILockTypes.InvalidLockAmount();
+        checkNonZeroLockAmount(amount);
 
         _prepareLock(partition, tokenHolder);
 
@@ -279,6 +279,10 @@ library LockStorageWrapper {
         assembly {
             lock_.slot := position
         }
+    }
+
+    function checkNonZeroLockAmount(uint256 amount) internal pure {
+        if (amount == 0) revert ILockTypes.InvalidLockAmount();
     }
 
     // --- Private helper functions ---

--- a/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
@@ -40,6 +40,8 @@ library LockStorageWrapper {
         uint256 expirationTimestamp,
         address operator
     ) internal returns (bool success_, uint256 lockId_) {
+        if (amount == 0) revert ILockTypes.InvalidLockAmount();
+
         _prepareLock(partition, tokenHolder);
 
         uint256 abaf = updateTotalLock(partition, tokenHolder);

--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -5,6 +5,7 @@ import { _ERC3643_STORAGE_POSITION } from "../../constants/storagePositions.sol"
 import { AGENT_ROLE } from "../../constants/roles.sol";
 import { _DEFAULT_PARTITION } from "../../constants/values.sol";
 import { IERC3643Types } from "../../facets/layer_1/ERC3643/IERC3643Types.sol";
+import { IFreeze } from "../../facets/freeze/IFreeze.sol";
 import { IAccessControl } from "../../facets/accessControl/IAccessControl.sol";
 import { IIdentityRegistry } from "../../facets/layer_1/ERC3643/IIdentityRegistry.sol";
 import { ICompliance } from "../../facets/layer_1/ERC3643/ICompliance.sol";
@@ -135,6 +136,8 @@ library ERC3643StorageWrapper {
     }
 
     function freezeTokensByPartition(bytes32 _partition, address _account, uint256 _amount) internal {
+        if (_amount == 0) revert IFreeze.InvalidFreezeAmount();
+
         ERC1410StorageWrapper.triggerAndSyncAll(_partition, _account, address(0));
         updateTotalFreeze(_partition, _account);
         SnapshotsStorageWrapper.updateAccountSnapshot(_account, _partition);

--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -136,7 +136,7 @@ library ERC3643StorageWrapper {
     }
 
     function freezeTokensByPartition(bytes32 _partition, address _account, uint256 _amount) internal {
-        if (_amount == 0) revert IFreeze.InvalidFreezeAmount();
+        checkNonZeroFreezeAmount(_amount);
 
         ERC1410StorageWrapper.triggerAndSyncAll(_partition, _account, address(0));
         updateTotalFreeze(_partition, _account);
@@ -366,6 +366,10 @@ library ERC3643StorageWrapper {
         if (_addresses.length != _status.length) {
             revert IERC3643Types.InputBoolArrayLengthMismatch();
         }
+    }
+
+    function checkNonZeroFreezeAmount(uint256 _amount) internal pure {
+        if (_amount == 0) revert IFreeze.InvalidFreezeAmount();
     }
 
     function _transferFrozenBalanceOnly(bytes32 _partition, address _to, uint256 _amount) private {

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
@@ -228,6 +228,8 @@ library ClearingOps {
         bytes memory _operatorData,
         ThirdPartyType _thirdPartyType
     ) public returns (bool success_, uint256 clearingId_) {
+        HoldStorageWrapper.checkNonZeroHoldAmount(_hold.amount);
+
         bytes32 partition = _clearingOperation.partition;
 
         clearingId_ = ClearingStorageWrapper.increaseClearingId(

--- a/packages/ats/contracts/contracts/facets/freeze/IFreeze.sol
+++ b/packages/ats/contracts/contracts/facets/freeze/IFreeze.sol
@@ -40,6 +40,14 @@ interface IFreeze {
     event AddressFrozen(address indexed userAddress, bool indexed isFrozen, address indexed owner);
 
     /**
+     * @notice Reverts when a partial token freeze is attempted with a zero amount.
+     * @dev Checked at the start of `ERC3643StorageWrapper.freezeTokensByPartition`, the
+     *      single entry point shared by both `freezePartialTokens` and any partition-scoped
+     *      freeze call. Freezing zero tokens is semantically invalid and rejected early.
+     */
+    error InvalidFreezeAmount();
+
+    /**
      * @notice Freezes a specific amount of tokens for a wallet, reducing its liquid balance.
      * @dev Requires `FREEZE_MANAGER_ROLE` or `AGENT_ROLE`, the token to be unpaused, a non-zero
      *      non-recovered address, and a single-partition token (`onlyWithoutMultiPartition`).

--- a/packages/ats/contracts/contracts/facets/layer_1/hold/IHoldTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/hold/IHoldTypes.sol
@@ -113,4 +113,5 @@ interface IHoldTypes {
     error InsufficientHoldBalance(uint256 holdAmount, uint256 amount);
     error HoldExpirationReached();
     error IsNotEscrow();
+    error InvalidHoldAmount();
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/lock/ILockTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/lock/ILockTypes.sol
@@ -66,4 +66,11 @@ interface ILockTypes {
      *      `LockStorageWrapper.checkValidLockId`.
      */
     error WrongLockId();
+
+    /**
+     * @notice Reverts when a lock creation is attempted with a zero amount.
+     * @dev Checked at the start of `LockStorageWrapper.lockByPartition`, which is the
+     *      single entry point shared by both `Lock.lock` and `LockByPartition.lockByPartition`.
+     */
+    error InvalidLockAmount();
 }

--- a/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
@@ -4,13 +4,11 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMaturity } from "./IMaturity.sol";
 import { IKyc } from "../layer_1/kyc/IKyc.sol";
 import { BOND_MANAGER_ROLE, MATURITY_REDEEMER_ROLE } from "../../constants/roles.sol";
-import { KPI_BOND_REDEEM_BALANCE } from "../../constants/values.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
 import { BondStorageWrapper } from "../../domain/asset/BondStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
-import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 
 /**
  * @title  Maturity
@@ -45,8 +43,9 @@ abstract contract Maturity is IMaturity, Modifiers {
         for (uint256 i; i < length; ) {
             bytes32 partition = partitions[i];
             uint256 balance = ERC1410StorageWrapper.balanceOfByPartition(partition, _tokenHolder);
-            _checkUnexpectedError(balance == 0, KPI_BOND_REDEEM_BALANCE);
-            ERC1410StorageWrapper.redeemByPartition(partition, _tokenHolder, sender, balance, "", "");
+            if (balance != 0) {
+                ERC1410StorageWrapper.redeemByPartition(partition, _tokenHolder, sender, balance, "", "");
+            }
             unchecked {
                 ++i;
             }

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T08:27:08.486Z
- * Facets: 123
+ * Generated: 2026-05-12T13:13:04.253Z
+ * Facets: 124
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -102,6 +102,7 @@ import {
   MetadataFacet__factory,
   MintByPartitionFacet__factory,
   MintFacet__factory,
+  NominalValueAtSnapshotFacet__factory,
   NominalValueFacet__factory,
   NoncesFacet__factory,
   OperatorByPartitionFacet__factory,
@@ -4440,7 +4441,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       {
         name: "getCouponFor",
         signature: {
-          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
+          full: "function getCouponFor(uint256 _couponID, address _account) view returns ((uint256 tokenBalance, uint8 decimals, uint256 nominalValue, uint256 nominalValueDecimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled) couponFor_)",
           canonical: "getCouponFor(uint256,address)",
         },
         selector: "0xbba7b56d",
@@ -4660,7 +4661,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       {
         name: "getCouponsFor",
         signature: {
-          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint256 nominalValue, uint8 decimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] holders_)",
+          full: "function getCouponsFor(uint256 _couponID, uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 tokenBalance, uint8 decimals, uint256 nominalValue, uint256 nominalValueDecimals, bool recordDateReached, (uint256 recordDate, uint256 executionDate, uint256 startDate, uint256 endDate, uint256 fixingDate, uint256 rate, uint8 rateDecimals, uint8 rateStatus) coupon, (uint256 numerator, uint256 denominator, bool recordDateReached) couponAmount, bool isDisabled)[] couponFor_, address[] holders_)",
           canonical: "getCouponsFor(uint256,uint256,uint256)",
         },
         selector: "0x7327ad90",
@@ -7617,6 +7618,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 
   KpiLinkedRateFacet: {
     name: "KpiLinkedRateFacet",
+    description: "Diamond facet that exposes the KPI-linked interest rate capability (`IKpiLinkedRate`) on a token.",
     resolverKey: {
       name: "_KPI_LINKED_RATE_RESOLVER_KEY",
       value: "0x92999bd0329d03e46274ce7743ebe0060df95286df4fa7b354937b7d21757d22",
@@ -7624,45 +7626,45 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     inheritance: ["KpiLinkedRate", "IStaticFunctionSelectors"],
     methods: [
       {
-        name: "getImpactData",
+        name: "getKpiLinkedRateImpactData",
         signature: {
-          full: "function getImpactData() view returns ((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData_)",
-          canonical: "getImpactData()",
+          full: "function getKpiLinkedRateImpactData() view returns ((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) impactData_)",
+          canonical: "getKpiLinkedRateImpactData()",
         },
-        selector: "0x24bffca8",
+        selector: "0x8e0ae3e7",
       },
       {
-        name: "getInterestRate",
+        name: "getKpiLinkedRateInterestRate",
         signature: {
-          full: "function getInterestRate() view returns ((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate_)",
-          canonical: "getInterestRate()",
+          full: "function getKpiLinkedRateInterestRate() view returns ((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) interestRate_)",
+          canonical: "getKpiLinkedRateInterestRate()",
         },
-        selector: "0x5257b566",
+        selector: "0x11cce521",
       },
       {
-        name: "initialize_KpiLinkedRate",
+        name: "initializeKpiLinkedRate",
         signature: {
-          full: "function initialize_KpiLinkedRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _impactData)",
+          full: "function initializeKpiLinkedRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _interestRate, (uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _impactData)",
           canonical:
-            "initialize_KpiLinkedRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256))",
+            "initializeKpiLinkedRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8),(uint256,uint256,uint256,uint8,uint256))",
         },
-        selector: "0x0b7c89d7",
+        selector: "0x4d1b66be",
       },
       {
-        name: "setImpactData",
+        name: "setKpiLinkedRateImpactData",
         signature: {
-          full: "function setImpactData((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _newImpactData)",
-          canonical: "setImpactData((uint256,uint256,uint256,uint8,uint256))",
+          full: "function setKpiLinkedRateImpactData((uint256 maxDeviationCap, uint256 baseLine, uint256 maxDeviationFloor, uint8 impactDataDecimals, uint256 adjustmentPrecision) _newImpactData)",
+          canonical: "setKpiLinkedRateImpactData((uint256,uint256,uint256,uint8,uint256))",
         },
-        selector: "0x9ce6e100",
+        selector: "0x5c993888",
       },
       {
-        name: "setInterestRate",
+        name: "setKpiLinkedRateInterestRate",
         signature: {
-          full: "function setInterestRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _newInterestRate)",
-          canonical: "setInterestRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
+          full: "function setKpiLinkedRateInterestRate((uint256 maxRate, uint256 baseRate, uint256 minRate, uint256 startPeriod, uint256 startRate, uint256 missedPenalty, uint256 reportPeriod, uint8 rateDecimals) _newInterestRate)",
+          canonical: "setKpiLinkedRateInterestRate((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint8))",
         },
-        selector: "0x9a833a5b",
+        selector: "0x6b4bbb7a",
       },
     ],
     events: [
@@ -7704,11 +7706,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "AlreadyInitialized",
         signature: { full: "error AlreadyInitialized()", canonical: "AlreadyInitialized()" },
         selector: "0x0dc149f0",
-      },
-      {
-        name: "InterestRateIsKpiLinked",
-        signature: { full: "error InterestRateIsKpiLinked()", canonical: "InterestRateIsKpiLinked()" },
-        selector: "0x68eba14f",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -9115,7 +9112,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8579befe",
       },
     ],
-    factory: (signer) => new MaturityByPartitionFacet__factory(signer),
+    factory: (signer) => new MaturityByPartitionFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   MaturityFacet: {
@@ -9278,7 +9275,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x8579befe",
       },
     ],
-    factory: (signer) => new MaturityFacet__factory(signer),
+    factory: (signer) => new MaturityFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   MetadataFacet: {
@@ -9477,8 +9474,53 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     factory: (signer) => new MintFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
   },
 
+  NominalValueAtSnapshotFacet: {
+    name: "NominalValueAtSnapshotFacet",
+    description: "NominalValueAtSnapshotFacet",
+    resolverKey: {
+      name: "_NOMINAL_VALUE_AT_SNAPSHOT_RESOLVER_KEY",
+      value: "0xa9eb978fb9b2f23119fbe6dc3a3f6010398d58b37b5221961eaa584486c8c6fb",
+    },
+    inheritance: ["NominalValueAtSnapshot", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "nominalValueAtSnapshot",
+        signature: {
+          full: "function nominalValueAtSnapshot(uint256 _snapshotID) view returns (uint256 nominalValue_)",
+          canonical: "nominalValueAtSnapshot(uint256)",
+        },
+        selector: "0x526ce5ee",
+      },
+      {
+        name: "nominalValueDecimalsAtSnapshot",
+        signature: {
+          full: "function nominalValueDecimalsAtSnapshot(uint256 _snapshotID) view returns (uint8 nominalValueDecimals_)",
+          canonical: "nominalValueDecimalsAtSnapshot(uint256)",
+        },
+        selector: "0x1fed7107",
+      },
+    ],
+    errors: [
+      {
+        name: "SnapshotIdDoesNotExists",
+        signature: {
+          full: "error SnapshotIdDoesNotExists(uint256 snapshotId)",
+          canonical: "SnapshotIdDoesNotExists(uint256)",
+        },
+        selector: "0x8e81eb83",
+      },
+      {
+        name: "SnapshotIdNull",
+        signature: { full: "error SnapshotIdNull()", canonical: "SnapshotIdNull()" },
+        selector: "0xf128004d",
+      },
+    ],
+    factory: (signer) => new NominalValueAtSnapshotFacet__factory(signer),
+  },
+
   NominalValueFacet: {
     name: "NominalValueFacet",
+    description: "Diamond facet that exposes the nominal value capability (`INominalValue`) on a token.",
     resolverKey: {
       name: "_NOMINAL_VALUE_RESOLVER_KEY",
       value: "0x48903d4da8b1f0a5e9a9874be74ec5d2f8043d4d5b65cc093173c3dae103df8f",
@@ -9491,6 +9533,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xbd4ff0a9",
       },
       {
+        name: "getNominalValueCurrency",
+        signature: {
+          full: "function getNominalValueCurrency() view returns (bytes3)",
+          canonical: "getNominalValueCurrency()",
+        },
+        selector: "0x416b5554",
+      },
+      {
         name: "getNominalValueDecimals",
         signature: {
           full: "function getNominalValueDecimals() view returns (uint8)",
@@ -9499,12 +9549,12 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x27e4bb51",
       },
       {
-        name: "initialize_NominalValue",
+        name: "initializeNominalValue",
         signature: {
-          full: "function initialize_NominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals)",
-          canonical: "initialize_NominalValue(uint256,uint8)",
+          full: "function initializeNominalValue(uint256 _nominalValue, uint8 _nominalValueDecimals, bytes3 _nominalValueCurrency)",
+          canonical: "initializeNominalValue(uint256,uint8,bytes3)",
         },
-        selector: "0x0c0e65af",
+        selector: "0x1bc79e1d",
       },
       {
         name: "setNominalValue",
@@ -9514,8 +9564,32 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0x40ba1a0d",
       },
+      {
+        name: "setNominalValueCurrency",
+        signature: {
+          full: "function setNominalValueCurrency(bytes3 _nominalValueCurrency)",
+          canonical: "setNominalValueCurrency(bytes3)",
+        },
+        selector: "0x1c941c77",
+      },
     ],
     events: [
+      {
+        name: "NominalValueCurrencySet",
+        signature: {
+          full: "event NominalValueCurrencySet(address indexed operator, bytes3 nominalValueCurrency)",
+          canonical: "NominalValueCurrencySet(address,bytes3)",
+        },
+        topic0: "0x121154ad7f7eb7b91da8448a24fd91b473ce28adcb1c5127257918f37b4a3508",
+      },
+      {
+        name: "NominalValueInitialized",
+        signature: {
+          full: "event NominalValueInitialized(address indexed operator, uint256 nominalValue, uint8 nominalValueDecimals, bytes3 nominalValueCurrency)",
+          canonical: "NominalValueInitialized(address,uint256,uint8,bytes3)",
+        },
+        topic0: "0x9a822fe5a63dc100e6c6c4e0c1bfcc813c9343a12c7adbaf651b92b91fbcf2db",
+      },
       {
         name: "NominalValueSet",
         signature: {
@@ -12123,8 +12197,8 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xf9f9bcf9",
       },
     ],
-    factory: (signer) => new RecoveryFacet__factory(signer),
-    timeTravelFactory: (signer) => new RecoveryFacetTimeTravel__factory(signer),
+    factory: (signer) => new RecoveryFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) => new RecoveryFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   ScheduledCrossOrderedTasksFacet: {
@@ -13085,7 +13159,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockByPartitionFacet__factory(signer),
+    factory: (signer) => new TransferAndLockByPartitionFacet__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockFacet: {
@@ -13223,8 +13297,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockFixedRateFacet: {
@@ -13362,8 +13437,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockFixedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockFixedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockFixedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockFixedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockKpiLinkedRateFacet: {
@@ -13501,8 +13577,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockKpiLinkedRateFacet__factory(signer),
-    timeTravelFactory: (signer) => new TransferAndLockKpiLinkedRateFacetTimeTravel__factory(signer),
+    factory: (signer) => new TransferAndLockKpiLinkedRateFacet__factory(getLibLinks("clearingReadOps") as any, signer),
+    timeTravelFactory: (signer) =>
+      new TransferAndLockKpiLinkedRateFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
   TransferAndLockSustainabilityPerformanceTargetRateFacet: {
@@ -13640,9 +13717,16 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xe39f4776",
       },
     ],
-    factory: (signer) => new TransferAndLockSustainabilityPerformanceTargetRateFacet__factory(signer),
+    factory: (signer) =>
+      new TransferAndLockSustainabilityPerformanceTargetRateFacet__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
     timeTravelFactory: (signer) =>
-      new TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory(signer),
+      new TransferAndLockSustainabilityPerformanceTargetRateFacetTimeTravel__factory(
+        getLibLinks("clearingReadOps") as any,
+        signer,
+      ),
   },
 
   TransferByPartitionFacet: {
@@ -14070,7 +14154,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 123 as const;
+export const TOTAL_FACETS = 124 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-11T13:27:01.689Z
+ * Generated: 2026-05-12T08:27:08.486Z
  * Facets: 123
  * Infrastructure: 2
  *
@@ -965,6 +965,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x57fbc6f7",
       },
       {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -1482,6 +1487,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InsufficientFrozenBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0xefafde54",
+      },
+      {
+        name: "InvalidFreezeAmount",
+        signature: { full: "error InvalidFreezeAmount()", canonical: "InvalidFreezeAmount()" },
+        selector: "0xc5083c69",
       },
       {
         name: "InvalidPartition",
@@ -3828,6 +3838,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InvalidDestinationAddress(address,address)",
         },
         selector: "0xdb0a3012",
+      },
+      {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
       },
       {
         name: "InvalidPartition",
@@ -6759,6 +6774,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xefafde54",
       },
       {
+        name: "InvalidFreezeAmount",
+        signature: { full: "error InvalidFreezeAmount()", canonical: "InvalidFreezeAmount()" },
+        selector: "0xc5083c69",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -7134,6 +7154,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xdb0a3012",
       },
       {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -7327,6 +7352,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InvalidDestinationAddress(address,address)",
         },
         selector: "0xdb0a3012",
+      },
+      {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
       },
       {
         name: "IsNotEscrow",
@@ -7566,6 +7596,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InvalidDestinationAddress(address,address)",
         },
         selector: "0xdb0a3012",
+      },
+      {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
       },
       {
         name: "IsNotEscrow",
@@ -8637,6 +8672,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x5d6824c4",
       },
       {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -8852,6 +8892,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
+      },
+      {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
       },
       {
         name: "InvalidPartition",
@@ -10356,6 +10401,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xdb0a3012",
       },
       {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -11661,6 +11711,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xdb0a3012",
       },
       {
+        name: "InvalidHoldAmount",
+        signature: { full: "error InvalidHoldAmount()", canonical: "InvalidHoldAmount()" },
+        selector: "0x352b484a",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -12025,6 +12080,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InsufficientFrozenBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0xefafde54",
+      },
+      {
+        name: "InvalidFreezeAmount",
+        signature: { full: "error InvalidFreezeAmount()", canonical: "InvalidFreezeAmount()" },
+        selector: "0xc5083c69",
       },
       {
         name: "InvalidPartition",
@@ -12972,6 +13032,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x5d6824c4",
       },
       {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -13108,6 +13173,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x5d6824c4",
       },
       {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -13240,6 +13310,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
+      },
+      {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
       },
       {
         name: "InvalidPartition",
@@ -13376,6 +13451,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x5d6824c4",
       },
       {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
+      },
+      {
         name: "InvalidPartition",
         signature: {
           full: "error InvalidPartition(address account, bytes32 partition)",
@@ -13508,6 +13588,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "InsufficientBalance(address,uint256,uint256,bytes32)",
         },
         selector: "0x5d6824c4",
+      },
+      {
+        name: "InvalidLockAmount",
+        signature: { full: "error InvalidLockAmount()", canonical: "InvalidLockAmount()" },
+        selector: "0x409fef33",
       },
       {
         name: "InvalidPartition",

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-12T13:13:04.253Z
+ * Generated: 2026-05-13T08:47:51.051Z
  * Facets: 124
  * Infrastructure: 2
  *
@@ -2258,12 +2258,9 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
-        name: "NewMaxSupplyByPartitionTooHigh",
-        signature: {
-          full: "error NewMaxSupplyByPartitionTooHigh(bytes32 partition, uint256 newMaxSupplyByPartition, uint256 maxSupply)",
-          canonical: "NewMaxSupplyByPartitionTooHigh(bytes32,uint256,uint256)",
-        },
-        selector: "0x21aa64a7",
+        name: "NewMaxSupplyCannotBeZero",
+        signature: { full: "error NewMaxSupplyCannotBeZero()", canonical: "NewMaxSupplyCannotBeZero()" },
+        selector: "0x76f138fb",
       },
       {
         name: "NewMaxSupplyForPartitionTooLow",
@@ -2362,14 +2359,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "MaxSupplyReachedForPartition(bytes32,uint256)",
         },
         selector: "0x57c004a9",
-      },
-      {
-        name: "NewMaxSupplyByPartitionTooHigh",
-        signature: {
-          full: "error NewMaxSupplyByPartitionTooHigh(bytes32 partition, uint256 newMaxSupplyByPartition, uint256 maxSupply)",
-          canonical: "NewMaxSupplyByPartitionTooHigh(bytes32,uint256,uint256)",
-        },
-        selector: "0x21aa64a7",
       },
       {
         name: "NewMaxSupplyCannotBeZero",

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -219,7 +219,7 @@ describe("Kpi Linked Rate Tests", () => {
 
     it("GIVEN Max deviation floor equal to Base Line WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setImpactData({
+        asset.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 700,
           maxDeviationFloor: 700,
@@ -244,7 +244,7 @@ describe("Kpi Linked Rate Tests", () => {
 
     it("GIVEN Base Line equal to Max Deviation Cap WHEN setImpactData THEN transaction fails with WrongImpactDataValues", async () => {
       await expect(
-        kpiLinkedRateFacet.connect(signer_A).setImpactData({
+        asset.connect(signer_A).setKpiLinkedRateImpactData({
           maxDeviationCap: 1000,
           baseLine: 1000,
           maxDeviationFloor: 800,

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -194,6 +194,28 @@ describe("Maturity Tests", () => {
       await expect(asset.connect(signer_A).fullRedeemAtMaturity(newUser.address)).to.not.be.reverted;
     });
 
+    it("GIVEN a zero-amount hold creation attempt WHEN createHoldByPartition THEN reverts with InvalidHoldAmount preventing ghost partition DoS on fullRedeemAtMaturity", async () => {
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_C.address);
+      await asset.connect(signer_C).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        value: amount,
+        data: "0x",
+      });
+
+      const zeroAmountHold = {
+        amount: 0,
+        expirationTimestamp: maturityDate,
+        escrow: signer_B.address,
+        to: signer_C.address,
+        data: "0x",
+      };
+
+      await expect(
+        asset.connect(signer_A).createHoldByPartition(DEFAULT_PARTITION, zeroAmountHold),
+      ).to.be.revertedWithCustomError(asset, "InvalidHoldAmount");
+    });
+
     it("GIVEN a multi-partition token holder WHEN fullRedeemAtMaturity THEN emits RedeemedByPartition for each partition", async () => {
       await deploySecurityFixture(true);
       await asset.connect(signer_A).grantRole(ATS_ROLES.ISSUER_ROLE, signer_C.address);


### PR DESCRIPTION
This pull request introduces stricter input validation across the asset contract domain to prevent zero-amount operations for holds, locks, and freezes. These changes ensure that attempts to create holds, locks, or freezes with a zero amount are rejected early, reducing the risk of edge-case bugs and denial-of-service vectors. The update also includes new custom error types, updated Solidity interfaces, and comprehensive registry and test coverage for these checks.

**Input validation and error handling improvements:**

* Added custom errors `InvalidHoldAmount`, `InvalidLockAmount`, and `InvalidFreezeAmount` to the respective interfaces (`IHoldTypes`, `ILockTypes`, `IFreeze`) to standardize error handling for zero-amount operations. [[1]](diffhunk://#diff-0741681e71f0ed0107af103ac3e80ae3a567028a531465dd914d3aff3387286eR116) [[2]](diffhunk://#diff-addbb37935eda517cf0c6b44524b85c12c973cdb25628e59e0e0381dae8f718aR69-R75) [[3]](diffhunk://#diff-dc206dad649cb459f8a47335d1ea35d7b3807a18501d3fd6be5b34231c4eb555R42-R49)
* Enforced non-zero amount checks at the start of hold, lock, and freeze creation functions in `HoldStorageWrapper`, `LockStorageWrapper`, and `ERC3643StorageWrapper`, reverting with the new errors if violated. [[1]](diffhunk://#diff-9d0d744e7cebc6a0e0957d1d99644b486542b317400fb6cd0b3014e811e10ef5R55-R56) [[2]](diffhunk://#diff-9d0d744e7cebc6a0e0957d1d99644b486542b317400fb6cd0b3014e811e10ef5R515-R523) [[3]](diffhunk://#diff-5afa74df0a0ad47409d4e2fc5f06826ec66a5770efb812bc17807b843912e40cR231-R232) [[4]](diffhunk://#diff-2ea5fc7e64996ffe53d049f2dbe1e3274df7ff48a1743bbb186d0514d990ea12R43-R44) [[5]](diffhunk://#diff-7a741b116a06ea131933f2a1986e2471cdee7282ac578e5967cc092db9d14cf3R139-R140)
* Updated the `ClearingOps` library to reuse the centralized zero-amount hold check.

**Registry and interface updates:**

* Registered the new custom errors in the facet registry data (`atsRegistry.data.ts`), ensuring correct ABI and selector mappings for `InvalidHoldAmount`, `InvalidLockAmount`, and `InvalidFreezeAmount` across all relevant facets. [[1]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R968-R972) [[2]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R1492-R1496) [[3]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R3843-R3847) [[4]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R6777-R6781) [[5]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R7157-R7161) [[6]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R7357-R7361) [[7]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R7601-R7605) [[8]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R8671-R8675) [[9]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R8893-R8897) [[10]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R10477-R10481) [[11]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R11787-R11791) [[12]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R12158-R12162) [[13]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R13108-R13112) [[14]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R13249-R13253) [[15]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R13389-R13393) [[16]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R13529-R13533) [[17]](diffhunk://#diff-4877815dbe43a7ccce353957f47744602330bcb60863d6b811363d6e886cd949R13669-R13673)

**Testing and documentation:**

* Added an integration test to verify that attempting to create a hold with zero amount reverts with `InvalidHoldAmount`, preventing ghost partition DoS attacks in `fullRedeemAtMaturity`.
* Updated interface and function documentation to clarify the semantics and rationale for rejecting zero-amount operations. [[1]](diffhunk://#diff-9d0d744e7cebc6a0e0957d1d99644b486542b317400fb6cd0b3014e811e10ef5R515-R523) [[2]](diffhunk://#diff-dc206dad649cb459f8a47335d1ea35d7b3807a18501d3fd6be5b34231c4eb555R42-R49) [[3]](diffhunk://#diff-addbb37935eda517cf0c6b44524b85c12c973cdb25628e59e0e0381dae8f718aR69-R75)

**Minor code cleanup:**

* Removed unused imports and simplified logic in the `Maturity` contract, now only redeeming partitions with non-zero balances. [[1]](diffhunk://#diff-c2454de09e3856738b6f56be23519a9bd25f8267813cfd47cf6ecfb8212a44e3L7-L13) [[2]](diffhunk://#diff-c2454de09e3856738b6f56be23519a9bd25f8267813cfd47cf6ecfb8212a44e3L48-R48)
* Updated facet registry generation timestamp to reflect the latest contract changes.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
