### PR TITLE
feat: onlyActivated for external functions of AccessControl

### DIFF
--- a/.changeset/fix-find-access-control-deactivated-gate.md
+++ b/.changeset/fix-find-access-control-deactivated-gate.md
@@ -1,0 +1,9 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix: add `onlyActivated` guard to all role-mutating functions in `AccessControl`.
+
+`grantRole`, `revokeRole`, `renounceRole`, and `applyRoles` lacked the `onlyActivated` modifier, meaning that after a token was deactivated it was still possible to modify role assignments. A deactivated token should be immutable in all respects — including its access-control configuration.
+
+The fix adds `onlyActivated` as the first modifier on each of those four functions, ensuring any role mutation attempt on a deactivated token reverts with `Deactivated`.

--- a/packages/ats/contracts/contracts/facets/accessControl/AccessControl.sol
+++ b/packages/ats/contracts/contracts/facets/accessControl/AccessControl.sol
@@ -23,7 +23,14 @@ abstract contract AccessControl is IAccessControl, Modifiers {
     function grantRole(
         bytes32 _role,
         address _account
-    ) external override onlyUnpaused onlyRole(AccessControlStorageWrapper.getRoleAdmin(_role)) returns (bool success_) {
+    )
+        external
+        override
+        onlyActivated
+        onlyUnpaused
+        onlyRole(AccessControlStorageWrapper.getRoleAdmin(_role))
+        returns (bool success_)
+    {
         if (!AccessControlStorageWrapper.grantRole(_role, _account)) {
             revert AccountAssignedToRole(_role, _account);
         }
@@ -36,7 +43,14 @@ abstract contract AccessControl is IAccessControl, Modifiers {
     function revokeRole(
         bytes32 _role,
         address _account
-    ) external override onlyUnpaused onlyRole(AccessControlStorageWrapper.getRoleAdmin(_role)) returns (bool success_) {
+    )
+        external
+        override
+        onlyActivated
+        onlyUnpaused
+        onlyRole(AccessControlStorageWrapper.getRoleAdmin(_role))
+        returns (bool success_)
+    {
         success_ = AccessControlStorageWrapper.revokeRole(_role, _account);
         if (!success_) {
             revert AccountNotAssignedToRole(_role, _account);
@@ -46,7 +60,7 @@ abstract contract AccessControl is IAccessControl, Modifiers {
 
     /// @inheritdoc IAccessControl
     /// @dev Requires the token to be unpaused. No admin role required; acts on `msg.sender`.
-    function renounceRole(bytes32 _role) external override onlyUnpaused returns (bool success_) {
+    function renounceRole(bytes32 _role) external override onlyActivated onlyUnpaused returns (bool success_) {
         address account = EvmAccessors.getMsgSender();
         success_ = AccessControlStorageWrapper.revokeRole(_role, account);
         if (!success_) {
@@ -65,6 +79,7 @@ abstract contract AccessControl is IAccessControl, Modifiers {
     )
         external
         override
+        onlyActivated
         onlyUnpaused
         onlySameRolesAndActivesLength(_roles.length, _actives.length)
         onlyConsistentRoles(_roles, _actives)

--- a/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
@@ -38,16 +38,40 @@ describe("Access Control Tests", () => {
     await loadFixture(deployFixture);
   });
 
+  it("GIVEN a deactivated asset WHEN grantRole THEN transaction fails with Deactivated", async () => {
+    await asset.connect(deployer).grantRole(ATS_ROLES.DEACTIVATE_ROLE, deployer.address);
+    await asset.connect(deployer).deactivate();
+    await expect(
+      asset.connect(deployer).grantRole(ATS_ROLES.PAUSER_ROLE, unknownSigner.address),
+    ).to.be.revertedWithCustomError(asset, "Deactivated");
+  });
+
   it("GIVEN an account without administrative role WHEN grantRole THEN transaction fails with AccountHasNoRole", async () => {
     await expect(
       asset.connect(signer_C).grantRole(ATS_ROLES.PAUSER_ROLE, unknownSigner.address),
     ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
   });
 
+  it("GIVEN a deactivated asset WHEN revokeRole THEN transaction fails with Deactivated", async () => {
+    await asset.connect(deployer).grantRole(ATS_ROLES.DEACTIVATE_ROLE, deployer.address);
+    await asset.connect(deployer).deactivate();
+    await expect(
+      asset.connect(deployer).revokeRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, unknownSigner.address),
+    ).to.be.revertedWithCustomError(asset, "Deactivated");
+  });
+
   it("GIVEN an account without administrative role WHEN revokeRole THEN transaction fails with AccountHasNoRole", async () => {
     await expect(
       asset.connect(signer_C).revokeRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, unknownSigner.address),
     ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
+  });
+
+  it("GIVEN a deactivated asset WHEN applyRoles THEN transaction fails with Deactivated", async () => {
+    await asset.connect(deployer).grantRole(ATS_ROLES.DEACTIVATE_ROLE, deployer.address);
+    await asset.connect(deployer).deactivate();
+    await expect(
+      asset.connect(signer_C).applyRoles([ATS_ROLES.DEFAULT_ADMIN_ROLE], [true], unknownSigner.address),
+    ).to.be.revertedWithCustomError(asset, "Deactivated");
   });
 
   it("GIVEN an account without administrative role WHEN applyRoles THEN transaction fails with AccountHasNoRole", async () => {
@@ -101,6 +125,15 @@ describe("Access Control Tests", () => {
     await expect(
       asset.connect(deployer).revokeRole(ATS_ROLES.PAUSER_ROLE, unknownSigner.address),
     ).to.be.revertedWithCustomError(asset, "IsPaused");
+  });
+
+  it("GIVEN a deactivated asset WHEN renounceRole THEN transaction fails with Deactivated", async () => {
+    await asset.connect(deployer).grantRole(ATS_ROLES.DEACTIVATE_ROLE, deployer.address);
+    await asset.connect(deployer).deactivate();
+    await expect(asset.connect(signer_C).renounceRole(ATS_ROLES.PAUSER_ROLE)).to.be.revertedWithCustomError(
+      asset,
+      "Deactivated",
+    );
   });
 
   it("GIVEN a paused Token WHEN renounce THEN transaction fails with IsPaused", async () => {


### PR DESCRIPTION
## Description

All external non view function of `AccessControl` contract were added `onlyActivated` modifier in order for this functions only work if were not previously deactivated. Otherwise a `Deactivated` error will be produced.
Tests for each function were added to `accessControl.test.ts`

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
