### PR TITLE
refactor(contracts): migrate 93 facets to Bytes4Builder pattern

### DIFF
--- a/.changeset/bytes4builder-facet-migration.md
+++ b/.changeset/bytes4builder-facet-migration.md
@@ -1,0 +1,12 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+Migrate 93 facets to Bytes4Builder pattern, eliminating manual bytes4[] array construction
+
+Extended `Bytes4Builder` library with overloads 7–12 (stack-safe without `viaIR`, capped at
+12 parameters). Migrated 93 `*Facet.sol` contracts from repetitive manual `bytes4[]`
+construction to `Bytes4Builder.build(...)`, reducing boilerplate and improving consistency.
+
+Two facets remain with the manual pattern due to Solidity stack limits without `viaIR`:
+`LoansPortfolioFacet` (20 selectors) and `AmortizationFacetBase` (15 selectors).

--- a/packages/ats/contracts/contracts/facets/accessControl/AccessControlFacet.sol
+++ b/packages/ats/contracts/contracts/facets/accessControl/AccessControlFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IAccessControl } from "./IAccessControl.sol";
 import { AccessControl } from "./AccessControl.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ACCESS_CONTROL_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,24 +24,23 @@ contract AccessControlFacet is AccessControl, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](9);
-        staticFunctionSelectors_[selectorIndex++] = this.grantRole.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.revokeRole.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.renounceRole.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.applyRoles.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRoleCountFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRolesFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRoleMemberCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRoleMembers.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.hasRole.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.grantRole.selector,
+                this.revokeRole.selector,
+                this.renounceRole.selector,
+                this.applyRoles.selector,
+                this.getRoleCountFor.selector,
+                this.getRolesFor.selector,
+                this.getRoleMemberCount.selector,
+                this.getRoleMembers.selector,
+                this.hasRole.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IAccessControl).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IAccessControl).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalancesFacet.sol
+++ b/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalancesFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IAdjustBalances } from "./IAdjustBalances.sol";
 import { AdjustBalances } from "./AdjustBalances.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_ADJUSTMENTS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,27 +21,22 @@ contract AdjustBalancesFacet is AdjustBalances, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 8;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.triggerAndSyncAll.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getScheduledBalanceAdjustments.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getPendingBalanceAdjustmentCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getBalanceAdjustmentCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getScheduledBalanceAdjustment.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.cancelScheduledBalanceAdjustment.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setScheduledBalanceAdjustment.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.adjustBalances.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.adjustBalances.selector,
+                this.setScheduledBalanceAdjustment.selector,
+                this.cancelScheduledBalanceAdjustment.selector,
+                this.getScheduledBalanceAdjustment.selector,
+                this.getBalanceAdjustmentCount.selector,
+                this.getPendingBalanceAdjustmentCount.selector,
+                this.getScheduledBalanceAdjustments.selector,
+                this.triggerAndSyncAll.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IAdjustBalances).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IAdjustBalances).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/allowance/AllowanceFacet.sol
+++ b/packages/ats/contracts/contracts/facets/allowance/AllowanceFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IAllowance } from "./IAllowance.sol";
 import { Allowance } from "./Allowance.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ALLOWANCE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,20 +20,18 @@ contract AllowanceFacet is Allowance, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.allowance.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.decreaseAllowance.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.increaseAllowance.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.approve.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.approve.selector,
+                this.increaseAllowance.selector,
+                this.decreaseAllowance.selector,
+                this.allowance.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IAllowance).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IAllowance).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/balanceTracker/BalanceTrackerFacet.sol
+++ b/packages/ats/contracts/contracts/facets/balanceTracker/BalanceTrackerFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBalanceTracker } from "./IBalanceTracker.sol";
 import { BalanceTracker } from "./BalanceTracker.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_TRACKER_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -29,22 +30,16 @@ contract BalanceTrackerFacet is BalanceTracker, IStaticFunctionSelectors {
      * @return staticFunctionSelectors_ Array containing selectors for `balanceOf`,
      *         `totalSupply`, and `getTotalBalanceFor`.
      */
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalBalanceFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.totalSupply.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.balanceOf.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(this.balanceOf.selector, this.totalSupply.selector, this.getTotalBalanceFor.selector);
     }
 
     /**
      * @notice Returns the interface IDs supported by this facet for ERC-165 introspection.
      * @return staticInterfaceIds_ Array containing the `IBalanceTracker` interface ID.
      */
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IBalanceTracker).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBalanceTracker).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/balanceTrackerAdjusted/BalanceTrackerAdjustedFacet.sol
+++ b/packages/ats/contracts/contracts/facets/balanceTrackerAdjusted/BalanceTrackerAdjustedFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBalanceTrackerAdjusted } from "./IBalanceTrackerAdjusted.sol";
 import { BalanceTrackerAdjusted } from "./BalanceTrackerAdjusted.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_TRACKER_ADJUSTED_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract BalanceTrackerAdjustedFacet is BalanceTrackerAdjusted, IStaticFunctionS
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.balanceOfAt.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.balanceOfAt.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBalanceTrackerAdjusted).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBalanceTrackerAdjusted).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/balanceTrackerAtSnapshot/BalanceTrackerAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/balanceTrackerAtSnapshot/BalanceTrackerAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBalanceTrackerAtSnapshot } from "./IBalanceTrackerAtSnapshot.sol";
 import { BalanceTrackerAtSnapshot } from "./BalanceTrackerAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_TRACKER_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,22 +23,17 @@ contract BalanceTrackerAtSnapshotFacet is BalanceTrackerAtSnapshot, IStaticFunct
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.totalSupplyAtSnapshot.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.balancesOfAtSnapshot.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.balanceOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.balanceOfAtSnapshot.selector,
+                this.balancesOfAtSnapshot.selector,
+                this.totalSupplyAtSnapshot.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBalanceTrackerAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBalanceTrackerAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/balanceTrackerAtSnapshotByPartition/BalanceTrackerAtSnapshotByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/balanceTrackerAtSnapshotByPartition/BalanceTrackerAtSnapshotByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBalanceTrackerAtSnapshotByPartition } from "./IBalanceTrackerAtSnapshotByPartition.sol";
 import { BalanceTrackerAtSnapshotByPartition } from "./BalanceTrackerAtSnapshotByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_TRACKER_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,21 +24,16 @@ contract BalanceTrackerAtSnapshotByPartitionFacet is BalanceTrackerAtSnapshotByP
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.totalSupplyAtSnapshotByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.balanceOfAtSnapshotByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.balanceOfAtSnapshotByPartition.selector,
+                this.totalSupplyAtSnapshotByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBalanceTrackerAtSnapshotByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBalanceTrackerAtSnapshotByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/balanceTrackerByPartition/BalanceTrackerByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/balanceTrackerByPartition/BalanceTrackerByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBalanceTrackerByPartition } from "./IBalanceTrackerByPartition.sol";
 import { BalanceTrackerByPartition } from "./BalanceTrackerByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BALANCE_TRACKER_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,22 +24,17 @@ contract BalanceTrackerByPartitionFacet is BalanceTrackerByPartition, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalBalanceForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.totalSupplyByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.balanceOfByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.balanceOfByPartition.selector,
+                this.totalSupplyByPartition.selector,
+                this.getTotalBalanceForByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBalanceTrackerByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBalanceTrackerByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchBurn/BatchBurnFacet.sol
+++ b/packages/ats/contracts/contracts/facets/batchBurn/BatchBurnFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBatchBurn } from "./IBatchBurn.sol";
 import { BatchBurn } from "./BatchBurn.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BATCH_BURN_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract BatchBurnFacet is BatchBurn, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.batchBurn.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.batchBurn.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBatchBurn).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBatchBurn).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchController/BatchControllerFacet.sol
+++ b/packages/ats/contracts/contracts/facets/batchController/BatchControllerFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBatchController } from "./IBatchController.sol";
 import { BatchController } from "./BatchController.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BATCH_CONTROLLER_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,20 +20,12 @@ contract BatchControllerFacet is BatchController, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.batchForcedTransfer.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.batchForcedTransfer.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBatchController).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBatchController).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchFreeze/BatchFreezeFacet.sol
+++ b/packages/ats/contracts/contracts/facets/batchFreeze/BatchFreezeFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBatchFreeze } from "./IBatchFreeze.sol";
 import { BatchFreeze } from "./BatchFreeze.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BATCH_FREEZE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,22 +22,17 @@ contract BatchFreezeFacet is BatchFreeze, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.batchUnfreezePartialTokens.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.batchFreezePartialTokens.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.batchSetAddressFrozen.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.batchSetAddressFrozen.selector,
+                this.batchFreezePartialTokens.selector,
+                this.batchUnfreezePartialTokens.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBatchFreeze).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBatchFreeze).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchMint/BatchMintFacet.sol
+++ b/packages/ats/contracts/contracts/facets/batchMint/BatchMintFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBatchMint } from "./IBatchMint.sol";
 import { BatchMint } from "./BatchMint.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BATCH_MINT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,20 +24,12 @@ contract BatchMintFacet is BatchMint, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.batchMint.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.batchMint.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBatchMint).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBatchMint).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransferFacet.sol
+++ b/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransferFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBatchTransfer } from "./IBatchTransfer.sol";
 import { BatchTransfer } from "./BatchTransfer.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BATCH_TRANSFER_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract BatchTransferFacet is BatchTransfer, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.batchTransfer.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.batchTransfer.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBatchTransfer).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBatchTransfer).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/burn/BurnFacet.sol
+++ b/packages/ats/contracts/contracts/facets/burn/BurnFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBurn } from "./IBurn.sol";
 import { Burn } from "./Burn.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BURN_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,19 +23,12 @@ contract BurnFacet is Burn, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.redeemFrom.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.redeem.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.burn.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.burn.selector, this.redeem.selector, this.redeemFrom.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IBurn).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBurn).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/burnByPartition/BurnByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/burnByPartition/BurnByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IBurnByPartition } from "./IBurnByPartition.sol";
 import { BurnByPartition } from "./BurnByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _BURN_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,20 +25,12 @@ contract BurnByPartitionFacet is BurnByPartition, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.redeemByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.redeemByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IBurnByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBurnByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/cap/CapFacet.sol
+++ b/packages/ats/contracts/contracts/facets/cap/CapFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICap } from "./ICap.sol";
 import { Cap } from "./Cap.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CAP_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,18 +23,12 @@ contract CapFacet is Cap, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeCap.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setMaxSupply.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getMaxSupply.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.initializeCap.selector, this.setMaxSupply.selector, this.getMaxSupply.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ICap).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICap).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/capByPartition/CapByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/capByPartition/CapByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICapByPartition } from "./ICapByPartition.sol";
 import { CapByPartition } from "./CapByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CAP_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,21 +23,12 @@ contract CapByPartitionFacet is CapByPartition, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getMaxSupplyByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setMaxSupplyByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.setMaxSupplyByPartition.selector, this.getMaxSupplyByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ICapByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICapByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/clearing/ClearingFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearing/ClearingFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearing } from "./IClearing.sol";
 import { Clearing } from "./Clearing.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CLEARING_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,25 +23,20 @@ contract ClearingFacet is Clearing, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 6;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingThirdParty.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearedAmountFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isClearingActivated.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.deactivateClearing.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.activateClearing.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.initializeClearing.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeClearing.selector,
+                this.activateClearing.selector,
+                this.deactivateClearing.selector,
+                this.isClearingActivated.selector,
+                this.getClearedAmountFor.selector,
+                this.getClearingThirdParty.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IClearing).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IClearing).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/clearingAtSnapshot/ClearingAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearingAtSnapshot/ClearingAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingAtSnapshot } from "./IClearingAtSnapshot.sol";
 import { ClearingAtSnapshot } from "./ClearingAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CLEARING_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,20 +22,12 @@ contract ClearingAtSnapshotFacet is ClearingAtSnapshot, IStaticFunctionSelectors
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.clearedBalanceOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.clearedBalanceOfAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IClearingAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IClearingAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/clearingAtSnapshotByPartition/ClearingAtSnapshotByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearingAtSnapshotByPartition/ClearingAtSnapshotByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingAtSnapshotByPartition } from "./IClearingAtSnapshotByPartition.sol";
 import { ClearingAtSnapshotByPartition } from "./ClearingAtSnapshotByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CLEARING_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,20 +24,12 @@ contract ClearingAtSnapshotByPartitionFacet is ClearingAtSnapshotByPartition, IS
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.clearedBalanceOfAtSnapshotByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.clearedBalanceOfAtSnapshotByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IClearingAtSnapshotByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IClearingAtSnapshotByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingByPartition } from "./IClearingByPartition.sol";
 import { ClearingByPartition } from "./ClearingByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CLEARING_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,31 +22,26 @@ contract ClearingByPartitionFacet is ClearingByPartition, IStaticFunctionSelecto
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 12;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingsIdForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingCountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearedAmountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingTransferForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.clearingTransferFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.clearingTransferByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingRedeemForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.clearingRedeemFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.clearingRedeemByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.reclaimClearingOperationByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.cancelClearingOperationByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.approveClearingOperationByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.approveClearingOperationByPartition.selector,
+                this.cancelClearingOperationByPartition.selector,
+                this.reclaimClearingOperationByPartition.selector,
+                this.clearingRedeemByPartition.selector,
+                this.clearingRedeemFromByPartition.selector,
+                this.getClearingRedeemForByPartition.selector,
+                this.clearingTransferByPartition.selector,
+                this.clearingTransferFromByPartition.selector,
+                this.getClearingTransferForByPartition.selector,
+                this.getClearedAmountForByPartition.selector,
+                this.getClearingCountForByPartition.selector,
+                this.getClearingsIdForByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IClearingByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IClearingByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/clearingHoldByPartition/ClearingHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/clearingHoldByPartition/ClearingHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IClearingHoldByPartition } from "./IClearingHoldByPartition.sol";
 import { ClearingHoldByPartition } from "./ClearingHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CLEARING_HOLDBYPARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,22 +22,17 @@ contract ClearingHoldByPartitionFacet is ClearingHoldByPartition, IStaticFunctio
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.clearingCreateHoldByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.clearingCreateHoldFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getClearingCreateHoldForByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getClearingCreateHoldForByPartition.selector,
+                this.clearingCreateHoldFromByPartition.selector,
+                this.clearingCreateHoldByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IClearingHoldByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IClearingHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/compliance/ComplianceFacet.sol
+++ b/packages/ats/contracts/contracts/facets/compliance/ComplianceFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IComplianceFacet } from "./IComplianceFacet.sol";
 import { Compliance } from "./Compliance.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _COMPLIANCE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,20 +20,18 @@ contract ComplianceFacet is Compliance, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.compliance.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setCompliance.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.canTransferFrom.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.canTransfer.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.canTransfer.selector,
+                this.canTransferFrom.selector,
+                this.setCompliance.selector,
+                this.compliance.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IComplianceFacet).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IComplianceFacet).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/complianceByPartition/ComplianceByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/complianceByPartition/ComplianceByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IComplianceByPartition } from "./IComplianceByPartition.sol";
 import { ComplianceByPartition } from "./ComplianceByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _COMPLIANCE_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,21 +21,12 @@ contract ComplianceByPartitionFacet is ComplianceByPartition, IStaticFunctionSel
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.canRedeemByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.canTransferByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.canTransferByPartition.selector, this.canRedeemByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IComplianceByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IComplianceByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/controlList/ControlListFacet.sol
+++ b/packages/ats/contracts/contracts/facets/controlList/ControlListFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IControlList } from "./IControlList.sol";
 import { ControlList } from "./ControlList.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CONTROL_LIST_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,22 +23,21 @@ contract ControlListFacet is ControlList, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addToControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeFromControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isInControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getControlListType.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getControlListCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getControlListMembers.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeControlList.selector,
+                this.addToControlList.selector,
+                this.removeFromControlList.selector,
+                this.isInControlList.selector,
+                this.getControlListType.selector,
+                this.getControlListCount.selector,
+                this.getControlListMembers.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IControlList).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IControlList).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/controller/ControllerFacet.sol
+++ b/packages/ats/contracts/contracts/facets/controller/ControllerFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IController } from "./IController.sol";
 import { Controller } from "./Controller.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CONTROLLER_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,25 +21,23 @@ contract ControllerFacet is Controller, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 9;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.isAgent.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.removeAgent.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.addAgent.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.forcedTransfer.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.finalizeControllable.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.controllerRedeem.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.controllerTransfer.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isControllable.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.initializeController.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeController.selector,
+                this.isControllable.selector,
+                this.controllerTransfer.selector,
+                this.controllerRedeem.selector,
+                this.finalizeControllable.selector,
+                this.forcedTransfer.selector,
+                this.addAgent.selector,
+                this.removeAgent.selector,
+                this.isAgent.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IController).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IController).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/controllerByPartition/ControllerByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IControllerByPartition } from "./IControllerByPartition.sol";
 import { ControllerByPartition } from "./ControllerByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CONTROLLER_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,21 +23,13 @@ contract ControllerByPartitionFacet is ControllerByPartition, IStaticFunctionSel
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.controllerTransferByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.controllerRedeemByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(this.controllerRedeemByPartition.selector, this.controllerTransferByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IControllerByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IControllerByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/controllerHoldByPartition/ControllerHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/controllerHoldByPartition/ControllerHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IControllerHoldByPartition } from "./IControllerHoldByPartition.sol";
 import { ControllerHoldByPartition } from "./ControllerHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CONTROLLER_HOLD_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,17 +24,12 @@ contract ControllerHoldByPartitionFacet is ControllerHoldByPartition, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.controllerCreateHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.controllerCreateHoldByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IControllerHoldByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IControllerHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/core/CoreFacet.sol
+++ b/packages/ats/contracts/contracts/facets/core/CoreFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICore } from "./ICore.sol";
 import { Core } from "./Core.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CORE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -16,23 +17,21 @@ contract CoreFacet is Core, IStaticFunctionSelectors {
         staticResolverKey_ = _CORE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 8;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.version.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setSymbol.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setName.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getERC20Metadata.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.symbol.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.name.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.decimals.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.initializeCore.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeCore.selector,
+                this.decimals.selector,
+                this.name.selector,
+                this.symbol.selector,
+                this.getERC20Metadata.selector,
+                this.setName.selector,
+                this.setSymbol.selector,
+                this.version.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ICore).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICore).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/coreAdjusted/CoreAdjustedFacet.sol
+++ b/packages/ats/contracts/contracts/facets/coreAdjusted/CoreAdjustedFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICoreAdjusted } from "./ICoreAdjusted.sol";
 import { CoreAdjusted } from "./CoreAdjusted.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CORE_ADJUSTED_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -29,17 +30,15 @@ contract CoreAdjustedFacet is CoreAdjusted, IStaticFunctionSelectors {
      * @notice Returns the list of function selectors provided by this facet.
      * @return staticFunctionSelectors_ Array containing the `decimalsAt` selector.
      */
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](1);
-        staticFunctionSelectors_[0] = this.decimalsAt.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.decimalsAt.selector);
     }
 
     /**
      * @notice Returns the list of interface identifiers supported by this facet.
      * @return staticInterfaceIds_ Array containing the `ICoreAdjusted` interface ID.
      */
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ICoreAdjusted).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICoreAdjusted).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/coreAtSnapshot/CoreAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/coreAtSnapshot/CoreAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICoreAtSnapshot } from "./ICoreAtSnapshot.sol";
 import { CoreAtSnapshot } from "./CoreAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CORE_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,20 +22,12 @@ contract CoreAtSnapshotFacet is CoreAtSnapshot, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.decimalsAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.decimalsAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ICoreAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICoreAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/corporateActions/CorporateActionsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/corporateActions/CorporateActionsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICorporateActions } from "./ICorporateActions.sol";
 import { CorporateActions } from "./CorporateActions.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _CORPORATE_ACTIONS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,23 +24,22 @@ contract CorporateActionsFacet is CorporateActions, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateAction.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActionCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActionIds.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActionCountByType.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActionIdsByType.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.actionContentHashExists.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActions.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getCorporateActionsByType.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getCorporateAction.selector,
+                this.getCorporateActionCount.selector,
+                this.getCorporateActionIds.selector,
+                this.getCorporateActionCountByType.selector,
+                this.getCorporateActionIdsByType.selector,
+                this.actionContentHashExists.selector,
+                this.getCorporateActions.selector,
+                this.getCorporateActionsByType.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ICorporateActions).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICorporateActions).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/coupon/CouponFacet.sol
+++ b/packages/ats/contracts/contracts/facets/coupon/CouponFacet.sol
@@ -5,6 +5,7 @@ import { Coupon } from "./Coupon.sol";
 import { ICoupon } from "./ICoupon.sol";
 import { _COUPON_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 
 /**
  * @title CouponFacet
@@ -28,25 +29,20 @@ contract CouponFacet is Coupon, IStaticFunctionSelectors {
     ///      block; the resulting array reads in declaration order (`setCoupon`,
     ///      `cancelCoupon`, `getCoupon`, `getCouponFor`, `getCouponAmountFor`,
     ///      `getCouponCount`).
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 6;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponAmountFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCoupon.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.cancelCoupon.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setCoupon.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setCoupon.selector,
+                this.cancelCoupon.selector,
+                this.getCoupon.selector,
+                this.getCouponFor.selector,
+                this.getCouponAmountFor.selector,
+                this.getCouponCount.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorsIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorsIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorsIndex] = type(ICoupon).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICoupon).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/couponListing/CouponListingFacet.sol
+++ b/packages/ats/contracts/contracts/facets/couponListing/CouponListingFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICouponListing } from "./ICouponListing.sol";
 import { CouponListing } from "./CouponListing.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _COUPON_LISTING_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,24 +25,19 @@ contract CouponListingFacet is CouponListing, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getScheduledCouponListing.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.scheduledCouponListingCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponsOrderedListTotal.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponsOrderedList.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponFromOrderedListAt.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getCouponFromOrderedListAt.selector,
+                this.getCouponsOrderedList.selector,
+                this.getCouponsOrderedListTotal.selector,
+                this.scheduledCouponListingCount.selector,
+                this.getScheduledCouponListing.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ICouponListing).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICouponListing).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHoldersFacet.sol
+++ b/packages/ats/contracts/contracts/facets/couponSecurityHolders/CouponSecurityHoldersFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ICouponSecurityHolders } from "./ICouponSecurityHolders.sol";
 import { CouponSecurityHolders } from "./CouponSecurityHolders.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _COUPON_SECURITY_HOLDERS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -25,22 +26,17 @@ contract CouponSecurityHoldersFacet is CouponSecurityHolders, IStaticFunctionSel
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalCouponHolders.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponsFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getCouponHolders.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getCouponHolders.selector,
+                this.getCouponsFor.selector,
+                this.getTotalCouponHolders.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ICouponSecurityHolders).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ICouponSecurityHolders).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/deactivate/DeactivateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/deactivate/DeactivateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IDeactivate } from "./IDeactivate.sol";
 import { Deactivate } from "./Deactivate.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _DEACTIVATE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,18 +23,12 @@ contract DeactivateFacet is Deactivate, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.deactivate.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isDeactivated.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.isDeactivated.selector, this.deactivate.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IDeactivate).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IDeactivate).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/dividend/DividendFacet.sol
+++ b/packages/ats/contracts/contracts/facets/dividend/DividendFacet.sol
@@ -5,6 +5,7 @@ import { Dividend } from "./Dividend.sol";
 import { IDividend } from "./IDividend.sol";
 import { _DIVIDEND_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 
 /**
  * @title DividendFacet
@@ -25,25 +26,20 @@ contract DividendFacet is Dividend, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    /// @dev Selectors are written in reverse via `--selectorIndex` inside an `unchecked` block;
-    ///      the resulting array reads in declaration order (`setDividend`, `cancelDividend`,
-    ///      `getDividend`, `getDividendFor`, `getDividendAmountFor`, `getDividendsCount`).
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 6;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getDividendsCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getDividendAmountFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getDividendFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getDividend.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.cancelDividend.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setDividend.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setDividend.selector,
+                this.cancelDividend.selector,
+                this.getDividend.selector,
+                this.getDividendFor.selector,
+                this.getDividendAmountFor.selector,
+                this.getDividendsCount.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IDividend).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IDividend).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/dividendSecurityHolders/DividendSecurityHoldersFacet.sol
+++ b/packages/ats/contracts/contracts/facets/dividendSecurityHolders/DividendSecurityHoldersFacet.sol
@@ -5,6 +5,7 @@ import { DividendSecurityHolders } from "./DividendSecurityHolders.sol";
 import { IDividendSecurityHolders } from "./IDividendSecurityHolders.sol";
 import { _DIVIDEND_SECURITY_HOLDERS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 
 /**
  * @title DividendSecurityHoldersFacet
@@ -23,21 +24,12 @@ contract DividendSecurityHoldersFacet is DividendSecurityHolders, IStaticFunctio
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    /// @dev Selectors are written in reverse via `--selectorIndex` inside an `unchecked` block;
-    ///      the resulting array reads in declaration order (`getDividendHolders` first, then
-    ///      `getTotalDividendHolders`).
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalDividendHolders.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getDividendHolders.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getDividendHolders.selector, this.getTotalDividendHolders.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IDividendSecurityHolders).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IDividendSecurityHolders).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/documentation/DocumentationFacet.sol
+++ b/packages/ats/contracts/contracts/facets/documentation/DocumentationFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IDocumentation } from "./IDocumentation.sol";
 import { Documentation } from "./Documentation.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _DOCUMENTATION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -32,15 +33,14 @@ contract DocumentationFacet is Documentation, IStaticFunctionSelectors {
      * @return staticFunctionSelectors_ Array containing selectors for `getDocument`,
      *         `setDocument`, `removeDocument`, and `getAllDocuments`.
      */
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getAllDocuments.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.removeDocument.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setDocument.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getDocument.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.getDocument.selector,
+                this.setDocument.selector,
+                this.removeDocument.selector,
+                this.getAllDocuments.selector
+            );
     }
 
     /**
@@ -48,8 +48,7 @@ contract DocumentationFacet is Documentation, IStaticFunctionSelectors {
      *         introspection.
      * @return staticInterfaceIds_ Array containing the `IDocumentation` interface ID.
      */
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IDocumentation).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IDocumentation).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/eip712/EIP712Facet.sol
+++ b/packages/ats/contracts/contracts/facets/eip712/EIP712Facet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IEIP712 } from "./IEIP712.sol";
 import { EIP712 } from "./EIP712.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _EIP712_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,20 +21,12 @@ contract EIP712Facet is EIP712, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.DOMAIN_SEPARATOR.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.DOMAIN_SEPARATOR.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IEIP712).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IEIP712).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/externalControlListManagement/ExternalControlListManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/externalControlListManagement/ExternalControlListManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IExternalControlListManagement } from "./IExternalControlListManagement.sol";
 import { ExternalControlListManagement } from "./ExternalControlListManagement.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _EXTERNAL_CONTROL_LIST_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,22 +24,21 @@ contract ExternalControlListManagementFacet is ExternalControlListManagement, IS
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeExternalControlLists.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateExternalControlLists.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addExternalControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeExternalControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isExternalControlList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalControlListsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalControlListsMembers.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeExternalControlLists.selector,
+                this.updateExternalControlLists.selector,
+                this.addExternalControlList.selector,
+                this.removeExternalControlList.selector,
+                this.isExternalControlList.selector,
+                this.getExternalControlListsCount.selector,
+                this.getExternalControlListsMembers.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IExternalControlListManagement).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IExternalControlListManagement).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/externalKycListManagement/ExternalKycListManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/externalKycListManagement/ExternalKycListManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IExternalKycListManagement } from "./IExternalKycListManagement.sol";
 import { ExternalKycListManagement } from "./ExternalKycListManagement.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _EXTERNAL_KYC_LIST_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,23 +24,22 @@ contract ExternalKycListManagementFacet is ExternalKycListManagement, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeExternalKycLists.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateExternalKycLists.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addExternalKycList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeExternalKycList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isExternalKycList.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isExternallyGranted.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalKycListsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalKycListsMembers.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeExternalKycLists.selector,
+                this.updateExternalKycLists.selector,
+                this.addExternalKycList.selector,
+                this.removeExternalKycList.selector,
+                this.isExternalKycList.selector,
+                this.isExternallyGranted.selector,
+                this.getExternalKycListsCount.selector,
+                this.getExternalKycListsMembers.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IExternalKycListManagement).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IExternalKycListManagement).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/externalPauseManagement/ExternalPauseManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/externalPauseManagement/ExternalPauseManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IExternalPauseManagement } from "./IExternalPauseManagement.sol";
 import { ExternalPauseManagement } from "./ExternalPauseManagement.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _EXTERNAL_PAUSE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,22 +24,21 @@ contract ExternalPauseManagementFacet is ExternalPauseManagement, IStaticFunctio
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeExternalPauses.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateExternalPauses.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addExternalPause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeExternalPause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isExternalPause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalPausesCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getExternalPausesMembers.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeExternalPauses.selector,
+                this.updateExternalPauses.selector,
+                this.addExternalPause.selector,
+                this.removeExternalPause.selector,
+                this.isExternalPause.selector,
+                this.getExternalPausesCount.selector,
+                this.getExternalPausesMembers.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IExternalPauseManagement).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IExternalPauseManagement).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/freeze/FreezeFacet.sol
+++ b/packages/ats/contracts/contracts/facets/freeze/FreezeFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IFreeze } from "./IFreeze.sol";
 import { Freeze } from "./Freeze.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _FREEZE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,24 +23,19 @@ contract FreezeFacet is Freeze, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.isFrozen.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getFrozenTokens.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setAddressFrozen.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.unfreezePartialTokens.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.freezePartialTokens.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.freezePartialTokens.selector,
+                this.unfreezePartialTokens.selector,
+                this.setAddressFrozen.selector,
+                this.getFrozenTokens.selector,
+                this.isFrozen.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IFreeze).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IFreeze).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/freezeAtSnapshot/FreezeAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/freezeAtSnapshot/FreezeAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IFreezeAtSnapshot } from "./IFreezeAtSnapshot.sol";
 import { FreezeAtSnapshot } from "./FreezeAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _FREEZE_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,20 +22,12 @@ contract FreezeAtSnapshotFacet is FreezeAtSnapshot, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.frozenBalanceOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.frozenBalanceOfAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IFreezeAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IFreezeAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/freezeAtSnapshotByPartition/FreezeAtSnapshotByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/freezeAtSnapshotByPartition/FreezeAtSnapshotByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IFreezeAtSnapshotByPartition } from "./IFreezeAtSnapshotByPartition.sol";
 import { FreezeAtSnapshotByPartition } from "./FreezeAtSnapshotByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _FREEZE_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract FreezeAtSnapshotByPartitionFacet is FreezeAtSnapshotByPartition, IStati
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.frozenBalanceOfAtSnapshotByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.frozenBalanceOfAtSnapshotByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IFreezeAtSnapshotByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IFreezeAtSnapshotByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/hold/HoldFacet.sol
+++ b/packages/ats/contracts/contracts/facets/hold/HoldFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IHoldFacet } from "./IHoldFacet.sol";
 import { Hold } from "./Hold.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _HOLD_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,18 +20,12 @@ contract HoldFacet is Hold, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getHoldThirdParty.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getHeldAmountFor.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getHeldAmountFor.selector, this.getHoldThirdParty.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IHoldFacet).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IHoldFacet).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/holdAtSnapshot/HoldAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IHoldAtSnapshot } from "./IHoldAtSnapshot.sol";
 import { HoldAtSnapshot } from "./HoldAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _HOLD_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract HoldAtSnapshotFacet is HoldAtSnapshot, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.heldBalanceOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.heldBalanceOfAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IHoldAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IHoldAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/holdAtSnapshotByPartition/HoldAtSnapshotByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/holdAtSnapshotByPartition/HoldAtSnapshotByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IHoldAtSnapshotByPartition } from "./IHoldAtSnapshotByPartition.sol";
 import { HoldAtSnapshotByPartition } from "./HoldAtSnapshotByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _HOLD_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,20 +24,12 @@ contract HoldAtSnapshotByPartitionFacet is HoldAtSnapshotByPartition, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.heldBalanceOfAtSnapshotByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.heldBalanceOfAtSnapshotByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IHoldAtSnapshotByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IHoldAtSnapshotByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/holdByPartition/HoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/holdByPartition/HoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IHoldByPartition } from "./IHoldByPartition.sol";
 import { HoldByPartition } from "./HoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _HOLD_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -25,25 +26,23 @@ contract HoldByPartitionFacet is HoldByPartition, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 9;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getHoldForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getHoldsIdForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getHoldCountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getHeldAmountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.reclaimHoldByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.releaseHoldByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.executeHoldByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.createHoldFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.createHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.createHoldByPartition.selector,
+                this.createHoldFromByPartition.selector,
+                this.executeHoldByPartition.selector,
+                this.releaseHoldByPartition.selector,
+                this.reclaimHoldByPartition.selector,
+                this.getHeldAmountForByPartition.selector,
+                this.getHoldCountForByPartition.selector,
+                this.getHoldsIdForByPartition.selector,
+                this.getHoldForByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IHoldByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/identity/IdentityFacet.sol
+++ b/packages/ats/contracts/contracts/facets/identity/IdentityFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IIdentity } from "./IIdentity.sol";
 import { Identity } from "./Identity.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _IDENTITY_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,18 @@ contract IdentityFacet is Identity, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.onchainID.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.identityRegistry.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setIdentityRegistry.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setOnchainID.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setOnchainID.selector,
+                this.setIdentityRegistry.selector,
+                this.identityRegistry.selector,
+                this.onchainID.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IIdentity).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IIdentity).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/ERC1410ManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IERC1410Management } from "./IERC1410Management.sol";
 import { ERC1410Management } from "./ERC1410Management.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ERC1410_MANAGEMENT_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract ERC1410ManagementFacet is ERC1410Management, IStaticFunctionSelectors {
@@ -11,19 +12,11 @@ contract ERC1410ManagementFacet is ERC1410Management, IStaticFunctionSelectors {
         staticResolverKey_ = _ERC1410_MANAGEMENT_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC1410.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.initialize_ERC1410.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IERC1410Management).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IERC1410Management).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC20Permit/ERC20PermitFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC20Permit/ERC20PermitFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IERC20Permit } from "./IERC20Permit.sol";
 import { ERC20Permit } from "./ERC20Permit.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ERC20PERMIT_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract ERC20PermitFacet is ERC20Permit, IStaticFunctionSelectors {
@@ -11,19 +12,11 @@ contract ERC20PermitFacet is ERC20Permit, IStaticFunctionSelectors {
         staticResolverKey_ = _ERC20PERMIT_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.permit.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.permit.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IERC20Permit).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IERC20Permit).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC20Votes/ERC20VotesFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC20Votes/ERC20VotesFacet.sol
@@ -7,6 +7,7 @@ import { IERC6372 } from "@openzeppelin/contracts/interfaces/IERC6372.sol";
 import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import { ERC20Votes } from "./ERC20Votes.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ERC20VOTES_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract ERC20VotesFacet is ERC20Votes, IStaticFunctionSelectors {
@@ -14,28 +15,30 @@ contract ERC20VotesFacet is ERC20Votes, IStaticFunctionSelectors {
         staticResolverKey_ = _ERC20VOTES_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](11);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ERC20Votes.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.delegate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.clock.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.CLOCK_MODE.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getVotes.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getPastVotes.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getPastTotalSupply.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.delegates.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.checkpoints.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.numCheckpoints.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isActivated.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ERC20Votes.selector,
+                this.delegate.selector,
+                this.clock.selector,
+                this.CLOCK_MODE.selector,
+                this.getVotes.selector,
+                this.getPastVotes.selector,
+                this.getPastTotalSupply.selector,
+                this.delegates.selector,
+                this.checkpoints.selector,
+                this.numCheckpoints.selector,
+                this.isActivated.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](4);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IERC20Votes).interfaceId;
-        staticInterfaceIds_[selectorsIndex++] = type(IERC5805).interfaceId;
-        staticInterfaceIds_[selectorsIndex++] = type(IERC6372).interfaceId;
-        staticInterfaceIds_[selectorsIndex++] = type(IVotes).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                type(IERC20Votes).interfaceId,
+                type(IERC5805).interfaceId,
+                type(IERC6372).interfaceId,
+                type(IVotes).interfaceId
+            );
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC3643/ERC3643ManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC3643/ERC3643ManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IERC3643Management } from "./IERC3643Management.sol";
 import { ERC3643Management } from "./ERC3643Management.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _ERC3643_MANAGEMENT_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 contract ERC3643ManagementFacet is ERC3643Management, IStaticFunctionSelectors {
@@ -11,16 +12,11 @@ contract ERC3643ManagementFacet is ERC3643Management, IStaticFunctionSelectors {
         staticResolverKey_ = _ERC3643_MANAGEMENT_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC3643.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.initialize_ERC3643.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IERC3643Management).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IERC3643Management).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/operatorClearingHoldByPartition/OperatorClearingHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/operatorClearingHoldByPartition/OperatorClearingHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IOperatorClearingHoldByPartition } from "./IOperatorClearingHoldByPartition.sol";
 import { OperatorClearingHoldByPartition } from "./OperatorClearingHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _OPERATOR_CLEARING_HOLDBYPARTITION_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 /**
@@ -19,20 +20,12 @@ contract OperatorClearingHoldByPartitionFacet is OperatorClearingHoldByPartition
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.operatorClearingCreateHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.operatorClearingCreateHoldByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IOperatorClearingHoldByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IOperatorClearingHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/kyc/KycFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/kyc/KycFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IKyc } from "./IKyc.sol";
 import { Kyc } from "./Kyc.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _KYC_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 contract KycFacet is Kyc, IStaticFunctionSelectors {
@@ -11,24 +12,23 @@ contract KycFacet is Kyc, IStaticFunctionSelectors {
         staticResolverKey_ = _KYC_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](10);
-        staticFunctionSelectors_[selectorIndex++] = this.initializeInternalKyc.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.activateInternalKyc.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.deactivateInternalKyc.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.grantKyc.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.revokeKyc.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getKycFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getKycStatusFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getKycAccountsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getKycAccountsData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isInternalKycActivated.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initializeInternalKyc.selector,
+                this.activateInternalKyc.selector,
+                this.deactivateInternalKyc.selector,
+                this.grantKyc.selector,
+                this.revokeKyc.selector,
+                this.getKycFor.selector,
+                this.getKycStatusFor.selector,
+                this.getKycAccountsCount.selector,
+                this.getKycAccountsData.selector,
+                this.isInternalKycActivated.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IKyc).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IKyc).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/lock/LockFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/lock/LockFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { Lock } from "./Lock.sol";
 import { ILock } from "./ILock.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _LOCK_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 /**
@@ -25,23 +26,22 @@ contract LockFacet is Lock, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.forceReleaseByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLockByPartition.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.lock.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.release.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLockedAmountFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLockCountFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLocksIdFor.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLockFor.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.forceReleaseByPartition.selector,
+                this.getLockByPartition.selector,
+                this.lock.selector,
+                this.release.selector,
+                this.getLockedAmountFor.selector,
+                this.getLockCountFor.selector,
+                this.getLocksIdFor.selector,
+                this.getLockFor.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ILock).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ILock).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/protectedPartition/ProtectedPartitionsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/protectedPartition/ProtectedPartitionsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProtectedPartitions } from "./IProtectedPartitions.sol";
 import { ProtectedPartitions } from "./ProtectedPartitions.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROTECTED_PARTITIONS_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 contract ProtectedPartitionsFacet is ProtectedPartitions, IStaticFunctionSelectors {
@@ -11,19 +12,18 @@ contract ProtectedPartitionsFacet is ProtectedPartitions, IStaticFunctionSelecto
         staticResolverKey_ = _PROTECTED_PARTITIONS_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ProtectedPartitions.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.protectPartitions.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.unprotectPartitions.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.arePartitionsProtected.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.calculateRoleForPartition.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ProtectedPartitions.selector,
+                this.protectPartitions.selector,
+                this.unprotectPartitions.selector,
+                this.arePartitionsProtected.selector,
+                this.calculateRoleForPartition.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IProtectedPartitions).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProtectedPartitions).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/snapshot/SnapshotsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/snapshot/SnapshotsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ISnapshots } from "./ISnapshots.sol";
 import { Snapshots } from "./Snapshots.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SNAPSHOTS_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 /**
@@ -23,22 +24,17 @@ contract SnapshotsFacet is Snapshots, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.takeSnapshot.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getScheduledSnapshots.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.scheduledSnapshotCount.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.scheduledSnapshotCount.selector,
+                this.getScheduledSnapshots.selector,
+                this.takeSnapshot.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ISnapshots).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISnapshots).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/fixedRate/FixedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/fixedRate/FixedRateFacet.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IFixedRate } from "./IFixedRate.sol";
 import { _FIXED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { FixedRate } from "./FixedRate.sol";
 
 contract FixedRateFacet is FixedRate, IStaticFunctionSelectors {
@@ -10,17 +11,11 @@ contract FixedRateFacet is FixedRate, IStaticFunctionSelectors {
         staticResolverKey_ = _FIXED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_FixedRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRate.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.initialize_FixedRate.selector, this.setRate.selector, this.getRate.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IFixedRate).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IFixedRate).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/kpiLinkedRate/KpiLinkedRateFacet.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IKpiLinkedRate } from "./IKpiLinkedRate.sol";
 import { _KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { KpiLinkedRate } from "./KpiLinkedRate.sol";
 
 contract KpiLinkedRateFacet is KpiLinkedRate, IStaticFunctionSelectors {
@@ -10,19 +11,18 @@ contract KpiLinkedRateFacet is KpiLinkedRate, IStaticFunctionSelectors {
         staticResolverKey_ = _KPI_LINKED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_KpiLinkedRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setImpactData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getImpactData.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_KpiLinkedRate.selector,
+                this.setInterestRate.selector,
+                this.setImpactData.selector,
+                this.getInterestRate.selector,
+                this.getImpactData.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IKpiLinkedRate).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IKpiLinkedRate).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/interestRate/sustainabilityPerformanceTargetRate/SustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/interestRate/sustainabilityPerformanceTargetRate/SustainabilityPerformanceTargetRateFacet.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ISustainabilityPerformanceTargetRate } from "./ISustainabilityPerformanceTargetRate.sol";
 import { _SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { SustainabilityPerformanceTargetRate } from "./SustainabilityPerformanceTargetRate.sol";
 
 contract SustainabilityPerformanceTargetRateFacet is SustainabilityPerformanceTargetRate, IStaticFunctionSelectors {
@@ -10,19 +11,18 @@ contract SustainabilityPerformanceTargetRateFacet is SustainabilityPerformanceTa
         staticResolverKey_ = _SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](5);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_SustainabilityPerformanceTargetRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setImpactData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getInterestRate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getImpactDataFor.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_SustainabilityPerformanceTargetRate.selector,
+                this.setInterestRate.selector,
+                this.setImpactData.selector,
+                this.getInterestRate.selector,
+                this.getImpactDataFor.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ISustainabilityPerformanceTargetRate).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISustainabilityPerformanceTargetRate).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/kpi/kpiLatest/KpisKpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/kpi/kpiLatest/KpisKpiLinkedRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IKpis } from "./IKpis.sol";
 import { Kpis } from "./Kpis.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _KPIS_LATEST_KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract KpisKpiLinkedRateFacet is Kpis, IStaticFunctionSelectors {
@@ -11,18 +12,17 @@ contract KpisKpiLinkedRateFacet is Kpis, IStaticFunctionSelectors {
         staticResolverKey_ = _KPIS_LATEST_KPI_LINKED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
-        staticFunctionSelectors_[selectorIndex++] = this.addKpiData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLatestKpiData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getMinDate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isCheckPointDate.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.addKpiData.selector,
+                this.getLatestKpiData.selector,
+                this.getMinDate.selector,
+                this.isCheckPointDate.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IKpis).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IKpis).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/kpi/kpiLatest/KpisSustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/kpi/kpiLatest/KpisSustainabilityPerformanceTargetRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IKpis } from "./IKpis.sol";
 import { Kpis } from "./Kpis.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import {
     _KPIS_LATEST_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY
 } from "../../../../constants/resolverKeys.sol";
@@ -13,18 +14,17 @@ contract KpisSustainabilityPerformanceTargetRateFacet is Kpis, IStaticFunctionSe
         staticResolverKey_ = _KPIS_LATEST_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
-        staticFunctionSelectors_[selectorIndex++] = this.addKpiData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLatestKpiData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getMinDate.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isCheckPointDate.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.addKpiData.selector,
+                this.getLatestKpiData.selector,
+                this.getMinDate.selector,
+                this.isCheckPointDate.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IKpis).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IKpis).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/loan/LoanFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/loan/LoanFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ILoan } from "./ILoan.sol";
 import { _LOAN_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { Loan } from "./Loan.sol";
 
 /**
@@ -17,17 +18,16 @@ contract LoanFacet is Loan, IStaticFunctionSelectors {
         staticResolverKey_ = _LOAN_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_Loan.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.setLoanDetails.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getLoanDetails.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_Loan.selector,
+                this.setLoanDetails.selector,
+                this.getLoanDetails.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ILoan).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ILoan).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProceedRecipients } from "./IProceedRecipients.sol";
 import { ProceedRecipients } from "./ProceedRecipients.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROCEED_RECIPIENTS_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 contract ProceedRecipientsFacet is ProceedRecipients, IStaticFunctionSelectors {
@@ -11,22 +12,21 @@ contract ProceedRecipientsFacet is ProceedRecipients, IStaticFunctionSelectors {
         staticResolverKey_ = _PROCEED_RECIPIENTS_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ProceedRecipients.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipients.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ProceedRecipients.selector,
+                this.addProceedRecipient.selector,
+                this.removeProceedRecipient.selector,
+                this.updateProceedRecipientData.selector,
+                this.isProceedRecipient.selector,
+                this.getProceedRecipientData.selector,
+                this.getProceedRecipientsCount.selector,
+                this.getProceedRecipients.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IProceedRecipients).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProceedRecipients).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsKpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsKpiLinkedRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProceedRecipients } from "./IProceedRecipients.sol";
 import { ProceedRecipients } from "./ProceedRecipients.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROCEED_RECIPIENTS_KPI_LINKED_RATE_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 import { PROCEED_RECIPIENT_MANAGER_ROLE } from "../../../constants/roles.sol";
 import { ScheduledTasksStorageWrapper } from "../../../domain/asset/ScheduledTasksStorageWrapper.sol";
@@ -28,22 +29,21 @@ contract ProceedRecipientsKpiLinkedRateFacet is ProceedRecipients, IStaticFuncti
         staticResolverKey_ = _PROCEED_RECIPIENTS_KPI_LINKED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ProceedRecipients.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipients.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ProceedRecipients.selector,
+                this.addProceedRecipient.selector,
+                this.removeProceedRecipient.selector,
+                this.updateProceedRecipientData.selector,
+                this.isProceedRecipient.selector,
+                this.getProceedRecipientData.selector,
+                this.getProceedRecipientsCount.selector,
+                this.getProceedRecipients.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IProceedRecipients).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProceedRecipients).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsSustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/proceedRecipient/ProceedRecipientsSustainabilityPerformanceTargetRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProceedRecipients } from "./IProceedRecipients.sol";
 import { ProceedRecipients } from "./ProceedRecipients.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import {
     _PROCEED_RECIPIENTS_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY
 } from "../../../constants/resolverKeys.sol";
@@ -30,22 +31,21 @@ contract ProceedRecipientsSustainabilityPerformanceTargetRateFacet is ProceedRec
         staticResolverKey_ = _PROCEED_RECIPIENTS_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](8);
-        staticFunctionSelectors_[selectorIndex++] = this.initialize_ProceedRecipients.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.updateProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isProceedRecipient.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientData.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipientsCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getProceedRecipients.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ProceedRecipients.selector,
+                this.addProceedRecipient.selector,
+                this.removeProceedRecipient.selector,
+                this.updateProceedRecipientData.selector,
+                this.isProceedRecipient.selector,
+                this.getProceedRecipientData.selector,
+                this.getProceedRecipientsCount.selector,
+                this.getProceedRecipients.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IProceedRecipients).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProceedRecipients).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IScheduledCrossOrderedTasks } from "./IScheduledCrossOrderedTasks.sol";
 import { ScheduledCrossOrderedTasks } from "./ScheduledCrossOrderedTasks.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SCHEDULED_TASKS_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract ScheduledCrossOrderedTasksFacet is ScheduledCrossOrderedTasks, IStaticFunctionSelectors {
@@ -11,18 +12,17 @@ contract ScheduledCrossOrderedTasksFacet is ScheduledCrossOrderedTasks, IStaticF
         staticResolverKey_ = _SCHEDULED_TASKS_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
-        staticFunctionSelectors_[selectorIndex++] = this.triggerPendingScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.triggerScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.scheduledCrossOrderedTaskCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getScheduledCrossOrderedTasks.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.triggerPendingScheduledCrossOrderedTasks.selector,
+                this.triggerScheduledCrossOrderedTasks.selector,
+                this.scheduledCrossOrderedTaskCount.selector,
+                this.getScheduledCrossOrderedTasks.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IScheduledCrossOrderedTasks).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IScheduledCrossOrderedTasks).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksKpiLinkedRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksKpiLinkedRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IScheduledCrossOrderedTasks } from "./IScheduledCrossOrderedTasks.sol";
 import { ScheduledCrossOrderedTasks } from "./ScheduledCrossOrderedTasks.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SCHEDULED_CROSS_ORDERED_TASKS_KPI_LINKED_RATE_RESOLVER_KEY } from "../../../../constants/resolverKeys.sol";
 
 contract ScheduledCrossOrderedTasksKpiLinkedRateFacet is ScheduledCrossOrderedTasks, IStaticFunctionSelectors {
@@ -11,18 +12,17 @@ contract ScheduledCrossOrderedTasksKpiLinkedRateFacet is ScheduledCrossOrderedTa
         staticResolverKey_ = _SCHEDULED_CROSS_ORDERED_TASKS_KPI_LINKED_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
-        staticFunctionSelectors_[selectorIndex++] = this.triggerPendingScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.triggerScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.scheduledCrossOrderedTaskCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getScheduledCrossOrderedTasks.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.triggerPendingScheduledCrossOrderedTasks.selector,
+                this.triggerScheduledCrossOrderedTasks.selector,
+                this.scheduledCrossOrderedTaskCount.selector,
+                this.getScheduledCrossOrderedTasks.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IScheduledCrossOrderedTasks).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IScheduledCrossOrderedTasks).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/scheduledTask/scheduledCrossOrderedTask/ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IScheduledCrossOrderedTasks } from "./IScheduledCrossOrderedTasks.sol";
 import { ScheduledCrossOrderedTasks } from "./ScheduledCrossOrderedTasks.sol";
 import { IStaticFunctionSelectors } from "../../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../../infrastructure/proxy/Bytes4Builder.sol";
 import {
     _SCHEDULED_CROSS_ORDERED_TASKS_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY
 } from "../../../../constants/resolverKeys.sol";
@@ -16,18 +17,17 @@ contract ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacet is
         staticResolverKey_ = _SCHEDULED_CROSS_ORDERED_TASKS_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](4);
-        staticFunctionSelectors_[selectorIndex++] = this.triggerPendingScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.triggerScheduledCrossOrderedTasks.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.scheduledCrossOrderedTaskCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getScheduledCrossOrderedTasks.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.triggerPendingScheduledCrossOrderedTasks.selector,
+                this.triggerScheduledCrossOrderedTasks.selector,
+                this.scheduledCrossOrderedTaskCount.selector,
+                this.getScheduledCrossOrderedTasks.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IScheduledCrossOrderedTasks).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IScheduledCrossOrderedTasks).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_2/voting/VotingFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_2/voting/VotingFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { Voting } from "./Voting.sol";
 import { IVoting } from "./IVoting.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { _VOTING_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 
 /// @title VotingFacet
@@ -15,21 +16,19 @@ contract VotingFacet is Voting, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getVotingCount.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getVotingFor.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getVoting.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.cancelVoting.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.setVoting.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setVoting.selector,
+                this.cancelVoting.selector,
+                this.getVoting.selector,
+                this.getVotingFor.selector,
+                this.getVotingCount.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IVoting).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IVoting).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAFacetBase.sol
@@ -3,19 +3,15 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { IBondUSA } from "./IBondUSA.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { BondUSA } from "./BondUSA.sol";
 
 abstract contract BondUSAFacetBase is BondUSA, IStaticFunctionSelectors {
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this._initialize_bondUSA.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this._initialize_bondUSA.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IBondUSA).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBondUSA).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAReadFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/bondUSA/BondUSAReadFacetBase.sol
@@ -6,6 +6,7 @@ import { Security } from "../../layer_2/security/Security.sol";
 import { IBondRead } from "../../layer_2/bond/IBondRead.sol";
 import { ISecurity } from "../../layer_2/security/ISecurity.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 
 /**
  * @title BondUSAReadFacetBase
@@ -28,22 +29,15 @@ abstract contract BondUSAReadFacetBase is BondRead, IStaticFunctionSelectors, Se
     ///      block; the resulting array reads in declaration order (`getBondDetails`,
     ///      `getSecurityRegulationData`, `getSecurityHolders`, `getTotalSecurityHolders`).
     ///      All four concrete USA-bond read facets share this selector set.
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getSecurityRegulationData.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getBondDetails.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getBondDetails.selector, this.getSecurityRegulationData.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
     /// @dev Advertises both `IBondRead` (bond-specific reads) and `ISecurity` (USA
     ///      Reg-S/Reg-D holder bookkeeping) so EIP-165 probes for either interface succeed
     ///      against the diamond.
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](2);
-        staticInterfaceIds_[0] = type(IBondRead).interfaceId;
-        staticInterfaceIds_[1] = type(ISecurity).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IBondRead).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_3/equityUSA/EquityUSAFacet.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/equityUSA/EquityUSAFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IEquityUSA } from "./IEquityUSA.sol";
 import { _EQUITY_RESOLVER_KEY } from "../../../constants/resolverKeys.sol";
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { IEquity } from "../../layer_2/equity/IEquity.sol";
 import { ISecurity } from "../../layer_2/security/ISecurity.sol";
 import { EquityUSA } from "./EquityUSA.sol";
@@ -13,19 +14,16 @@ contract EquityUSAFacet is EquityUSA, IStaticFunctionSelectors {
         staticResolverKey_ = _EQUITY_RESOLVER_KEY;
     }
 
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
-        staticFunctionSelectors_[selectorIndex++] = this._initialize_equityUSA.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getEquityDetails.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getSecurityRegulationData.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this._initialize_equityUSA.selector,
+                this.getEquityDetails.selector,
+                this.getSecurityRegulationData.selector
+            );
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](3);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IEquity).interfaceId;
-        staticInterfaceIds_[selectorsIndex++] = type(ISecurity).interfaceId;
-        staticInterfaceIds_[selectorsIndex++] = type(IEquityUSA).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IEquity).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/layer_3/transferAndLock/TransferAndLockFacetBase.sol
+++ b/packages/ats/contracts/contracts/facets/layer_3/transferAndLock/TransferAndLockFacetBase.sol
@@ -2,17 +2,16 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IStaticFunctionSelectors } from "../../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../../infrastructure/proxy/Bytes4Builder.sol";
 import { ITransferAndLock } from "./ITransferAndLock.sol";
 import { TransferAndLock } from "./TransferAndLock.sol";
 
 abstract contract TransferAndLockFacetBase is TransferAndLock, IStaticFunctionSelectors {
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](1);
-        staticFunctionSelectors_[0] = this.transferAndLock.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.transferAndLock.selector);
     }
 
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ITransferAndLock).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ITransferAndLock).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/lockAtSnapshot/LockAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/lockAtSnapshot/LockAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ILockAtSnapshot } from "./ILockAtSnapshot.sol";
 import { LockAtSnapshot } from "./LockAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _LOCK_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract LockAtSnapshotFacet is LockAtSnapshot, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.lockedBalanceOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.lockedBalanceOfAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ILockAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ILockAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/lockAtSnapshotByPartition/LockAtSnapshotByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/lockAtSnapshotByPartition/LockAtSnapshotByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ILockAtSnapshotByPartition } from "./ILockAtSnapshotByPartition.sol";
 import { LockAtSnapshotByPartition } from "./LockAtSnapshotByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _LOCK_AT_SNAPSHOT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,20 +24,12 @@ contract LockAtSnapshotByPartitionFacet is LockAtSnapshotByPartition, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.lockedBalanceOfAtSnapshotByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.lockedBalanceOfAtSnapshotByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ILockAtSnapshotByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ILockAtSnapshotByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/lockByPartition/LockByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/lockByPartition/LockByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ILockByPartition } from "./ILockByPartition.sol";
 import { LockByPartition } from "./LockByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _LOCK_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,22 +25,20 @@ contract LockByPartitionFacet is LockByPartition, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 6;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getLockForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getLocksIdForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getLockCountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getLockedAmountForByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.releaseByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.lockByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.lockByPartition.selector,
+                this.releaseByPartition.selector,
+                this.getLockedAmountForByPartition.selector,
+                this.getLockCountForByPartition.selector,
+                this.getLocksIdForByPartition.selector,
+                this.getLockForByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ILockByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ILockByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/maturity/MaturityFacet.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/MaturityFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMaturity } from "./IMaturity.sol";
 import { Maturity } from "./Maturity.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _MATURITY_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,21 +23,12 @@ contract MaturityFacet is Maturity, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.updateMaturityDate.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.fullRedeemAtMaturity.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.fullRedeemAtMaturity.selector, this.updateMaturityDate.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IMaturity).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IMaturity).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/maturityByPartition/MaturityByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/maturityByPartition/MaturityByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMaturityByPartition } from "./IMaturityByPartition.sol";
 import { MaturityByPartition } from "./MaturityByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _MATURITY_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,20 +24,12 @@ contract MaturityByPartitionFacet is MaturityByPartition, IStaticFunctionSelecto
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.redeemAtMaturityByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.redeemAtMaturityByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IMaturityByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IMaturityByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/metadata/MetadataFacet.sol
+++ b/packages/ats/contracts/contracts/facets/metadata/MetadataFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMetadata } from "./IMetadata.sol";
 import { Metadata } from "./Metadata.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _METADATA_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,18 +23,12 @@ contract MetadataFacet is Metadata, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.setMetadata.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getMetadata.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getMetadata.selector, this.setMetadata.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IMetadata).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IMetadata).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/mint/MintFacet.sol
+++ b/packages/ats/contracts/contracts/facets/mint/MintFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMint } from "./IMint.sol";
 import { Mint } from "./Mint.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _MINT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,20 +21,18 @@ contract MintFacet is Mint, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.mint.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.issue.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isIssuable.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.initialize_ERC1594.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.initialize_ERC1594.selector,
+                this.isIssuable.selector,
+                this.issue.selector,
+                this.mint.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IMint).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IMint).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/mintByPartition/MintByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/mintByPartition/MintByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IMintByPartition } from "./IMintByPartition.sol";
 import { MintByPartition } from "./MintByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _MINT_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,20 +25,12 @@ contract MintByPartitionFacet is MintByPartition, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.issueByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.issueByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IMintByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IMintByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/nominalValueAtSnapshot/NominalValueAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/nominalValueAtSnapshot/NominalValueAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { INominalValueAtSnapshot } from "./INominalValueAtSnapshot.sol";
 import { NominalValueAtSnapshot } from "./NominalValueAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _NOMINAL_VALUE_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -16,15 +17,12 @@ contract NominalValueAtSnapshotFacet is NominalValueAtSnapshot, IStaticFunctionS
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](2);
-        staticFunctionSelectors_[0] = this.nominalValueAtSnapshot.selector;
-        staticFunctionSelectors_[1] = this.nominalValueDecimalsAtSnapshot.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.nominalValueAtSnapshot.selector, this.nominalValueDecimalsAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(INominalValueAtSnapshot).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(INominalValueAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/nonces/NoncesFacet.sol
+++ b/packages/ats/contracts/contracts/facets/nonces/NoncesFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { INonces } from "./INonces.sol";
 import { Nonces } from "./Nonces.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _NONCES_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,16 +22,12 @@ contract NoncesFacet is Nonces, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](1);
-        staticFunctionSelectors_[selectorIndex++] = this.nonces.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.nonces.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(INonces).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(INonces).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/operator/OperatorFacet.sol
+++ b/packages/ats/contracts/contracts/facets/operator/OperatorFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IOperator } from "./IOperator.sol";
 import { Operator } from "./Operator.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _OPERATOR_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,22 +22,17 @@ contract OperatorFacet is Operator, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 3;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.revokeOperator.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.authorizeOperator.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isOperator.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.isOperator.selector,
+                this.authorizeOperator.selector,
+                this.revokeOperator.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IOperator).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IOperator).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/operatorByPartition/OperatorByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IOperatorByPartition } from "./IOperatorByPartition.sol";
 import { OperatorByPartition } from "./OperatorByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _OPERATOR_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -25,24 +26,19 @@ contract OperatorByPartitionFacet is OperatorByPartition, IStaticFunctionSelecto
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 5;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.operatorRedeemByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.operatorTransferByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isOperatorForPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.revokeOperatorByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.authorizeOperatorByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.authorizeOperatorByPartition.selector,
+                this.revokeOperatorByPartition.selector,
+                this.isOperatorForPartition.selector,
+                this.operatorTransferByPartition.selector,
+                this.operatorRedeemByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IOperatorByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IOperatorByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/operatorClearingByPartition/OperatorClearingByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/operatorClearingByPartition/OperatorClearingByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IOperatorClearingByPartition } from "./IOperatorClearingByPartition.sol";
 import { OperatorClearingByPartition } from "./OperatorClearingByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _OPERATOR_CLEARING_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,21 +20,16 @@ contract OperatorClearingByPartitionFacet is OperatorClearingByPartition, IStati
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.operatorClearingTransferByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.operatorClearingRedeemByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.operatorClearingRedeemByPartition.selector,
+                this.operatorClearingTransferByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IOperatorClearingByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IOperatorClearingByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/operatorHoldByPartition/OperatorHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/operatorHoldByPartition/OperatorHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IOperatorHoldByPartition } from "./IOperatorHoldByPartition.sol";
 import { OperatorHoldByPartition } from "./OperatorHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _OPERATOR_HOLD_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,20 +23,12 @@ contract OperatorHoldByPartitionFacet is OperatorHoldByPartition, IStaticFunctio
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.operatorCreateHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.operatorCreateHoldByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(IOperatorHoldByPartition).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IOperatorHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/partitions/PartitionsFacet.sol
+++ b/packages/ats/contracts/contracts/facets/partitions/PartitionsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IPartitions } from "./IPartitions.sol";
 import { Partitions } from "./Partitions.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PARTITIONS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -20,18 +21,12 @@ contract PartitionsFacet is Partitions, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.isMultiPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.partitionsOf.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.partitionsOf.selector, this.isMultiPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IPartitions).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IPartitions).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
+++ b/packages/ats/contracts/contracts/facets/pause/PauseFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IPause } from "./IPause.sol";
 import { Pause } from "./Pause.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PAUSE_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,18 +23,12 @@ contract PauseFacet is Pause, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](3);
-        staticFunctionSelectors_[selectorIndex++] = this.pause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.unpause.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.paused.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.pause.selector, this.unpause.selector, this.paused.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(IPause).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IPause).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/principal/PrincipalFacet.sol
+++ b/packages/ats/contracts/contracts/facets/principal/PrincipalFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IPrincipal } from "./IPrincipal.sol";
 import { Principal } from "./Principal.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PRINCIPAL_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,17 +22,12 @@ contract PrincipalFacet is Principal, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getPrincipalFor.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getPrincipalFor.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IPrincipal).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IPrincipal).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/protectedByPartition/ProtectedByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProtectedByPartition } from "./IProtectedByPartition.sol";
 import { ProtectedByPartition } from "./ProtectedByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROTECTED_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,18 +25,16 @@ contract ProtectedByPartitionFacet is ProtectedByPartition, IStaticFunctionSelec
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.protectedRedeemFromByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.protectedTransferFromByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.protectedTransferFromByPartition.selector,
+                this.protectedRedeemFromByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IProtectedByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProtectedByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/protectedClearingByPartition/ProtectedClearingByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/protectedClearingByPartition/ProtectedClearingByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProtectedClearingByPartition } from "./IProtectedClearingByPartition.sol";
 import { ProtectedClearingByPartition } from "./ProtectedClearingByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROTECTED_CLEARING_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,18 +23,16 @@ contract ProtectedClearingByPartitionFacet is ProtectedClearingByPartition, ISta
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.protectedClearingTransferByPartition.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.protectedClearingRedeemByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.protectedClearingRedeemByPartition.selector,
+                this.protectedClearingTransferByPartition.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IProtectedClearingByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProtectedClearingByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/protectedClearingHoldByPartition/ProtectedClearingHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/protectedClearingHoldByPartition/ProtectedClearingHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProtectedClearingHoldByPartition } from "./IProtectedClearingHoldByPartition.sol";
 import { ProtectedClearingHoldByPartition } from "./ProtectedClearingHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROTECTED_CLEARING_HOLD_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,17 +23,12 @@ contract ProtectedClearingHoldByPartitionFacet is ProtectedClearingHoldByPartiti
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.protectedClearingCreateHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.protectedClearingCreateHoldByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IProtectedClearingHoldByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProtectedClearingHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/protectedHoldByPartition/ProtectedHoldByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/protectedHoldByPartition/ProtectedHoldByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IProtectedHoldByPartition } from "./IProtectedHoldByPartition.sol";
 import { ProtectedHoldByPartition } from "./ProtectedHoldByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _PROTECTED_HOLD_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -21,17 +22,12 @@ contract ProtectedHoldByPartitionFacet is ProtectedHoldByPartition, IStaticFunct
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.protectedCreateHoldByPartition.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.protectedCreateHoldByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IProtectedHoldByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IProtectedHoldByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/recovery/RecoveryFacet.sol
+++ b/packages/ats/contracts/contracts/facets/recovery/RecoveryFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IRecovery } from "./IRecovery.sol";
 import { Recovery } from "./Recovery.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _RECOVERY_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /// @title RecoveryFacet
@@ -18,18 +19,12 @@ contract RecoveryFacet is Recovery, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.recoveryAddress.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.isAddressRecovered.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.isAddressRecovered.selector, this.recoveryAddress.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IRecovery).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IRecovery).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/securityHolders/SecurityHoldersFacet.sol
+++ b/packages/ats/contracts/contracts/facets/securityHolders/SecurityHoldersFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { SecurityHolders } from "./SecurityHolders.sol";
 import { ISecurityHolders } from "./ISecurityHolders.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SECURITYHOLDERS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -18,17 +19,12 @@ contract SecurityHoldersFacet is SecurityHolders, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](2);
-        staticFunctionSelectors_[selectorIndex++] = this.getSecurityHolders.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getTotalSecurityHolders.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getSecurityHolders.selector, this.getTotalSecurityHolders.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ISecurityHolders).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISecurityHolders).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/securityHoldersAtSnapshot/SecurityHoldersAtSnapshotFacet.sol
+++ b/packages/ats/contracts/contracts/facets/securityHoldersAtSnapshot/SecurityHoldersAtSnapshotFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ISecurityHoldersAtSnapshot } from "./ISecurityHoldersAtSnapshot.sol";
 import { SecurityHoldersAtSnapshot } from "./SecurityHoldersAtSnapshot.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SECURITY_HOLDERS_AT_SNAPSHOT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,21 +25,13 @@ contract SecurityHoldersAtSnapshotFacet is SecurityHoldersAtSnapshot, IStaticFun
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 2;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.getTotalTokenHoldersAtSnapshot.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.getTokenHoldersAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(this.getTokenHoldersAtSnapshot.selector, this.getTotalTokenHoldersAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        uint256 selectorIndex = 1;
-        staticInterfaceIds_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticInterfaceIds_[--selectorIndex] = type(ISecurityHoldersAtSnapshot).interfaceId;
-        }
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISecurityHoldersAtSnapshot).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/snapshotsByPartition/SnapshotsByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/snapshotsByPartition/SnapshotsByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ISnapshotsByPartition } from "./ISnapshotsByPartition.sol";
 import { SnapshotsByPartition } from "./SnapshotsByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SNAPSHOTS_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /// @title SnapshotsByPartitionFacet
@@ -18,17 +19,12 @@ contract SnapshotsByPartitionFacet is SnapshotsByPartition, IStaticFunctionSelec
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 1;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.partitionsOfAtSnapshot.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.partitionsOfAtSnapshot.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ISnapshotsByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISnapshotsByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/ssiManagement/SsiManagementFacet.sol
+++ b/packages/ats/contracts/contracts/facets/ssiManagement/SsiManagementFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ISsiManagement } from "./ISsiManagement.sol";
 import { SsiManagement } from "./SsiManagement.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _SSI_MANAGEMENT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -22,22 +23,21 @@ contract SsiManagementFacet is SsiManagement, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex;
-        staticFunctionSelectors_ = new bytes4[](7);
-        staticFunctionSelectors_[selectorIndex++] = this.setRevocationRegistryAddress.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.addIssuer.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.removeIssuer.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.isIssuer.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getRevocationRegistryAddress.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getIssuerListCount.selector;
-        staticFunctionSelectors_[selectorIndex++] = this.getIssuerListMembers.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setRevocationRegistryAddress.selector,
+                this.addIssuer.selector,
+                this.removeIssuer.selector,
+                this.isIssuer.selector,
+                this.getRevocationRegistryAddress.selector,
+                this.getIssuerListCount.selector,
+                this.getIssuerListMembers.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        uint256 selectorsIndex;
-        staticInterfaceIds_[selectorsIndex++] = type(ISsiManagement).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ISsiManagement).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/transfer/TransferFacet.sol
+++ b/packages/ats/contracts/contracts/facets/transfer/TransferFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ITransfer } from "./ITransfer.sol";
 import { Transfer } from "./Transfer.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _TRANSFER_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -19,20 +20,18 @@ contract TransferFacet is Transfer, IStaticFunctionSelectors {
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        uint256 selectorIndex = 4;
-        staticFunctionSelectors_ = new bytes4[](selectorIndex);
-        unchecked {
-            staticFunctionSelectors_[--selectorIndex] = this.transferFromWithData.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.transferWithData.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.transferFrom.selector;
-            staticFunctionSelectors_[--selectorIndex] = this.transfer.selector;
-        }
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.transfer.selector,
+                this.transferFrom.selector,
+                this.transferWithData.selector,
+                this.transferFromWithData.selector
+            );
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ITransfer).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ITransfer).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/transferAndLockByPartition/TransferAndLockByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/transferAndLockByPartition/TransferAndLockByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ITransferAndLockByPartition } from "./ITransferAndLockByPartition.sol";
 import { TransferAndLockByPartition } from "./TransferAndLockByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _TRANSFER_AND_LOCK_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -23,14 +24,12 @@ contract TransferAndLockByPartitionFacet is TransferAndLockByPartition, IStaticF
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](1);
-        staticFunctionSelectors_[0] = this.transferAndLockByPartition.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.transferAndLockByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ITransferAndLockByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ITransferAndLockByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/transferByPartition/TransferByPartitionFacet.sol
+++ b/packages/ats/contracts/contracts/facets/transferByPartition/TransferByPartitionFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ITransferByPartition } from "./ITransferByPartition.sol";
 import { TransferByPartition } from "./TransferByPartition.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _TRANSFER_BY_PARTITION_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /// @title TransferByPartitionFacet
@@ -18,14 +19,12 @@ contract TransferByPartitionFacet is TransferByPartition, IStaticFunctionSelecto
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](1);
-        staticFunctionSelectors_[0] = this.transferByPartition.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.transferByPartition.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(ITransferByPartition).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(ITransferByPartition).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/facets/votingSecurityHolders/VotingSecurityHoldersFacet.sol
+++ b/packages/ats/contracts/contracts/facets/votingSecurityHolders/VotingSecurityHoldersFacet.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import { IVotingSecurityHolders } from "./IVotingSecurityHolders.sol";
 import { VotingSecurityHolders } from "./VotingSecurityHolders.sol";
 import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
 import { _VOTING_SECURITY_HOLDERS_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
 
 /**
@@ -24,15 +25,12 @@ contract VotingSecurityHoldersFacet is VotingSecurityHolders, IStaticFunctionSel
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory staticFunctionSelectors_) {
-        staticFunctionSelectors_ = new bytes4[](2);
-        staticFunctionSelectors_[0] = this.getVotingHolders.selector;
-        staticFunctionSelectors_[1] = this.getTotalVotingHolders.selector;
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(this.getVotingHolders.selector, this.getTotalVotingHolders.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors
-    function getStaticInterfaceIds() external pure override returns (bytes4[] memory staticInterfaceIds_) {
-        staticInterfaceIds_ = new bytes4[](1);
-        staticInterfaceIds_[0] = type(IVotingSecurityHolders).interfaceId;
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IVotingSecurityHolders).interfaceId);
     }
 }

--- a/packages/ats/contracts/contracts/infrastructure/proxy/Bytes4Builder.sol
+++ b/packages/ats/contracts/contracts/infrastructure/proxy/Bytes4Builder.sol
@@ -13,7 +13,7 @@ pragma solidity >=0.8.0 <0.9.0;
  *      boilerplate that facets otherwise carry. The compiler inlines each call, so the only
  *      runtime cost is argument marshalling onto the stack.
  *
- *      Overloads are provided for 1 through 6 elements. Facets needing larger arrays should
+ *      Overloads are provided for 1 through 12 elements. Facets needing larger arrays should
  *      fall back to the manual descending-loop form rather than padding this library with
  *      ever-wider overloads — the readability win flattens once N grows past the cap.
  */
@@ -113,5 +113,230 @@ library Bytes4Builder {
         r[3] = d;
         r[4] = e;
         r[5] = f;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 7 containing `a` through `g` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @return r Newly allocated 7-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](7);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 8 containing `a` through `h` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @param h Element at index 7.
+     * @return r Newly allocated 8-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g,
+        bytes4 h
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](8);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+        r[7] = h;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 9 containing `a` through `i` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @param h Element at index 7.
+     * @param i Element at index 8.
+     * @return r Newly allocated 9-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g,
+        bytes4 h,
+        bytes4 i
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](9);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+        r[7] = h;
+        r[8] = i;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 10 containing `a` through `j` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @param h Element at index 7.
+     * @param i Element at index 8.
+     * @param j Element at index 9.
+     * @return r Newly allocated 10-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g,
+        bytes4 h,
+        bytes4 i,
+        bytes4 j
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](10);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+        r[7] = h;
+        r[8] = i;
+        r[9] = j;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 11 containing `a` through `k` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @param h Element at index 7.
+     * @param i Element at index 8.
+     * @param j Element at index 9.
+     * @param k Element at index 10.
+     * @return r Newly allocated 11-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g,
+        bytes4 h,
+        bytes4 i,
+        bytes4 j,
+        bytes4 k
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](11);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+        r[7] = h;
+        r[8] = i;
+        r[9] = j;
+        r[10] = k;
+    }
+
+    /**
+     * @notice Returns a `bytes4[] memory` of length 12 containing `a` through `m` in order.
+     * @param a Element at index 0.
+     * @param b Element at index 1.
+     * @param c Element at index 2.
+     * @param d Element at index 3.
+     * @param e Element at index 4.
+     * @param f Element at index 5.
+     * @param g Element at index 6.
+     * @param h Element at index 7.
+     * @param i Element at index 8.
+     * @param j Element at index 9.
+     * @param k Element at index 10.
+     * @param m Element at index 11.
+     * @return r Newly allocated 12-element array.
+     */
+    function build(
+        bytes4 a,
+        bytes4 b,
+        bytes4 c,
+        bytes4 d,
+        bytes4 e,
+        bytes4 f,
+        bytes4 g,
+        bytes4 h,
+        bytes4 i,
+        bytes4 j,
+        bytes4 k,
+        bytes4 m
+    ) internal pure returns (bytes4[] memory r) {
+        r = new bytes4[](12);
+        r[0] = a;
+        r[1] = b;
+        r[2] = c;
+        r[3] = d;
+        r[4] = e;
+        r[5] = f;
+        r[6] = g;
+        r[7] = h;
+        r[8] = i;
+        r[9] = j;
+        r[10] = k;
+        r[11] = m;
     }
 }


### PR DESCRIPTION
## Description

- add overloads 7-12 to Bytes4Builder (stack-safe without viaIR, capped at 12)
- replace manual bytes4[] construction with Bytes4Builder.build() in 93 facets
- add @param/@return NatSpec to Bytes4Builder overloads 7-12
- update Bytes4Builder JSDoc to reflect 1-12 element range
- add changeset for minor version bump
- 2 facets remain manual: LoansPortfolioFacet (20 selectors), AmortizationFacetBase (15 selectors) — stack too deep without viaIR

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing


**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅
