### PR TITLE
fix: [FIND-092] Swap-and-Pop Operations Leave Stale Storage Entries

### DIFF
--- a/.changeset/fix-stale-storage-after-swap-and-pop.md
+++ b/.changeset/fix-stale-storage-after-swap-and-pop.md
@@ -1,0 +1,14 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix stale storage slots left behind by swap-and-pop removal in token holder and document registries.
+
+**Ghost address in `ERC1410StorageWrapper.removeTokenHolder` (`ERC1410StorageWrapper.sol`)**
+The swap-and-pop routine moved the last holder into the vacated slot and decremented `totalTokenHolders`, but never issued `delete basicStorage.tokenHolders[lastIndex]`. The mapping slot at the old `lastIndex` retained the address that had just been moved, creating a permanently stale entry. Any off-chain or on-chain consumer reading that slot directly received a phantom address. Adds the missing `delete` call after the counter decrement.
+
+**Stale index entry in `DocumentationStorageWrapper.removeDocumentEntry` (`DocumentationStorageWrapper.sol`)**
+After swap-and-pop removal, `delete docStorage.documents[_name]` was issued but `delete docStorage.docIndexes[_name]` was not. The `docIndexes` mapping kept a non-zero value pointing at the slot now occupied by a different document, leaving inconsistent state that could confuse off-chain tooling or future reads of the index. Adds the missing `delete docStorage.docIndexes[_name]` alongside the existing document delete.
+
+**Regression tests**
+Both fixes are covered by new storage-level tests that compute the affected mapping slot via `keccak256(key || mappingBaseSlot)` and assert the slot equals `bytes32(0)` after the removal operation. Tests are added to `SecurityHolders.test.ts` and `documentation.test.ts` respectively.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -164,6 +164,7 @@ library ERC1410StorageWrapper {
         unchecked {
             --basicStorage.totalTokenHolders;
         }
+        delete basicStorage.tokenHolders[lastIndex];
     }
 
     function authorizeOperator(address operator) internal {

--- a/packages/ats/contracts/contracts/domain/core/DocumentationStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/DocumentationStorageWrapper.sol
@@ -89,6 +89,7 @@ library DocumentationStorageWrapper {
         }
         docStorage.docNames.pop();
         delete docStorage.documents[_name];
+        delete docStorage.docIndexes[_name];
     }
 
     // -------------------------------------------------------------------------

--- a/packages/ats/contracts/test/contracts/integration/layer_1/documentation/documentation.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/documentation/documentation.test.ts
@@ -164,6 +164,25 @@ describe("Documentation Tests", () => {
     expect(documents.length).to.equal(0);
   });
 
+  it("GIVEN a document that is removed THEN docIndexes storage slot is zeroed (audit fix FIND-123)", async () => {
+    await asset.connect(signer_A).grantRole(ATS_ROLES.DOCUMENTER_ROLE, signer_C.address);
+
+    await asset.connect(signer_C).setDocument(documentName_1, documentURI_1, documentHASH_1);
+    await asset.connect(signer_C).removeDocument(documentName_1);
+
+    // Compute storage slot for docIndexes[documentName_1].
+    // DocumentationDataStorage struct layout from _DOCUMENTATION_STORAGE_POSITION:
+    //   +0 documents, +1 docIndexes  ← mapping base slot, +2 docNames
+    const DOCS_BASE = BigInt("0x1fc4fd526525f9824b2c5281c13f150dcad8151e0be556d609cf96360a80fe2a");
+    const docIndexesMappingBaseSlot = DOCS_BASE + 1n;
+    const ghostSlot = ethers.keccak256(
+      ethers.AbiCoder.defaultAbiCoder().encode(["bytes32", "uint256"], [documentName_1, docIndexesMappingBaseSlot]),
+    );
+
+    const slotValue = await ethers.provider.getStorage(diamond.target, ghostSlot);
+    expect(slotValue).to.equal(ethers.ZeroHash);
+  });
+
   it("GIVEN an existing document WHEN setDocument is called again with same name THEN document is updated without adding to docNames array", async () => {
     await asset.connect(signer_A).grantRole(ATS_ROLES.DOCUMENTER_ROLE, signer_C.address);
 

--- a/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
@@ -409,4 +409,48 @@ describe("SecurityHoldersFacet Tests", () => {
       expect(holders).to.include(signer_C.address);
     });
   });
+
+  describe("removeTokenHolder storage cleanup (audit fix FIND-123)", () => {
+    it("GIVEN two holders WHEN first holder transfers all tokens out THEN tokenHolders[lastIndex] storage slot is zeroed", async () => {
+      const tokenAmount = 1000n;
+
+      // Issue to two holders: signer_B at index 1, signer_C at index 2 (lastIndex)
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_B.address,
+        value: tokenAmount,
+        data: "0x",
+      });
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_C.address,
+        value: tokenAmount,
+        data: "0x",
+      });
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(2);
+
+      // Transfer all of signer_B's tokens to signer_C → removeTokenHolder(signer_B) is triggered.
+      // Swap-and-pop moves signer_C (lastIndex=2) into slot 1.
+      // Without the fix, tokenHolders[2] retains signer_C's address as a ghost.
+      await asset.connect(signer_B).transfer(signer_C.address, tokenAmount);
+
+      expect(await asset.getTotalSecurityHolders()).to.equal(1);
+
+      // Compute storage slot for tokenHolders[2].
+      // ERC1410BasicStorage struct layout from _ERC1410_BASIC_STORAGE_POSITION:
+      //   +0 DEPRECATED_totalSupply, +1 totalSupplyByPartition, +2 DEPRECATED_balances,
+      //   +3 partitions, +4 partitionToIndex, +5 multiPartition+initialized (packed),
+      //   +6 tokenHolderIndex, +7 tokenHolders  ← mapping base slot
+      const ERC1410_BASE = BigInt("0x67661db80d37d3b9810c430f78991b4b5377bdebd3b71b39fbd3427092c1822a");
+      const tokenHoldersMappingBaseSlot = ERC1410_BASE + 7n;
+      const lastIndex = 2n;
+      const ghostSlot = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(["uint256", "uint256"], [lastIndex, tokenHoldersMappingBaseSlot]),
+      );
+
+      const slotValue = await ethers.provider.getStorage(diamond.target, ghostSlot);
+      expect(slotValue).to.equal(ethers.ZeroHash);
+    });
+  });
 });


### PR DESCRIPTION
This pull request addresses a critical storage cleanup issue in the asset tokenization contracts, fixing stale storage slots left behind after swap-and-pop removals in both the token holder and document registries. Without these fixes, phantom addresses or stale index entries could persist in storage, potentially confusing off-chain tools or future contract logic. The changes ensure that storage slots are properly zeroed out after removal, and regression tests are added to verify the fixes at the storage level.

**Storage cleanup fixes:**

- Added a `delete` statement for `basicStorage.tokenHolders[lastIndex]` in `ERC1410StorageWrapper.removeTokenHolder` to ensure no ghost addresses remain after a holder is removed. (`ERC1410StorageWrapper.sol`)
- Added a `delete` statement for `docStorage.docIndexes[_name]` in `DocumentationStorageWrapper.removeDocumentEntry` to prevent stale index entries after a document is removed. (`DocumentationStorageWrapper.sol`)

**Regression tests:**

- Added a test to `SecurityHolders.test.ts` that verifies the storage slot for a removed token holder is zeroed out after removal.
- Added a test to `documentation.test.ts` that checks the storage slot for a removed document index is cleared.

**Documentation:**

- Updated the changeset to document the fixes and their impact, including details on the issues and the new regression tests. (`.changeset/fix-stale-storage-after-swap-and-pop.md`)

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
