### PR TITLE
refactor(contracts): [BBND-1711] split ScheduledBalanceAdjustment facet

### DIFF
--- a/.changeset/maf-split-scheduled-balance-adjustment.md
+++ b/.changeset/maf-split-scheduled-balance-adjustment.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+Extract scheduled balance adjustment selectors from `AdjustBalances` into a new `ScheduledBalanceAdjustment` facet, leaving `AdjustBalances` with only the immediate `adjustBalances` and `triggerAndSyncAll` paths.

--- a/packages/ats/contracts/Configuration.ts
+++ b/packages/ats/contracts/Configuration.ts
@@ -121,6 +121,7 @@ export const CONTRACT_NAMES = [
   "LockFacet",
   "LockByPartitionFacet",
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "BalanceTrackerFacet",
   "BalanceTrackerAdjustedFacet",
   "BalanceTrackerByPartitionFacet",

--- a/packages/ats/contracts/contracts/constants/resolverKeys.sol
+++ b/packages/ats/contracts/contracts/constants/resolverKeys.sol
@@ -629,6 +629,8 @@ bytes32 constant _SCHEDULED_CROSS_ORDERED_TASKS_SUSTAINABILITY_PERFORMANCE_TARGE
 // keccak256('security.token.standard.balanceAdjustments.resolverKey');
 bytes32 constant _BALANCE_ADJUSTMENTS_RESOLVER_KEY = 0x2bbe9fb018f1e7dd12b4442154e7fdfd75aec7b0a65d07debf49de4ece5fe8b8;
 
+// keccak256("security.token.standard.scheduledBalanceAdjustment.resolverKey");
+bytes32 constant _SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY = 0xb1373c030944c4dcf728b6cc8106d93cbd0b7b2b8f59d82d57c56a369cb06487;
 // keccak256("security.token.standard.balanceAdjustments.fixed.rate.resolverKey");
 bytes32 constant _BALANCE_ADJUSTMENTS_FIXED_RATE_RESOLVER_KEY = 0xa7e8f6d5c4b3a2e1f9d8c7b6a5e4f3d2c1b9a8e7f6d5c4b3a2e1f9d8c7b6a5e4;
 

--- a/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
@@ -8,7 +8,7 @@ import {
     KPI_EQUITY_BALANCE_ADJ
 } from "../../constants/values.sol";
 import { IEquity } from "../../facets/layer_2/equity/IEquity.sol";
-import { IAdjustBalances } from "../../facets/adjustBalances/IAdjustBalances.sol";
+import { IScheduledBalanceAdjustment } from "../../facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol";
 import { CorporateActionsStorageWrapper } from "../core/CorporateActionsStorageWrapper.sol";
 import { NominalValueStorageWrapper } from "./nominalValue/NominalValueStorageWrapper.sol";
 import { ScheduledTasksStorageWrapper } from "./ScheduledTasksStorageWrapper.sol";
@@ -57,7 +57,7 @@ library EquityStorageWrapper {
     }
 
     function setScheduledBalanceAdjustment(
-        IAdjustBalances.ScheduledBalanceAdjustment calldata newBalanceAdjustment
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment calldata newBalanceAdjustment
     ) internal returns (bytes32 corporateActionId_, uint256 balanceAdjustmentID_) {
         bytes memory data = abi.encode(newBalanceAdjustment);
 
@@ -74,23 +74,23 @@ library EquityStorageWrapper {
             BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE,
             balanceAdjustmentId - 1
         );
-        IAdjustBalances.ScheduledBalanceAdjustment memory balanceAdjustment;
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory balanceAdjustment;
         bytes32 corporateActionId;
         (balanceAdjustment, corporateActionId, ) = getScheduledBalanceAdjustment(balanceAdjustmentId);
         if (balanceAdjustment.executionDate <= TimeTravelStorageWrapper.getBlockTimestamp()) {
-            revert IAdjustBalances.BalanceAdjustmentAlreadyExecuted(corporateActionId, balanceAdjustmentId);
+            revert IScheduledBalanceAdjustment.BalanceAdjustmentAlreadyExecuted(corporateActionId, balanceAdjustmentId);
         }
         CorporateActionsStorageWrapper.cancelCorporateAction(corporateActionId);
     }
 
     function initBalanceAdjustment(bytes32 actionId, bytes memory data) internal {
         if (actionId == bytes32(0)) {
-            revert IAdjustBalances.BalanceAdjustmentCreationFailed();
+            revert IScheduledBalanceAdjustment.BalanceAdjustmentCreationFailed();
         }
 
-        IAdjustBalances.ScheduledBalanceAdjustment memory newBalanceAdjustment = abi.decode(
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory newBalanceAdjustment = abi.decode(
             data,
-            (IAdjustBalances.ScheduledBalanceAdjustment)
+            (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment)
         );
 
         ScheduledTasksStorageWrapper.addScheduledCrossOrderedTask(
@@ -145,7 +145,7 @@ library EquityStorageWrapper {
         internal
         view
         returns (
-            IAdjustBalances.ScheduledBalanceAdjustment memory balanceAdjustment_,
+            IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory balanceAdjustment_,
             bytes32 corporateActionId_,
             bool isDisabled_
         )
@@ -159,7 +159,7 @@ library EquityStorageWrapper {
         (, , data, isDisabled_) = CorporateActionsStorageWrapper.getCorporateAction(corporateActionId_);
 
         _checkUnexpectedError(data.length == 0, KPI_EQUITY_BALANCE_ADJ);
-        (balanceAdjustment_) = abi.decode(data, (IAdjustBalances.ScheduledBalanceAdjustment));
+        (balanceAdjustment_) = abi.decode(data, (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment));
     }
 
     function getScheduledBalanceAdjustmentsCount() internal view returns (uint256 balanceAdjustmentCount_) {

--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -9,7 +9,7 @@ import {
 import {
     IScheduledCrossOrderedTasks
 } from "../../facets/layer_2/scheduledTask/scheduledCrossOrderedTask/IScheduledCrossOrderedTasks.sol";
-import { IAdjustBalances } from "../../facets/adjustBalances/IAdjustBalances.sol";
+import { IScheduledBalanceAdjustment } from "../../facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol";
 import { ISnapshots } from "../../facets/layer_1/snapshot/ISnapshots.sol";
 import {
     _SCHEDULED_SNAPSHOTS_STORAGE_POSITION,
@@ -231,9 +231,9 @@ library ScheduledTasksStorageWrapper {
                     abi.decode(scheduledTask.data, (bytes32))
                 );
 
-                IAdjustBalances.ScheduledBalanceAdjustment memory balanceAdjustment = abi.decode(
+                IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory balanceAdjustment = abi.decode(
                     balanceAdjustmentData,
-                    (IAdjustBalances.ScheduledBalanceAdjustment)
+                    (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment)
                 );
                 pendingABAF_ *= balanceAdjustment.factor;
                 pendingDecimals_ += balanceAdjustment.decimals;
@@ -379,9 +379,9 @@ library ScheduledTasksStorageWrapper {
 
         if (isDisabled_) return;
 
-        IAdjustBalances.ScheduledBalanceAdjustment memory balanceAdjustment = abi.decode(
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory balanceAdjustment = abi.decode(
             balanceAdjustmentData,
-            (IAdjustBalances.ScheduledBalanceAdjustment)
+            (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment)
         );
 
         AdjustBalancesStorageWrapper.adjustBalances(balanceAdjustment.factor, balanceAdjustment.decimals);

--- a/packages/ats/contracts/contracts/facets/IAsset.sol
+++ b/packages/ats/contracts/contracts/facets/IAsset.sol
@@ -93,6 +93,7 @@ import { ILockAtSnapshotByPartition } from "./lockAtSnapshotByPartition/ILockAtS
 import { ILockAtSnapshot } from "./lockAtSnapshot/ILockAtSnapshot.sol";
 import { IMaturityByPartition } from "./maturityByPartition/IMaturityByPartition.sol";
 import { ICouponListing } from "./couponListing/ICouponListing.sol";
+import { IScheduledBalanceAdjustment } from "./scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol";
 import { ICouponSecurityHolders } from "./couponSecurityHolders/ICouponSecurityHolders.sol";
 import { ISecurityHolders } from "./securityHolders/ISecurityHolders.sol";
 
@@ -198,6 +199,7 @@ interface IAsset is
     IAmortization,
     ILoan,
     IAdjustBalances,
+    IScheduledBalanceAdjustment,
     ILoansPortfolio,
     IVoting,
     IVotingSecurityHolders,

--- a/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalances.sol
+++ b/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalances.sol
@@ -2,25 +2,20 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IAdjustBalances } from "./IAdjustBalances.sol";
-import { ADJUSTMENT_BALANCE_ROLE, CORPORATE_ACTION_ROLE } from "../../constants/roles.sol";
-import { BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE } from "../../constants/values.sol";
+import { ADJUSTMENT_BALANCE_ROLE } from "../../constants/roles.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
 import { AdjustBalancesStorageWrapper } from "../../domain/asset/AdjustBalancesStorageWrapper.sol";
-import { CorporateActionsStorageWrapper } from "../../domain/core/CorporateActionsStorageWrapper.sol";
-import { EquityStorageWrapper } from "../../domain/asset/EquityStorageWrapper.sol";
 import { ScheduledTasksStorageWrapper } from "../../domain/asset/ScheduledTasksStorageWrapper.sol";
 import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
-import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
-import { ScheduledTask } from "../layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon.sol";
 
 /**
  * @title AdjustBalances
  * @author Asset Tokenization Studio Team
- * @notice Abstract implementation of `IAdjustBalances` providing immediate and scheduled
+ * @notice Abstract implementation of `IAdjustBalances` providing immediate
  *         balance adjustment corporate actions for tokenised assets.
  * @dev Inherits access-control guards from `Modifiers`. Immediate adjustments are applied via
- *      `AdjustBalancesStorageWrapper`; scheduled ones are managed through `EquityStorageWrapper`
- *      and `ScheduledTasksStorageWrapper`. Intended to be inherited by `AdjustBalancesFacet`.
+ *      `AdjustBalancesStorageWrapper`. Scheduled adjustments are handled by `IScheduledBalanceAdjustment`.
+ *      Intended to be inherited by `AdjustBalancesFacet`.
  */
 abstract contract AdjustBalances is IAdjustBalances, Modifiers {
     /// @inheritdoc IAdjustBalances
@@ -38,82 +33,5 @@ abstract contract AdjustBalances is IAdjustBalances, Modifiers {
     /// @dev May emit {SnapshotTriggered} or {AdjustmentBalanceSet} depending on pending scheduled tasks.
     function triggerAndSyncAll(bytes32 _partition, address _from, address _to) external override onlyUnpaused {
         TokenCoreOps.triggerAndSyncAll(_partition, _from, _to);
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function setScheduledBalanceAdjustment(
-        IAdjustBalances.ScheduledBalanceAdjustment calldata _newBalanceAdjustment
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(CORPORATE_ACTION_ROLE)
-        onlyValidTimestamp(_newBalanceAdjustment.executionDate)
-        onlyValidFactor(_newBalanceAdjustment.factor)
-        returns (uint256 balanceAdjustmentID_)
-    {
-        bytes32 corporateActionID;
-        (corporateActionID, balanceAdjustmentID_) = EquityStorageWrapper.setScheduledBalanceAdjustment(
-            _newBalanceAdjustment
-        );
-        emit IAdjustBalances.ScheduledBalanceAdjustmentSet(
-            corporateActionID,
-            balanceAdjustmentID_,
-            EvmAccessors.getMsgSender(),
-            _newBalanceAdjustment.executionDate,
-            _newBalanceAdjustment.factor,
-            _newBalanceAdjustment.decimals
-        );
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function cancelScheduledBalanceAdjustment(
-        uint256 _balanceAdjustmentId
-    )
-        external
-        override
-        onlyUnpaused
-        onlyRole(CORPORATE_ACTION_ROLE)
-        notZeroValue(_balanceAdjustmentId)
-        returns (bool success_)
-    {
-        EquityStorageWrapper.cancelScheduledBalanceAdjustment(_balanceAdjustmentId);
-        emit IAdjustBalances.ScheduledBalanceAdjustmentCancelled(_balanceAdjustmentId, EvmAccessors.getMsgSender());
-        success_ = true;
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function getScheduledBalanceAdjustment(
-        uint256 _balanceAdjustmentID
-    )
-        external
-        view
-        override
-        notZeroValue(_balanceAdjustmentID)
-        onlyMatchingActionType(BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE, _balanceAdjustmentID - 1)
-        returns (IAdjustBalances.ScheduledBalanceAdjustment memory balanceAdjustment_, bool isDisabled_)
-    {
-        (balanceAdjustment_, , isDisabled_) = EquityStorageWrapper.getScheduledBalanceAdjustment(_balanceAdjustmentID);
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function getBalanceAdjustmentCount() external view override returns (uint256 balanceAdjustmentCount_) {
-        return EquityStorageWrapper.getScheduledBalanceAdjustmentsCount();
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function getPendingBalanceAdjustmentCount() external view override returns (uint256) {
-        return ScheduledTasksStorageWrapper.getScheduledBalanceAdjustmentCount();
-    }
-
-    /// @inheritdoc IAdjustBalances
-    function getScheduledBalanceAdjustments(
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view override returns (ScheduledTask[] memory scheduledBalanceAdjustment_) {
-        scheduledBalanceAdjustment_ = ScheduledTasksStorageWrapper.getScheduledBalanceAdjustments(
-            _pageIndex,
-            _pageLength
-        );
     }
 }

--- a/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalancesFacet.sol
+++ b/packages/ats/contracts/contracts/facets/adjustBalances/AdjustBalancesFacet.sol
@@ -9,7 +9,7 @@ import { _BALANCE_ADJUSTMENTS_RESOLVER_KEY } from "../../constants/resolverKeys.
 
 /**
  * @title AdjustBalancesFacet
- * @notice Diamond facet that consolidates all 8 balance-adjustment selectors under a single
+ * @notice Diamond facet that consolidates the 2 immediate balance-adjustment selectors under a single
  *         `_BALANCE_ADJUSTMENTS_RESOLVER_KEY`.
  * @dev Inherits implementation from `AdjustBalances` and satisfies the `IStaticFunctionSelectors`
  *      contract required by the Diamond proxy for selector registration.
@@ -22,17 +22,7 @@ contract AdjustBalancesFacet is AdjustBalances, IStaticFunctionSelectors {
 
     /// @inheritdoc IStaticFunctionSelectors
     function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
-        return
-            Bytes4Builder.build(
-                this.adjustBalances.selector,
-                this.setScheduledBalanceAdjustment.selector,
-                this.cancelScheduledBalanceAdjustment.selector,
-                this.getScheduledBalanceAdjustment.selector,
-                this.getBalanceAdjustmentCount.selector,
-                this.getPendingBalanceAdjustmentCount.selector,
-                this.getScheduledBalanceAdjustments.selector,
-                this.triggerAndSyncAll.selector
-            );
+        return Bytes4Builder.build(this.adjustBalances.selector, this.triggerAndSyncAll.selector);
     }
 
     /// @inheritdoc IStaticFunctionSelectors

--- a/packages/ats/contracts/contracts/facets/adjustBalances/IAdjustBalances.sol
+++ b/packages/ats/contracts/contracts/facets/adjustBalances/IAdjustBalances.sol
@@ -1,30 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { ScheduledTask } from "../layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon.sol";
-
 /**
  * @title IAdjustBalances
  * @author Asset Tokenization Studio Team
- * @notice Interface for immediate and scheduled balance adjustment corporate actions on tokenised assets.
- * @dev Balance adjustments multiply every token holder's balance by `factor / 10^decimals`. Immediate
- *      adjustments execute synchronously; scheduled ones are enqueued and triggered when their
- *      `executionDate` is reached. Scheduled tasks are managed through `ScheduledTasksStorageWrapper`
- *      and corporate-action records through `EquityStorageWrapper`.
+ * @notice Interface for immediate balance adjustment corporate actions on tokenised assets.
+ * @dev Balance adjustments multiply every token holder's balance by `factor / 10^decimals`.
+ *      Immediate adjustments execute synchronously. Scheduled adjustments are handled by
+ *      the `IScheduledBalanceAdjustment` interface and facet.
  */
 interface IAdjustBalances {
-    /**
-     * @notice Parameters for a balance adjustment to be scheduled for future execution.
-     * @dev `factor` and `decimals` together represent the multiplier: effective ratio = factor / 10^decimals.
-     *      `executionDate` must be a future Unix timestamp; zero or past values are rejected by
-     *      `onlyValidTimestamp`.
-     */
-    struct ScheduledBalanceAdjustment {
-        uint256 executionDate;
-        uint256 factor;
-        uint8 decimals;
-    }
-
     /**
      * @notice Emitted when an immediate balance adjustment is applied.
      * @param operator Address that triggered the adjustment.
@@ -33,43 +18,8 @@ interface IAdjustBalances {
      */
     event AdjustmentBalanceSet(address indexed operator, uint256 factor, uint8 decimals);
 
-    /**
-     * @notice Emitted when a balance adjustment is successfully scheduled.
-     * @param corporateActionId   On-chain identifier of the associated corporate action record.
-     * @param balanceAdjustmentId Sequential identifier of the scheduled adjustment.
-     * @param operator            Address that scheduled the adjustment.
-     * @param executionDate       Unix timestamp at which the adjustment will be executed.
-     * @param factor              Numerator of the adjustment ratio.
-     * @param decimals            Denominator exponent; effective ratio = factor / 10^decimals.
-     */
-    event ScheduledBalanceAdjustmentSet(
-        bytes32 corporateActionId,
-        uint256 balanceAdjustmentId,
-        address indexed operator,
-        uint256 indexed executionDate,
-        uint256 factor,
-        uint256 decimals
-    );
-
-    /**
-     * @notice Emitted when a previously scheduled balance adjustment is cancelled.
-     * @param balanceAdjustmentId Sequential identifier of the cancelled adjustment.
-     * @param operator            Address that performed the cancellation.
-     */
-    event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator);
-
     /// @notice Reverts when `factor` is zero, which would zero-out all holder balances.
     error FactorIsZero();
-
-    /// @notice Reverts when the underlying storage layer fails to create a corporate action record.
-    error BalanceAdjustmentCreationFailed();
-
-    /**
-     * @notice Reverts when attempting to cancel or re-execute an adjustment that has already run.
-     * @param corporateActionId   Identifier of the corporate action that was already executed.
-     * @param balanceAdjustmentId Identifier of the balance adjustment that was already executed.
-     */
-    error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId);
 
     /**
      * @notice Applies a balance adjustment to all token holders immediately.
@@ -91,63 +41,4 @@ interface IAdjustBalances {
      * @param _to        Recipient address whose snapshot is synchronised.
      */
     function triggerAndSyncAll(bytes32 _partition, address _from, address _to) external;
-
-    /**
-     * @notice Enqueues a balance adjustment to be executed at a future date.
-     * @dev Caller must hold `CORPORATE_ACTION_ROLE`. The token must not be paused,
-     *      `_newBalanceAdjustment.executionDate` must be a future timestamp, and `factor` must be
-     *      non-zero. Creates a corporate action record via `EquityStorageWrapper` and emits
-     *      `ScheduledBalanceAdjustmentSet`.
-     * @param _newBalanceAdjustment Parameters of the adjustment to schedule.
-     * @return balanceAdjustmentID_ Sequential identifier assigned to the newly created adjustment.
-     */
-    function setScheduledBalanceAdjustment(
-        ScheduledBalanceAdjustment calldata _newBalanceAdjustment
-    ) external returns (uint256 balanceAdjustmentID_);
-
-    /**
-     * @notice Cancels a previously scheduled balance adjustment.
-     * @dev Caller must hold `CORPORATE_ACTION_ROLE`. The token must not be paused.
-     *      Emits `ScheduledBalanceAdjustmentCancelled` on success.
-     * @param _balanceAdjustmentID Identifier of the scheduled adjustment to cancel.
-     * @return success_ True if the cancellation succeeded.
-     */
-    function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) external returns (bool success_);
-
-    /**
-     * @notice Returns the parameters and disabled state of a previously scheduled balance adjustment.
-     * @dev Reverts if the corporate action type stored at index `_balanceAdjustmentID - 1` does not
-     *      match `BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE`.
-     * @param _balanceAdjustmentID Identifier of the scheduled adjustment to query.
-     * @return balanceAdjustment_ Struct containing executionDate, factor, and decimals.
-     * @return isDisabled_        True if the adjustment has been cancelled or already executed.
-     */
-    function getScheduledBalanceAdjustment(
-        uint256 _balanceAdjustmentID
-    ) external view returns (ScheduledBalanceAdjustment memory balanceAdjustment_, bool isDisabled_);
-
-    /**
-     * @notice Returns the total number of balance adjustments ever scheduled, including cancelled ones.
-     * @return balanceAdjustmentCount_ Total count of corporate-action balance adjustment records.
-     */
-    function getBalanceAdjustmentCount() external view returns (uint256 balanceAdjustmentCount_);
-
-    /**
-     * @notice Returns the number of pending scheduled balance adjustments in the task queue.
-     * @dev Reads directly from `ScheduledTasksStorageWrapper`; excludes already-executed tasks.
-     * @return Count of pending balance adjustment tasks.
-     */
-    function getPendingBalanceAdjustmentCount() external view returns (uint256);
-
-    /**
-     * @notice Returns a paginated slice of pending scheduled balance adjustment tasks.
-     * @dev Reads from `ScheduledTasksStorageWrapper`. Tasks are ordered by insertion index.
-     * @param _pageIndex  Zero-based page number.
-     * @param _pageLength Maximum number of tasks to return per page.
-     * @return scheduledBalanceAdjustment_ Array of `ScheduledTask` structs for the requested page.
-     */
-    function getScheduledBalanceAdjustments(
-        uint256 _pageIndex,
-        uint256 _pageLength
-    ) external view returns (ScheduledTask[] memory scheduledBalanceAdjustment_);
 }

--- a/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol
+++ b/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ScheduledTask } from "../layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon.sol";
+
+/**
+ * @title IScheduledBalanceAdjustment
+ * @author Asset Tokenization Studio Team
+ * @notice Interface for scheduled balance adjustment corporate actions on tokenised assets.
+ * @dev Scheduled balance adjustments enqueue operations to multiply every token holder's balance
+ *      by `factor / 10^decimals` at a future date. Tasks are managed through `ScheduledTasksStorageWrapper`
+ *      and corporate-action records through `EquityStorageWrapper`.
+ */
+interface IScheduledBalanceAdjustment {
+    /**
+     * @notice Parameters for a balance adjustment to be scheduled for future execution.
+     * @dev `factor` and `decimals` together represent the multiplier: effective ratio = factor / 10^decimals.
+     *      `executionDate` must be a future Unix timestamp; zero or past values are rejected by
+     *      `onlyValidTimestamp`.
+     */
+    struct ScheduledBalanceAdjustment {
+        uint256 executionDate;
+        uint256 factor;
+        uint8 decimals;
+    }
+
+    /**
+     * @notice Emitted when a balance adjustment is successfully scheduled.
+     * @param corporateActionId   On-chain identifier of the associated corporate action record.
+     * @param balanceAdjustmentId Sequential identifier of the scheduled adjustment.
+     * @param operator            Address that scheduled the adjustment.
+     * @param executionDate       Unix timestamp at which the adjustment will be executed.
+     * @param factor              Numerator of the adjustment ratio.
+     * @param decimals            Denominator exponent; effective ratio = factor / 10^decimals.
+     */
+    event ScheduledBalanceAdjustmentSet(
+        bytes32 corporateActionId,
+        uint256 balanceAdjustmentId,
+        address indexed operator,
+        uint256 indexed executionDate,
+        uint256 factor,
+        uint256 decimals
+    );
+
+    /**
+     * @notice Emitted when a previously scheduled balance adjustment is cancelled.
+     * @param balanceAdjustmentId Sequential identifier of the cancelled adjustment.
+     * @param operator            Address that performed the cancellation.
+     */
+    event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator);
+
+    /// @notice Reverts when the underlying storage layer fails to create a corporate action record.
+    error BalanceAdjustmentCreationFailed();
+
+    /**
+     * @notice Reverts when attempting to cancel or re-execute an adjustment that has already run.
+     * @param corporateActionId   Identifier of the corporate action that was already executed.
+     * @param balanceAdjustmentId Identifier of the balance adjustment that was already executed.
+     */
+    error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId);
+
+    /**
+     * @notice Enqueues a balance adjustment to be executed at a future date.
+     * @dev Caller must hold `CORPORATE_ACTION_ROLE`. The token must not be paused,
+     *      `_newBalanceAdjustment.executionDate` must be a future timestamp, and `factor` must be
+     *      non-zero. Creates a corporate action record via `EquityStorageWrapper` and emits
+     *      `ScheduledBalanceAdjustmentSet`.
+     * @param _newBalanceAdjustment Parameters of the adjustment to schedule.
+     * @return balanceAdjustmentID_ Sequential identifier assigned to the newly created adjustment.
+     */
+    function setScheduledBalanceAdjustment(
+        ScheduledBalanceAdjustment calldata _newBalanceAdjustment
+    ) external returns (uint256 balanceAdjustmentID_);
+
+    /**
+     * @notice Cancels a previously scheduled balance adjustment.
+     * @dev Caller must hold `CORPORATE_ACTION_ROLE`. The token must not be paused.
+     *      Emits `ScheduledBalanceAdjustmentCancelled` on success.
+     * @param _balanceAdjustmentID Identifier of the scheduled adjustment to cancel.
+     * @return success_ True if the cancellation succeeded.
+     */
+    function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) external returns (bool success_);
+
+    /**
+     * @notice Returns the parameters and disabled state of a previously scheduled balance adjustment.
+     * @dev Reverts if the corporate action type stored at index `_balanceAdjustmentID - 1` does not
+     *      match `BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE`.
+     * @param _balanceAdjustmentID Identifier of the scheduled adjustment to query.
+     * @return balanceAdjustment_ Struct containing executionDate, factor, and decimals.
+     * @return isDisabled_        True if the adjustment has been cancelled or already executed.
+     */
+    function getScheduledBalanceAdjustment(
+        uint256 _balanceAdjustmentID
+    ) external view returns (ScheduledBalanceAdjustment memory balanceAdjustment_, bool isDisabled_);
+
+    /**
+     * @notice Returns the total number of balance adjustments ever scheduled, including cancelled ones.
+     * @return balanceAdjustmentCount_ Total count of corporate-action balance adjustment records.
+     */
+    function getBalanceAdjustmentCount() external view returns (uint256 balanceAdjustmentCount_);
+
+    /**
+     * @notice Returns the number of pending scheduled balance adjustments in the task queue.
+     * @dev Reads directly from `ScheduledTasksStorageWrapper`; excludes already-executed tasks.
+     * @return Count of pending balance adjustment tasks.
+     */
+    function getPendingBalanceAdjustmentCount() external view returns (uint256);
+
+    /**
+     * @notice Returns a paginated slice of pending scheduled balance adjustment tasks.
+     * @dev Reads from `ScheduledTasksStorageWrapper`. Tasks are ordered by insertion index.
+     * @param _pageIndex  Zero-based page number.
+     * @param _pageLength Maximum number of tasks to return per page.
+     * @return scheduledBalanceAdjustment_ Array of `ScheduledTask` structs for the requested page.
+     */
+    function getScheduledBalanceAdjustments(
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view returns (ScheduledTask[] memory scheduledBalanceAdjustment_);
+}

--- a/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustment.sol
+++ b/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustment.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IScheduledBalanceAdjustment } from "./IScheduledBalanceAdjustment.sol";
+import { CORPORATE_ACTION_ROLE } from "../../constants/roles.sol";
+import { BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE } from "../../constants/values.sol";
+import { Modifiers } from "../../services/Modifiers.sol";
+import { EquityStorageWrapper } from "../../domain/asset/EquityStorageWrapper.sol";
+import { ScheduledTasksStorageWrapper } from "../../domain/asset/ScheduledTasksStorageWrapper.sol";
+import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
+import { ScheduledTask } from "../layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon.sol";
+
+/**
+ * @title ScheduledBalanceAdjustment
+ * @author Asset Tokenization Studio Team
+ * @notice Abstract implementation of `IScheduledBalanceAdjustment` providing scheduled
+ *         balance adjustment corporate actions for tokenised assets.
+ * @dev Inherits access-control guards from `Modifiers`. Scheduled adjustments are managed
+ *      through `EquityStorageWrapper` and `ScheduledTasksStorageWrapper`. Intended to be
+ *      inherited by `ScheduledBalanceAdjustmentFacet`.
+ */
+abstract contract ScheduledBalanceAdjustment is IScheduledBalanceAdjustment, Modifiers {
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function setScheduledBalanceAdjustment(
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment calldata _newBalanceAdjustment
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(CORPORATE_ACTION_ROLE)
+        onlyValidTimestamp(_newBalanceAdjustment.executionDate)
+        onlyValidFactor(_newBalanceAdjustment.factor)
+        returns (uint256 balanceAdjustmentID_)
+    {
+        bytes32 corporateActionID;
+        (corporateActionID, balanceAdjustmentID_) = EquityStorageWrapper.setScheduledBalanceAdjustment(
+            _newBalanceAdjustment
+        );
+        emit IScheduledBalanceAdjustment.ScheduledBalanceAdjustmentSet(
+            corporateActionID,
+            balanceAdjustmentID_,
+            EvmAccessors.getMsgSender(),
+            _newBalanceAdjustment.executionDate,
+            _newBalanceAdjustment.factor,
+            _newBalanceAdjustment.decimals
+        );
+    }
+
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function cancelScheduledBalanceAdjustment(
+        uint256 _balanceAdjustmentId
+    )
+        external
+        override
+        onlyUnpaused
+        onlyRole(CORPORATE_ACTION_ROLE)
+        notZeroValue(_balanceAdjustmentId)
+        returns (bool success_)
+    {
+        EquityStorageWrapper.cancelScheduledBalanceAdjustment(_balanceAdjustmentId);
+        emit IScheduledBalanceAdjustment.ScheduledBalanceAdjustmentCancelled(
+            _balanceAdjustmentId,
+            EvmAccessors.getMsgSender()
+        );
+        success_ = true;
+    }
+
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function getScheduledBalanceAdjustment(
+        uint256 _balanceAdjustmentID
+    )
+        external
+        view
+        override
+        notZeroValue(_balanceAdjustmentID)
+        onlyMatchingActionType(BALANCE_ADJUSTMENT_CORPORATE_ACTION_TYPE, _balanceAdjustmentID - 1)
+        returns (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory balanceAdjustment_, bool isDisabled_)
+    {
+        (balanceAdjustment_, , isDisabled_) = EquityStorageWrapper.getScheduledBalanceAdjustment(_balanceAdjustmentID);
+    }
+
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function getBalanceAdjustmentCount() external view override returns (uint256 balanceAdjustmentCount_) {
+        return EquityStorageWrapper.getScheduledBalanceAdjustmentsCount();
+    }
+
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function getPendingBalanceAdjustmentCount() external view override returns (uint256) {
+        return ScheduledTasksStorageWrapper.getScheduledBalanceAdjustmentCount();
+    }
+
+    /// @inheritdoc IScheduledBalanceAdjustment
+    function getScheduledBalanceAdjustments(
+        uint256 _pageIndex,
+        uint256 _pageLength
+    ) external view override returns (ScheduledTask[] memory scheduledBalanceAdjustment_) {
+        scheduledBalanceAdjustment_ = ScheduledTasksStorageWrapper.getScheduledBalanceAdjustments(
+            _pageIndex,
+            _pageLength
+        );
+    }
+}

--- a/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentFacet.sol
+++ b/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentFacet.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IScheduledBalanceAdjustment } from "./IScheduledBalanceAdjustment.sol";
+import { ScheduledBalanceAdjustment } from "./ScheduledBalanceAdjustment.sol";
+import { IStaticFunctionSelectors } from "../../infrastructure/proxy/IStaticFunctionSelectors.sol";
+import { Bytes4Builder } from "../../infrastructure/proxy/Bytes4Builder.sol";
+import { _SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY } from "../../constants/resolverKeys.sol";
+
+/**
+ * @title ScheduledBalanceAdjustmentFacet
+ * @author Asset Tokenization Studio Team
+ * @notice Diamond facet that consolidates all 6 scheduled balance-adjustment selectors under
+ *         a single `_SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY`.
+ * @dev Inherits implementation from `ScheduledBalanceAdjustment` and satisfies the
+ *      `IStaticFunctionSelectors` contract required by the Diamond proxy for selector
+ *      registration. Exposes: `setScheduledBalanceAdjustment`, `cancelScheduledBalanceAdjustment`,
+ *      `getScheduledBalanceAdjustment`, `getBalanceAdjustmentCount`,
+ *      `getPendingBalanceAdjustmentCount`, `getScheduledBalanceAdjustments`.
+ */
+contract ScheduledBalanceAdjustmentFacet is ScheduledBalanceAdjustment, IStaticFunctionSelectors {
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticResolverKey() external pure override returns (bytes32 staticResolverKey_) {
+        staticResolverKey_ = _SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY;
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+        return
+            Bytes4Builder.build(
+                this.setScheduledBalanceAdjustment.selector,
+                this.cancelScheduledBalanceAdjustment.selector,
+                this.getScheduledBalanceAdjustment.selector,
+                this.getBalanceAdjustmentCount.selector,
+                this.getPendingBalanceAdjustmentCount.selector,
+                this.getScheduledBalanceAdjustments.selector
+            );
+    }
+
+    /// @inheritdoc IStaticFunctionSelectors
+    function getStaticInterfaceIds() external pure override returns (bytes4[] memory) {
+        return Bytes4Builder.build(type(IScheduledBalanceAdjustment).interfaceId);
+    }
+}

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,8 +10,8 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-14T07:08:59.443Z
- * Facets: 124
+ * Generated: 2026-05-14T09:47:16.098Z
+ * Facets: 125
  * Infrastructure: 2
  *
  * @module domain/atsRegistry.data
@@ -122,6 +122,7 @@ import {
   ProtectedHoldByPartitionFacet__factory,
   ProtectedPartitionsFacet__factory,
   RecoveryFacet__factory,
+  ScheduledBalanceAdjustmentFacet__factory,
   ScheduledCrossOrderedTasksFacet__factory,
   ScheduledCrossOrderedTasksKpiLinkedRateFacet__factory,
   ScheduledCrossOrderedTasksSustainabilityPerformanceTargetRateFacet__factory,
@@ -402,7 +403,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
   AdjustBalancesFacet: {
     name: "AdjustBalancesFacet",
     description:
-      "Diamond facet that consolidates all 8 balance-adjustment selectors under a single `_BALANCE_ADJUSTMENTS_RESOLVER_KEY`.",
+      "Diamond facet that consolidates the 2 immediate balance-adjustment selectors under a single `_BALANCE_ADJUSTMENTS_RESOLVER_KEY`.",
     resolverKey: {
       name: "_BALANCE_ADJUSTMENTS_RESOLVER_KEY",
       value: "0x2bbe9fb018f1e7dd12b4442154e7fdfd75aec7b0a65d07debf49de4ece5fe8b8",
@@ -416,54 +417,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "adjustBalances(uint256,uint8)",
         },
         selector: "0xe2d77e44",
-      },
-      {
-        name: "cancelScheduledBalanceAdjustment",
-        signature: {
-          full: "function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentId) returns (bool success_)",
-          canonical: "cancelScheduledBalanceAdjustment(uint256)",
-        },
-        selector: "0x564387f9",
-      },
-      {
-        name: "getBalanceAdjustmentCount",
-        signature: {
-          full: "function getBalanceAdjustmentCount() view returns (uint256 balanceAdjustmentCount_)",
-          canonical: "getBalanceAdjustmentCount()",
-        },
-        selector: "0x0fdaff21",
-      },
-      {
-        name: "getPendingBalanceAdjustmentCount",
-        signature: {
-          full: "function getPendingBalanceAdjustmentCount() view returns (uint256)",
-          canonical: "getPendingBalanceAdjustmentCount()",
-        },
-        selector: "0x24b1dce6",
-      },
-      {
-        name: "getScheduledBalanceAdjustment",
-        signature: {
-          full: "function getScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) view returns ((uint256 executionDate, uint256 factor, uint8 decimals) balanceAdjustment_, bool isDisabled_)",
-          canonical: "getScheduledBalanceAdjustment(uint256)",
-        },
-        selector: "0x3d5338e8",
-      },
-      {
-        name: "getScheduledBalanceAdjustments",
-        signature: {
-          full: "function getScheduledBalanceAdjustments(uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 scheduledTimestamp, bytes data)[] scheduledBalanceAdjustment_)",
-          canonical: "getScheduledBalanceAdjustments(uint256,uint256)",
-        },
-        selector: "0xcb884d41",
-      },
-      {
-        name: "setScheduledBalanceAdjustment",
-        signature: {
-          full: "function setScheduledBalanceAdjustment((uint256 executionDate, uint256 factor, uint8 decimals) _newBalanceAdjustment) returns (uint256 balanceAdjustmentID_)",
-          canonical: "setScheduledBalanceAdjustment((uint256,uint256,uint8))",
-        },
-        selector: "0xd1661084",
       },
       {
         name: "triggerAndSyncAll",
@@ -482,22 +435,6 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AdjustmentBalanceSet(address,uint256,uint8)",
         },
         topic0: "0x312510931206ef5f91f1ef19e1a01253812b7201fb8b2d5d4afa056cce53e34a",
-      },
-      {
-        name: "ScheduledBalanceAdjustmentCancelled",
-        signature: {
-          full: "event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator)",
-          canonical: "ScheduledBalanceAdjustmentCancelled(uint256,address)",
-        },
-        topic0: "0x94a946c45b2317528f3b8fed727c5627bed2062d7fe7a83a5c6b38aa2dcc178a",
-      },
-      {
-        name: "ScheduledBalanceAdjustmentSet",
-        signature: {
-          full: "event ScheduledBalanceAdjustmentSet(bytes32 corporateActionId, uint256 balanceAdjustmentId, address indexed operator, uint256 indexed executionDate, uint256 factor, uint256 decimals)",
-          canonical: "ScheduledBalanceAdjustmentSet(bytes32,uint256,address,uint256,uint256,uint256)",
-        },
-        topic0: "0x71cd63a6f86ff487645dcceb29d3eac904f16d7006cfa7b1da3ea951a77a9666",
       },
       {
         name: "SnapshotTriggered",
@@ -526,51 +463,28 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0xa1180aad",
       },
       {
-        name: "BalanceAdjustmentAlreadyExecuted",
-        signature: {
-          full: "error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId)",
-          canonical: "BalanceAdjustmentAlreadyExecuted(bytes32,uint256)",
-        },
-        selector: "0xd0447e7d",
-      },
-      {
-        name: "BalanceAdjustmentCreationFailed",
-        signature: { full: "error BalanceAdjustmentCreationFailed()", canonical: "BalanceAdjustmentCreationFailed()" },
-        selector: "0x0c68e660",
-      },
-      {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       {
         name: "FactorIsZero",
         signature: { full: "error FactorIsZero()", canonical: "FactorIsZero()" },
         selector: "0x936e9b6d",
       },
-      {
-        name: "InvalidTimestamp",
-        signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
-        selector: "0xb7d09497",
-      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
         signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
         selector: "0xc9622656",
-      },
-      {
-        name: "WrongIndexForAction",
-        signature: {
-          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
-          canonical: "WrongIndexForAction(uint256,bytes32)",
-        },
-        selector: "0xd3924f4e",
-      },
-      {
-        name: "ZeroValueNotAllowed",
-        signature: { full: "error ZeroValueNotAllowed()", canonical: "ZeroValueNotAllowed()" },
-        selector: "0x9cf8540c",
       },
     ],
     factory: (signer) => new AdjustBalancesFacet__factory(getLibLinks("tokenCoreOps") as any, signer),
@@ -4237,6 +4151,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x3a848637",
       },
       {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
+      },
+      {
         name: "DuplicatedCorporateAction",
         signature: {
           full: "error DuplicatedCorporateAction(bytes32 actionType, bytes data)",
@@ -4431,6 +4353,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x69a80e75",
       },
       {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
+      },
+      {
         name: "InterestRateIsFixed",
         signature: { full: "error InterestRateIsFixed()", canonical: "InterestRateIsFixed()" },
         selector: "0x849d4eb8",
@@ -4610,6 +4540,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       {
         name: "SnapshotIdDoesNotExists",
@@ -5611,6 +5549,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       {
         name: "FutureLookup",
@@ -7641,6 +7587,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         selector: "0x69a80e75",
       },
       {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
+      },
+      {
         name: "InvalidDate",
         signature: {
           full: "error InvalidDate(uint256 providedDate, uint256 minDate, uint256 maxDate)",
@@ -7741,6 +7695,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       {
         name: "InvalidDate",
@@ -11779,6 +11741,146 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
     timeTravelFactory: (signer) => new RecoveryFacetTimeTravel__factory(getLibLinks("clearingReadOps") as any, signer),
   },
 
+  ScheduledBalanceAdjustmentFacet: {
+    name: "ScheduledBalanceAdjustmentFacet",
+    description:
+      "Diamond facet that consolidates all 6 scheduled balance-adjustment selectors under a single `_SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY`.",
+    resolverKey: {
+      name: "_SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY",
+      value: "0xb1373c030944c4dcf728b6cc8106d93cbd0b7b2b8f59d82d57c56a369cb06487",
+    },
+    inheritance: ["ScheduledBalanceAdjustment", "IStaticFunctionSelectors"],
+    methods: [
+      {
+        name: "cancelScheduledBalanceAdjustment",
+        signature: {
+          full: "function cancelScheduledBalanceAdjustment(uint256 _balanceAdjustmentId) returns (bool success_)",
+          canonical: "cancelScheduledBalanceAdjustment(uint256)",
+        },
+        selector: "0x564387f9",
+      },
+      {
+        name: "getBalanceAdjustmentCount",
+        signature: {
+          full: "function getBalanceAdjustmentCount() view returns (uint256 balanceAdjustmentCount_)",
+          canonical: "getBalanceAdjustmentCount()",
+        },
+        selector: "0x0fdaff21",
+      },
+      {
+        name: "getPendingBalanceAdjustmentCount",
+        signature: {
+          full: "function getPendingBalanceAdjustmentCount() view returns (uint256)",
+          canonical: "getPendingBalanceAdjustmentCount()",
+        },
+        selector: "0x24b1dce6",
+      },
+      {
+        name: "getScheduledBalanceAdjustment",
+        signature: {
+          full: "function getScheduledBalanceAdjustment(uint256 _balanceAdjustmentID) view returns ((uint256 executionDate, uint256 factor, uint8 decimals) balanceAdjustment_, bool isDisabled_)",
+          canonical: "getScheduledBalanceAdjustment(uint256)",
+        },
+        selector: "0x3d5338e8",
+      },
+      {
+        name: "getScheduledBalanceAdjustments",
+        signature: {
+          full: "function getScheduledBalanceAdjustments(uint256 _pageIndex, uint256 _pageLength) view returns ((uint256 scheduledTimestamp, bytes data)[] scheduledBalanceAdjustment_)",
+          canonical: "getScheduledBalanceAdjustments(uint256,uint256)",
+        },
+        selector: "0xcb884d41",
+      },
+      {
+        name: "setScheduledBalanceAdjustment",
+        signature: {
+          full: "function setScheduledBalanceAdjustment((uint256 executionDate, uint256 factor, uint8 decimals) _newBalanceAdjustment) returns (uint256 balanceAdjustmentID_)",
+          canonical: "setScheduledBalanceAdjustment((uint256,uint256,uint8))",
+        },
+        selector: "0xd1661084",
+      },
+    ],
+    events: [
+      {
+        name: "ScheduledBalanceAdjustmentCancelled",
+        signature: {
+          full: "event ScheduledBalanceAdjustmentCancelled(uint256 balanceAdjustmentId, address indexed operator)",
+          canonical: "ScheduledBalanceAdjustmentCancelled(uint256,address)",
+        },
+        topic0: "0x94a946c45b2317528f3b8fed727c5627bed2062d7fe7a83a5c6b38aa2dcc178a",
+      },
+      {
+        name: "ScheduledBalanceAdjustmentSet",
+        signature: {
+          full: "event ScheduledBalanceAdjustmentSet(bytes32 corporateActionId, uint256 balanceAdjustmentId, address indexed operator, uint256 indexed executionDate, uint256 factor, uint256 decimals)",
+          canonical: "ScheduledBalanceAdjustmentSet(bytes32,uint256,address,uint256,uint256,uint256)",
+        },
+        topic0: "0x71cd63a6f86ff487645dcceb29d3eac904f16d7006cfa7b1da3ea951a77a9666",
+      },
+    ],
+    errors: [
+      {
+        name: "AccessControlRequired",
+        signature: {
+          full: "error AccessControlRequired(bytes32 role, address sender)",
+          canonical: "AccessControlRequired(bytes32,address)",
+        },
+        selector: "0x10210dec",
+      },
+      {
+        name: "AccountHasNoRole",
+        signature: {
+          full: "error AccountHasNoRole(address account, bytes32 role)",
+          canonical: "AccountHasNoRole(address,bytes32)",
+        },
+        selector: "0xa1180aad",
+      },
+      {
+        name: "BalanceAdjustmentAlreadyExecuted",
+        signature: {
+          full: "error BalanceAdjustmentAlreadyExecuted(bytes32 corporateActionId, uint256 balanceAdjustmentId)",
+          canonical: "BalanceAdjustmentAlreadyExecuted(bytes32,uint256)",
+        },
+        selector: "0xd0447e7d",
+      },
+      {
+        name: "BalanceAdjustmentCreationFailed",
+        signature: { full: "error BalanceAdjustmentCreationFailed()", canonical: "BalanceAdjustmentCreationFailed()" },
+        selector: "0x0c68e660",
+      },
+      {
+        name: "FactorIsZero",
+        signature: { full: "error FactorIsZero()", canonical: "FactorIsZero()" },
+        selector: "0x936e9b6d",
+      },
+      {
+        name: "InvalidTimestamp",
+        signature: { full: "error InvalidTimestamp()", canonical: "InvalidTimestamp()" },
+        selector: "0xb7d09497",
+      },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
+      {
+        name: "UnexpectedError",
+        signature: { full: "error UnexpectedError(bytes4 _errorId)", canonical: "UnexpectedError(bytes4)" },
+        selector: "0xc9622656",
+      },
+      {
+        name: "WrongIndexForAction",
+        signature: {
+          full: "error WrongIndexForAction(uint256 index, bytes32 actionType)",
+          canonical: "WrongIndexForAction(uint256,bytes32)",
+        },
+        selector: "0xd3924f4e",
+      },
+      {
+        name: "ZeroValueNotAllowed",
+        signature: { full: "error ZeroValueNotAllowed()", canonical: "ZeroValueNotAllowed()" },
+        selector: "0x9cf8540c",
+      },
+    ],
+    factory: (signer) => new ScheduledBalanceAdjustmentFacet__factory(signer),
+  },
+
   ScheduledCrossOrderedTasksFacet: {
     name: "ScheduledCrossOrderedTasksFacet",
     resolverKey: {
@@ -11851,6 +11953,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -11936,6 +12046,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
       },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
+      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "UnexpectedError",
@@ -12018,6 +12136,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -12220,6 +12346,14 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "CouponNotFound",
         signature: { full: "error CouponNotFound(uint256 couponID)", canonical: "CouponNotFound(uint256)" },
         selector: "0x69a80e75",
+      },
+      {
+        name: "DecimalDifferenceTooLarge",
+        signature: {
+          full: "error DecimalDifferenceTooLarge(uint8 smallerDecimals, uint8 biggerDecimals)",
+          canonical: "DecimalDifferenceTooLarge(uint8,uint8)",
+        },
+        selector: "0x552d04f9",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -13624,7 +13758,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
 /**
  * Total number of facets in the registry.
  */
-export const TOTAL_FACETS = 124 as const;
+export const TOTAL_FACETS = 125 as const;
 
 /**
  * Registry of non-facet infrastructure contracts (BusinessLogicResolver, Factory, etc.).

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -128,6 +128,7 @@ const BOND_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "CouponFacet",
   "CouponSecurityHoldersFacet",
   "LockFacet",

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -123,6 +123,7 @@ const BOND_FIXED_RATE_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "LockFacet",
   "LockByPartitionFacet",
   "MaturityFacet",

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -118,6 +118,7 @@ const BOND_KPI_LINKED_RATE_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "LockFacet",
   "LockByPartitionFacet",
   "MaturityFacet",

--- a/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondSustainabilityPerformanceTargetRate/createConfiguration.ts
@@ -118,6 +118,7 @@ const BOND_SUSTAINABILITY_PERFORMANCE_TARGET_RATE_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "LockFacet",
   "LockByPartitionFacet",
   "MaturityFacet",

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -117,8 +117,9 @@ const EQUITY_FACETS = [
   "ExternalKycListManagementFacet",
   "ExternalPauseManagementFacet",
 
-  // Advanced Features (11)
+  // Advanced Features (12)
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "DividendFacet",
   "DividendSecurityHoldersFacet",
   "LockFacet",

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -144,6 +144,7 @@ const LOAN_FACETS = [
   "LockFacet",
   "LockByPartitionFacet",
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "ProtectedPartitionsFacet",
 ] as const;
 

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -135,6 +135,7 @@ const LOANS_PORTFOLIO_FACETS = [
 
   // Advanced Features
   "AdjustBalancesFacet",
+  "ScheduledBalanceAdjustmentFacet",
   "LockFacet",
   "LockByPartitionFacet",
   "ProtectedPartitionsFacet",

--- a/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCTransactionAdapter.ts
@@ -68,7 +68,7 @@ import {
   MockedWhitelist__factory,
   TREXFactoryAts__factory,
 } from "@hashgraph/asset-tokenization-contracts";
-import type { IAdjustBalances } from "@hashgraph/asset-tokenization-contracts";
+import type { IScheduledBalanceAdjustment } from "@hashgraph/asset-tokenization-contracts";
 import { ContractId } from "@hiero-ledger/sdk";
 import EventService from "@service/event/EventService";
 import LogService from "@service/log/LogService";
@@ -896,7 +896,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
             factor: ${factor},
             decimals : ${decimals}  `,
     );
-    const scheduledBalanceAdjustmentStruct: IAdjustBalances.ScheduledBalanceAdjustmentStruct = {
+    const scheduledBalanceAdjustmentStruct: IScheduledBalanceAdjustment.ScheduledBalanceAdjustmentStruct = {
       executionDate: executionDate.toBigInt(),
       factor: factor.toBigInt(),
       decimals: decimals.toBigInt(),
@@ -2719,10 +2719,7 @@ export class RPCTransactionAdapter extends TransactionAdapter {
     );
   }
 
-  async setNominalValueCurrency(
-    security: EvmAddress,
-    nominalValueCurrency: string,
-  ): Promise<TransactionResponse> {
+  async setNominalValueCurrency(security: EvmAddress, nominalValueCurrency: string): Promise<TransactionResponse> {
     LogService.logTrace(`Setting nominal value currency for security: ${security.toString()}`);
 
     return this.executeTransaction(

--- a/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
+++ b/packages/mass-payout/contracts/contracts/test/testAsset/AssetMock.sol
@@ -7,6 +7,9 @@ import { IAssetMock } from "./interfaces/IAssetMock.sol";
 import {
     ScheduledTask
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon.sol";
+import {
+    IScheduledBalanceAdjustment
+} from "@hashgraph/asset-tokenization-contracts/contracts/facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol";
 import { IFactory } from "@hashgraph/asset-tokenization-contracts/contracts/factory/IFactory.sol";
 import { ICouponTypes } from "@hashgraph/asset-tokenization-contracts/contracts/facets/coupon/ICouponTypes.sol";
 import { IVotingTypes } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/voting/IVotingTypes.sol";
@@ -15,6 +18,17 @@ import { IDividendTypes } from "@hashgraph/asset-tokenization-contracts/contract
 import { IBondTypes } from "@hashgraph/asset-tokenization-contracts/contracts/facets/layer_2/bond/IBondTypes.sol";
 import { IPrincipal } from "@hashgraph/asset-tokenization-contracts/contracts/facets/principal/IPrincipal.sol";
 
+/**
+ * @title AssetMock
+ * @author Asset Tokenization Studio Team
+ * @notice Test-only mock asset used by the mass-payout `LifeCycleCashFlow` integration
+ *         tests. Implements `IAssetMock`, which aggregates every facet interface the
+ *         flows interact with.
+ * @dev Most methods revert with `NotImplemented` — they exist solely to satisfy the
+ *      `IAssetMock` aggregated surface. A small subset returns canned values seeded by
+ *      the constructor parameters (`SecurityType`, `withHolders`, `amountNumerator`).
+ *      Production code MUST NOT instantiate or reference this mock.
+ */
 // solhint-disable no-unused-vars
 contract AssetMock is IAssetMock {
     IFactory.SecurityType private _securityType;
@@ -185,7 +199,9 @@ contract AssetMock is IAssetMock {
         revert NotImplemented();
     }
 
-    function setScheduledBalanceAdjustment(ScheduledBalanceAdjustment calldata) external pure returns (uint256) {
+    function setScheduledBalanceAdjustment(
+        IScheduledBalanceAdjustment.ScheduledBalanceAdjustment calldata
+    ) external pure returns (uint256) {
         revert NotImplemented();
     }
 
@@ -252,7 +268,9 @@ contract AssetMock is IAssetMock {
         revert NotImplemented();
     }
 
-    function getScheduledBalanceAdjustment(uint256) external pure returns (ScheduledBalanceAdjustment memory, bool) {
+    function getScheduledBalanceAdjustment(
+        uint256
+    ) external pure returns (IScheduledBalanceAdjustment.ScheduledBalanceAdjustment memory, bool) {
         revert NotImplemented();
     }
 

--- a/packages/mass-payout/contracts/contracts/test/testAsset/interfaces/IAssetMock.sol
+++ b/packages/mass-payout/contracts/contracts/test/testAsset/interfaces/IAssetMock.sol
@@ -9,7 +9,21 @@ import { IVoting } from "@hashgraph/asset-tokenization-contracts/contracts/facet
 import {
     IAdjustBalances
 } from "@hashgraph/asset-tokenization-contracts/contracts/facets/adjustBalances/IAdjustBalances.sol";
+import {
+    IScheduledBalanceAdjustment
+} from "@hashgraph/asset-tokenization-contracts/contracts/facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol";
 
-interface IAssetMock is ICoupon, IEquity, IVoting, ICore, IAdjustBalances {
+/**
+ * @title IAssetMock
+ * @author Asset Tokenization Studio Team
+ * @notice Aggregated test-only interface combining the asset facets that the mass-payout
+ *         LifeCycleCashFlow integration tests reach for on an asset token.
+ * @dev Mock surface used exclusively by `AssetMock`. Inherits every facet interface the
+ *      mass-payout flows interact with so the mock implementation can be typed against a
+ *      single handle. Production code MUST NOT depend on this interface — use the ATS
+ *      umbrella `IAsset` instead.
+ */
+interface IAssetMock is ICoupon, IEquity, IVoting, ICore, IAdjustBalances, IScheduledBalanceAdjustment {
+    /// @notice Reverts from any mock method that has not been given a canned implementation.
     error NotImplemented();
 }


### PR DESCRIPTION
## Description

Refactor extracting the scheduled balance-adjustment surface out of the `AdjustBalances` monolithic facet into its own MAF capability facet, with the matching cross-package retypes.

Contracts: new `ScheduledBalanceAdjustment` facet under `contracts/facets/scheduledBalanceAdjustment/` registered as `_SCHEDULED_BALANCE_ADJUSTMENT_RESOLVER_KEY` (deterministic `keccak256("security.token.standard.scheduledBalanceAdjustment.resolverKey")`). The 6 scheduled selectors (`setScheduledBalanceAdjustment`, `cancelScheduledBalanceAdjustment`, `getScheduledBalanceAdjustment`, `getBalanceAdjustmentCount`, `getPendingBalanceAdjustmentCount`, `getScheduledBalanceAdjustments`) move out of `AdjustBalances`; the struct, two events (`ScheduledBalanceAdjustmentSet`, `ScheduledBalanceAdjustmentCancelled`) and two errors (`BalanceAdjustmentCreationFailed`, `BalanceAdjustmentAlreadyExecuted`) relocate inline onto `IScheduledBalanceAdjustment`. `AdjustBalances` retains the two immediate selectors (`adjustBalances`, `triggerAndSyncAll`); `FactorIsZero` and `AdjustmentBalanceSet` stay on `IAdjustBalances` (still emitted/reverted from the immediate path). `EquityStorageWrapper` and `ScheduledTasksStorageWrapper` switch their import to the new interface for the relocated types. `IAsset.sol` adds the new interface to its umbrella inheritance list.

Deployment pipeline: `Configuration.ts` global facet list adds `ScheduledBalanceAdjustmentFacet`. All 7 domain `createConfiguration.ts` files (equity + bond family + loan family) register the new facet adjacent to `AdjustBalancesFacet`, preserving pre-split selector availability (bond-side coupon tests exercise record-date balance manipulation through the scheduled API). `scripts/domain/atsRegistry.data.ts` regenerated.

SDK: `RPCTransactionAdapter.ts` retypes the struct from `IAdjustBalances.ScheduledBalanceAdjustmentStruct` to `IScheduledBalanceAdjustment.ScheduledBalanceAdjustmentStruct`. Adapter call routing was already on `IAsset__factory`.

Mass-payout: `IAssetMock.sol` adds `IScheduledBalanceAdjustment` to its per-facet inheritance chain; `AssetMock.sol` imports the interface and qualifies the relocated struct refs in the two mock setters / getters.

No `Factory.sol` or `orchestratorLibraries.ts` changes — new facet has no initializer (storage owned by `EquityStorageWrapper`) and no orchestrator-library dependencies (storage-wrapper calls only).

Fixes https://iobuilders.atlassian.net/browse/BBND-1711

## Type of change

- [x] Refactor 🔧

## Testing

- `cd packages/ats/contracts && npx hardhat compile` — clean
- `cd packages/ats/contracts && npx hardhat test` — **2008 passing, 0 failing, 3 pending** (3 pending pre-existing on `getGeographicalExposure` loan tests)
- `cd packages/ats/contracts && npm run lint` — 0 errors (baseline natspec warnings on legacy `Eip1066` only)
- `npm run ats:contracts:build && npm run ats:sdk:build` — clean
- `cd packages/mass-payout/contracts && npx hardhat compile` — clean
- Independent `/review` agent run on the diff: 0 blockers, 0 majors, 2 minors (NatSpec polish on pre-existing carried-over comments)

**Node version**:

- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅