### PR TITLE
feat: add facet version deployment script

### DIFF
--- a/.changeset/facets-version-deployment.md
+++ b/.changeset/facets-version-deployment.md
@@ -2,4 +2,4 @@
 "@hashgraph/asset-tokenization-contracts": minor
 ---
 
-Add facets' version to deployment output file and flag to deploy only a Bond Configuration
+Add facets' version to deployment output file, a flag to deploy only a Bond Configuration and a flag to deploy in parallel Facets in networks as Besu (not compatible with Hedera)

--- a/.changeset/facets-version-deployment.md
+++ b/.changeset/facets-version-deployment.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+Add facets' version to deployment output file and flag to deploy only a Bond Configuration

--- a/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
@@ -21,7 +21,7 @@
  */
 
 import { deploySystemWithNewBlr } from "../workflows/deploySystemWithNewBlr";
-import { DEFAULT_BATCH_SIZE, info, success, error } from "@scripts/infrastructure";
+import { DEFAULT_BATCH_SIZE, info, success, error, isHederaNetwork } from "@scripts/infrastructure";
 import { requireNetworkSigner, parseBooleanEnv, parseIntEnv } from "./shared";
 
 /**
@@ -36,7 +36,7 @@ async function main() {
   const batchSize = parseIntEnv("BATCH_SIZE", DEFAULT_BATCH_SIZE);
   const deployOnlyBondConfig = parseBooleanEnv("DEPLOY_ONLY_BOND_CONFIG", false);
   const parallelFacetDeployment = parseBooleanEnv("PARALLEL_FACET_DEPLOYMENT", false);
-  const concurrency = parseIntEnv("FACET_DEPLOY_CONCURRENCY", 20);
+  const concurrency = parseIntEnv("FACET_DEPLOY_CONCURRENCY", 25);
 
   info(`🚀 Starting ATS deployment`);
   info("---");
@@ -48,6 +48,12 @@ async function main() {
   if (parallelFacetDeployment)
     info(`⚡ Parallel facet deployment: concurrency=${concurrency} (retries off, checkpoint skipped)`);
   info("---");
+
+  if (parallelFacetDeployment && isHederaNetwork(network)) {
+    throw new Error(
+      "parallelFacetDeployment is not supported on Hedera networks (relay rate-limit). Use Besu/local instead.",
+    );
+  }
 
   try {
     // Use signer from network configuration

--- a/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
@@ -34,6 +34,7 @@ async function main() {
   const useTimeTravel = parseBooleanEnv("USE_TIMETRAVEL", false);
   const partialBatchDeploy = parseBooleanEnv("PARTIAL_BATCH_DEPLOY", false);
   const batchSize = parseIntEnv("BATCH_SIZE", DEFAULT_BATCH_SIZE);
+  const deployOnlyBondConfig = parseBooleanEnv("DEPLOY_ONLY_BOND_CONFIG", false);
 
   info(`🚀 Starting ATS deployment`);
   info("---");
@@ -41,6 +42,7 @@ async function main() {
   info(`⏰ TimeTravel: ${useTimeTravel ? "enabled" : "disabled"}`);
   info(`📦 PartialBatchDeploy: ${partialBatchDeploy ? "enabled" : "disabled"}`);
   info(`📊 Batch Size: ${batchSize}`);
+  if (deployOnlyBondConfig) info(`⚡ Mode: Bond-only (Equity, Bond variants, Loan, LoansPortfolio skipped)`);
   info("---");
 
   try {
@@ -52,6 +54,7 @@ async function main() {
       useTimeTravel,
       partialBatchDeploy,
       batchSize,
+      deployOnlyBondConfig,
       saveOutput: true,
     });
 

--- a/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/cli/deploySystemWithNewBlr.ts
@@ -35,6 +35,8 @@ async function main() {
   const partialBatchDeploy = parseBooleanEnv("PARTIAL_BATCH_DEPLOY", false);
   const batchSize = parseIntEnv("BATCH_SIZE", DEFAULT_BATCH_SIZE);
   const deployOnlyBondConfig = parseBooleanEnv("DEPLOY_ONLY_BOND_CONFIG", false);
+  const parallelFacetDeployment = parseBooleanEnv("PARALLEL_FACET_DEPLOYMENT", false);
+  const concurrency = parseIntEnv("FACET_DEPLOY_CONCURRENCY", 20);
 
   info(`🚀 Starting ATS deployment`);
   info("---");
@@ -43,6 +45,8 @@ async function main() {
   info(`📦 PartialBatchDeploy: ${partialBatchDeploy ? "enabled" : "disabled"}`);
   info(`📊 Batch Size: ${batchSize}`);
   if (deployOnlyBondConfig) info(`⚡ Mode: Bond-only (Equity, Bond variants, Loan, LoansPortfolio skipped)`);
+  if (parallelFacetDeployment)
+    info(`⚡ Parallel facet deployment: concurrency=${concurrency} (retries off, checkpoint skipped)`);
   info("---");
 
   try {
@@ -55,6 +59,8 @@ async function main() {
       partialBatchDeploy,
       batchSize,
       deployOnlyBondConfig,
+      parallelFacetDeployment,
+      concurrency,
       saveOutput: true,
     });
 

--- a/packages/ats/contracts/scripts/domain/constants.ts
+++ b/packages/ats/contracts/scripts/domain/constants.ts
@@ -360,4 +360,4 @@ export const CURRENCIES = {
   JPY: "0x4a5059", // Japanese Yen
 } as const;
 
-export const FACET_REGISTRATION_BATCH_SIZE = 10;
+export const FACET_REGISTRATION_BATCH_SIZE = 20;

--- a/packages/ats/contracts/scripts/domain/constants.ts
+++ b/packages/ats/contracts/scripts/domain/constants.ts
@@ -360,4 +360,4 @@ export const CURRENCIES = {
   JPY: "0x4a5059", // Japanese Yen
 } as const;
 
-export const FACET_REGISTRATION_BATCH_SIZE = 20;
+export const FACET_REGISTRATION_BATCH_SIZE = 10;

--- a/packages/ats/contracts/scripts/infrastructure/networkConfig.ts
+++ b/packages/ats/contracts/scripts/infrastructure/networkConfig.ts
@@ -42,10 +42,8 @@ export type KnownNetwork = (typeof KNOWN_NETWORKS)[keyof typeof KNOWN_NETWORKS];
  * Different from NetworkConfig in types.ts which contains RPC endpoints.
  */
 export interface DeploymentConfig {
-  /** Number of block confirmations to wait for contract deployments (waitForDeployment + deployTx.wait) */
+  /** Number of block confirmations to wait for contract transactions */
   confirmations: number;
-  /** Number of block confirmations to wait for contract call transactions (e.g. createBatchConfiguration) */
-  txConfirmations: number;
   /** Transaction timeout in milliseconds */
   timeout: number;
   /** Retry configuration for failed transactions */
@@ -69,7 +67,6 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   hardhat: {
     confirmations: 0,
-    txConfirmations: 0,
     timeout: 10_000, // 10 seconds (should never timeout)
     retryOptions: {
       maxRetries: 0,
@@ -83,13 +80,11 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
   /**
    * Local Network (Hardhat node, Anvil, Ganache, Besu dev mode)
    * - External local node but still instant transactions
-   * - confirmations: 0 — waitForDeployment() handles the actual wait for contract deploys
-   * - txConfirmations: 1 — tx.wait(0) returns null on external nodes, causing false failures
+   * - confirmations: 1 — wait for 1 minted block
    * - Verification disabled for maximum deployment speed
    */
   local: {
-    confirmations: 0,
-    txConfirmations: 1,
+    confirmations: 1,
     timeout: 10_000, // 10 seconds (should rarely timeout)
     retryOptions: {
       maxRetries: 0,
@@ -105,10 +100,10 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    * - Local Hedera/Hiero node running in Docker
    * - Similar to local but with Hedera-specific behavior
    * - Minimal confirmations with light retry logic
+   * - confirmations: 1 — wait for 1 minted block
    */
   "hedera-local": {
     confirmations: 1,
-    txConfirmations: 1,
     timeout: 60_000, // 60 seconds
     retryOptions: {
       maxRetries: 1, // 2 total attempts
@@ -128,7 +123,6 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-previewnet": {
     confirmations: 2,
-    txConfirmations: 2,
     timeout: 120_000, // 2 minutes per attempt
     retryOptions: {
       maxRetries: 2, // 3 total attempts
@@ -148,7 +142,6 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-testnet": {
     confirmations: 2,
-    txConfirmations: 2,
     timeout: 120_000, // 2 minutes per attempt
     retryOptions: {
       maxRetries: 2, // 2 retries after initial attempt (3 total attempts)
@@ -168,7 +161,6 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-mainnet": {
     confirmations: 3,
-    txConfirmations: 3,
     timeout: 60_000 * 5, // 5 minutes per attempt
     retryOptions: {
       maxRetries: 3, // 3 retries after initial attempt (4 total attempts)

--- a/packages/ats/contracts/scripts/infrastructure/networkConfig.ts
+++ b/packages/ats/contracts/scripts/infrastructure/networkConfig.ts
@@ -42,8 +42,10 @@ export type KnownNetwork = (typeof KNOWN_NETWORKS)[keyof typeof KNOWN_NETWORKS];
  * Different from NetworkConfig in types.ts which contains RPC endpoints.
  */
 export interface DeploymentConfig {
-  /** Number of block confirmations to wait for */
+  /** Number of block confirmations to wait for contract deployments (waitForDeployment + deployTx.wait) */
   confirmations: number;
+  /** Number of block confirmations to wait for contract call transactions (e.g. createBatchConfiguration) */
+  txConfirmations: number;
   /** Transaction timeout in milliseconds */
   timeout: number;
   /** Retry configuration for failed transactions */
@@ -67,6 +69,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   hardhat: {
     confirmations: 0,
+    txConfirmations: 0,
     timeout: 10_000, // 10 seconds (should never timeout)
     retryOptions: {
       maxRetries: 0,
@@ -78,13 +81,15 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
   },
 
   /**
-   * Local Network (Hardhat node, Anvil, Ganache)
+   * Local Network (Hardhat node, Anvil, Ganache, Besu dev mode)
    * - External local node but still instant transactions
-   * - Minimal confirmations, no retries needed
-   * - Verification enabled for closer to production behavior
+   * - confirmations: 0 — waitForDeployment() handles the actual wait for contract deploys
+   * - txConfirmations: 1 — tx.wait(0) returns null on external nodes, causing false failures
+   * - Verification disabled for maximum deployment speed
    */
   local: {
-    confirmations: 1,
+    confirmations: 0,
+    txConfirmations: 1,
     timeout: 10_000, // 10 seconds (should rarely timeout)
     retryOptions: {
       maxRetries: 0,
@@ -92,7 +97,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
       maxDelay: 0,
       logRetries: false,
     },
-    verifyDeployment: true,
+    verifyDeployment: false,
   },
 
   /**
@@ -103,6 +108,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-local": {
     confirmations: 1,
+    txConfirmations: 1,
     timeout: 60_000, // 60 seconds
     retryOptions: {
       maxRetries: 1, // 2 total attempts
@@ -122,6 +128,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-previewnet": {
     confirmations: 2,
+    txConfirmations: 2,
     timeout: 120_000, // 2 minutes per attempt
     retryOptions: {
       maxRetries: 2, // 3 total attempts
@@ -141,6 +148,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-testnet": {
     confirmations: 2,
+    txConfirmations: 2,
     timeout: 120_000, // 2 minutes per attempt
     retryOptions: {
       maxRetries: 2, // 2 retries after initial attempt (3 total attempts)
@@ -160,6 +168,7 @@ export const DEPLOYMENT_CONFIGS: Record<string, DeploymentConfig> = {
    */
   "hedera-mainnet": {
     confirmations: 3,
+    txConfirmations: 3,
     timeout: 60_000 * 5, // 5 minutes per attempt
     retryOptions: {
       maxRetries: 3, // 3 retries after initial attempt (4 total attempts)

--- a/packages/ats/contracts/scripts/infrastructure/operations/blrConfigurations.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/blrConfigurations.ts
@@ -418,6 +418,29 @@ export async function createBatchConfiguration(
       versions = latestVersions.map((v) => Number(v));
     }
 
+    // Recover from a partial batch left by a previous crashed run.
+    // A non-zero batchVersion is detectable by querying version currentVersion+1:
+    // _resolveVersion returns explicit versions as-is, so if any facets were
+    // written to that slot the array will be non-empty.
+    const currentVersion = await getConfigurationVersion(blrContract, configurationId);
+    const ongoingBatchFacets = await blrContract.getFacetIdsByConfigurationIdAndVersion(
+      configurationId,
+      currentVersion + 1,
+      0,
+      1,
+    );
+    if (ongoingBatchFacets.length > 0) {
+      const { warn, GAS_LIMIT } = await import("@scripts/infrastructure");
+      warn(
+        `Detected uncommitted batch for config ${configurationId} (version ${currentVersion + 1}). ` +
+          `Cancelling to allow clean retry...`,
+      );
+      await blrContract.cancelBatchConfiguration(configurationId, {
+        gasLimit: GAS_LIMIT.businessLogicResolver.createConfiguration,
+        ...hederaGasOverrides(),
+      });
+    }
+
     info("Processing facets in batches", {
       facetCount: facetIdList.length,
       partialBatchDeploy,

--- a/packages/ats/contracts/scripts/infrastructure/operations/blrConfigurations.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/blrConfigurations.ts
@@ -43,6 +43,8 @@ import {
   waitForTransaction,
   isInstantMiningNetwork,
   hederaGasOverrides,
+  warn,
+  GAS_LIMIT,
 } from "@scripts/infrastructure";
 
 // Types imported from centralized types module
@@ -275,6 +277,17 @@ export async function sendBatchConfiguration(
     info(`  Transaction: ${receipt.hash}`);
     info(`  Block: ${receipt.blockNumber}`);
   } catch (err) {
+    // Re-simulate with staticCall to surface the decoded revert reason (custom
+    // errors, panic codes, etc.) that status=0 receipts don't carry.
+    try {
+      await blrContract.createBatchConfiguration.staticCall(configId, configurations, finalBatch, {
+        gasLimit: gasLimit || GAS_LIMIT.businessLogicResolver.createConfiguration,
+      });
+    } catch (simErr) {
+      const simMessage = simErr instanceof Error ? simErr.message : String(simErr);
+      logError(`Failed to send batch configuration: ${simMessage}`);
+      throw new Error(simMessage);
+    }
     const errorMessage = extractRevertReason(err);
     logError(`Failed to send batch configuration: ${errorMessage}`);
     throw err;
@@ -418,6 +431,18 @@ export async function createBatchConfiguration(
       versions = latestVersions.map((v) => Number(v));
     }
 
+    // Guard: version=0 means the facet was never registered in the BLR.
+    // Passing version=0 to createBatchConfiguration causes an arithmetic
+    // underflow panic in _resolveBusinessLogicByVersion (_version - 1 on
+    // uint256(0)), which surfaces only as a silent status=0 revert.
+    const unregistered = facetKeys.filter((_, i) => versions[i] === 0);
+    if (unregistered.length > 0) {
+      throw new Error(
+        `Cannot create configuration: ${unregistered.length} facet(s) have version 0 ` +
+          `(not registered in BLR): ${unregistered.map((f) => f.facetName).join(", ")}`,
+      );
+    }
+
     // Recover from a partial batch left by a previous crashed run.
     // A non-zero batchVersion is detectable by querying version currentVersion+1:
     // _resolveVersion returns explicit versions as-is, so if any facets were
@@ -430,15 +455,15 @@ export async function createBatchConfiguration(
       1,
     );
     if (ongoingBatchFacets.length > 0) {
-      const { warn, GAS_LIMIT } = await import("@scripts/infrastructure");
       warn(
         `Detected uncommitted batch for config ${configurationId} (version ${currentVersion + 1}). ` +
           `Cancelling to allow clean retry...`,
       );
-      await blrContract.cancelBatchConfiguration(configurationId, {
+      const cancelTx = await blrContract.cancelBatchConfiguration(configurationId, {
         gasLimit: GAS_LIMIT.businessLogicResolver.createConfiguration,
         ...hederaGasOverrides(),
       });
+      await cancelTx.wait(confirmations);
     }
 
     info("Processing facets in batches", {

--- a/packages/ats/contracts/scripts/infrastructure/operations/facetDeployment.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/facetDeployment.ts
@@ -54,6 +54,26 @@ export interface DeployFacetsOptions {
    * Default: true
    */
   verifyDeployment?: boolean;
+
+  /**
+   * Submit facet deploy transactions in parallel chunks instead of one-at-a-time.
+   * Safe because the underlying signer is wrapped in ethers' NonceManager, which
+   * assigns sequential nonces synchronously. Intended for pipeline use against
+   * nodes the caller does not control (e.g. Besu) where waiting per-block
+   * dominates wall time.
+   *
+   * Forces `enableRetry = false` internally — retries combined with NonceManager
+   * leave permanent nonce gaps on failure.
+   *
+   * Default: false
+   */
+  parallelFacetDeployment?: boolean;
+
+  /**
+   * Max in-flight deploy transactions when `parallelFacetDeployment` is on.
+   * Default: 20
+   */
+  concurrency?: number;
 }
 
 /**
@@ -122,10 +142,16 @@ export async function deployFacets(
   const {
     confirmations = 2, // Increased default for Hedera reliability
     overrides = {},
-    enableRetry = true,
+    enableRetry: rawEnableRetry = true,
     retryOptions = {},
     verifyDeployment = true,
+    parallelFacetDeployment = false,
+    concurrency = 20,
   } = options;
+
+  // Retries with NonceManager leave permanent nonce gaps on failure when txs
+  // are in-flight in parallel — fail fast instead.
+  const enableRetry = parallelFacetDeployment ? false : rawEnableRetry;
 
   section("Deploying Facets");
 
@@ -148,66 +174,101 @@ export async function deployFacets(
 
     info(`Total facets to deploy: ${facetNames.length}`);
 
-    // Deploy each facet using its factory
-    for (let i = 0; i < facetNames.length; i++) {
-      const facetName = facetNames[i];
+    const deployOne = async (facetName: string): Promise<DeploymentResult> => {
       const factory = facetFactories[facetName];
-      const progress = `[${i + 1}/${facetNames.length}]`;
-
-      try {
-        info(`${progress} Deploying ${facetName}...`);
-
-        // Deploy function that can be retried
-        // Convert Result pattern to Exception pattern for retry mechanism
-        const deployFacet = async (): Promise<DeploymentResult> => {
-          const result = await deployContract(factory, {
-            confirmations,
-            overrides,
-            verifyDeployment,
-          });
-
-          // Throw exception if deployment failed so retryTransaction can catch and retry
-          if (!result.success) {
-            throw new Error(result.error || "Deployment failed");
-          }
-
-          return result;
-        };
-
-        // Deploy with retry if enabled
-        // retryTransaction will catch exceptions and retry up to maxRetries times
-        const result = enableRetry ? await retryTransaction(deployFacet, retryOptions) : await deployFacet();
-
-        // If we get here, deployment succeeded (either first try or after retries)
-        if (result.success && result.address) {
-          deployed.set(facetName, result);
-          info(`${progress} ✓ ${facetName} deployed successfully`);
-        } else {
-          // This should not happen now, but keep for safety
-          failed.set(facetName, result.error || "Unknown error");
-        }
-      } catch (err) {
-        // Deployment failed after all retry attempts
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        failed.set(facetName, `Failed after retries: ${errorMessage}`);
+      const result = await deployContract(factory, {
+        confirmations,
+        overrides,
+        verifyDeployment,
+      });
+      if (!result.success) {
+        throw new Error(result.error || "Deployment failed");
       }
+      return result;
+    };
 
-      // Testing hook: Allow intentional failure for checkpoint testing
-      // Returns partial result instead of throwing to preserve deployed facets in checkpoint
-      // Supports both:
-      // - Legacy FAIL_AT_FACET=N (numeric)
-      // - New CHECKPOINT_TEST_FAIL_AT=facet:N or facet:FacetName
-      if (shouldFailAtFacet(deployed.size, facetName)) {
-        const testError = createTestFailureMessage("facet", deployed.size, facetName);
-        failed.set("__TEST_FAILURE__", testError);
-        warn(testError);
-        // Return partial result - workflow will save checkpoint before failing
-        return {
-          success: false,
-          deployed,
-          failed,
-          skipped,
-        };
+    if (parallelFacetDeployment) {
+      info(`Parallel mode: concurrency=${concurrency}, retries disabled`);
+
+      // Process in chunks so we cap in-flight txs without losing the
+      // NonceManager's sequential-nonce guarantee within each chunk.
+      for (let chunkStart = 0; chunkStart < facetNames.length; chunkStart += concurrency) {
+        const chunk = facetNames.slice(chunkStart, chunkStart + concurrency);
+        const settled = await Promise.allSettled(chunk.map((name) => deployOne(name)));
+
+        settled.forEach((outcome, i) => {
+          const facetName = chunk[i];
+          const globalIndex = chunkStart + i;
+          if (outcome.status === "fulfilled" && outcome.value.address) {
+            deployed.set(facetName, outcome.value);
+            info(`[${globalIndex + 1}/${facetNames.length}] ✓ ${facetName}`);
+          } else {
+            const reason =
+              outcome.status === "rejected" ? String(outcome.reason?.message ?? outcome.reason) : "Unknown error";
+            failed.set(facetName, reason);
+            warn(`[${globalIndex + 1}/${facetNames.length}] ✗ ${facetName}: ${reason}`);
+          }
+        });
+
+        // Testing hook: failure injection keyed on input position rather than
+        // dynamic deployed.size so behavior is deterministic under parallelism.
+        for (let i = 0; i < chunk.length; i++) {
+          const facetName = chunk[i];
+          const globalIndex = chunkStart + i;
+          if (shouldFailAtFacet(globalIndex + 1, facetName)) {
+            const testError = createTestFailureMessage("facet", globalIndex + 1, facetName);
+            failed.set("__TEST_FAILURE__", testError);
+            warn(testError);
+            return { success: false, deployed, failed, skipped };
+          }
+        }
+      }
+    } else {
+      // Deploy each facet using its factory
+      for (let i = 0; i < facetNames.length; i++) {
+        const facetName = facetNames[i];
+        const progress = `[${i + 1}/${facetNames.length}]`;
+
+        try {
+          info(`${progress} Deploying ${facetName}...`);
+
+          // Deploy with retry if enabled
+          // retryTransaction will catch exceptions and retry up to maxRetries times
+          const result = enableRetry
+            ? await retryTransaction(() => deployOne(facetName), retryOptions)
+            : await deployOne(facetName);
+
+          // If we get here, deployment succeeded (either first try or after retries)
+          if (result.success && result.address) {
+            deployed.set(facetName, result);
+            info(`${progress} ✓ ${facetName} deployed successfully`);
+          } else {
+            // This should not happen now, but keep for safety
+            failed.set(facetName, result.error || "Unknown error");
+          }
+        } catch (err) {
+          // Deployment failed after all retry attempts
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          failed.set(facetName, `Failed after retries: ${errorMessage}`);
+        }
+
+        // Testing hook: Allow intentional failure for checkpoint testing
+        // Returns partial result instead of throwing to preserve deployed facets in checkpoint
+        // Supports both:
+        // - Legacy FAIL_AT_FACET=N (numeric)
+        // - New CHECKPOINT_TEST_FAIL_AT=facet:N or facet:FacetName
+        if (shouldFailAtFacet(deployed.size, facetName)) {
+          const testError = createTestFailureMessage("facet", deployed.size, facetName);
+          failed.set("__TEST_FAILURE__", testError);
+          warn(testError);
+          // Return partial result - workflow will save checkpoint before failing
+          return {
+            success: false,
+            deployed,
+            failed,
+            skipped,
+          };
+        }
       }
     }
 

--- a/packages/ats/contracts/scripts/infrastructure/operations/facetDeployment.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/facetDeployment.ts
@@ -9,7 +9,7 @@
  * @module core/operations/facetDeployment
  */
 
-import { ContractFactory, Overrides } from "ethers";
+import { ContractFactory, NonceManager, Overrides, Signer } from "ethers";
 import {
   DeploymentResult,
   deployContract,
@@ -57,10 +57,10 @@ export interface DeployFacetsOptions {
 
   /**
    * Submit facet deploy transactions in parallel chunks instead of one-at-a-time.
-   * Safe because the underlying signer is wrapped in ethers' NonceManager, which
-   * assigns sequential nonces synchronously. Intended for pipeline use against
-   * nodes the caller does not control (e.g. Besu) where waiting per-block
-   * dominates wall time.
+   * The signer is automatically wrapped in ethers' NonceManager (if not already),
+   * so parallel deploys get sequential nonces without races. Intended for pipeline
+   * use against nodes the caller does not control (e.g. Besu) where waiting
+   * per-block dominates wall time.
    *
    * Forces `enableRetry = false` internally — retries combined with NonceManager
    * leave permanent nonce gaps on failure.
@@ -188,6 +188,16 @@ export async function deployFacets(
     };
 
     if (parallelFacetDeployment) {
+      // Ensure all factories share one NonceManager so parallel deploys get
+      // sequential nonces without racing getTransactionCount('pending').
+      const firstRunner = facetFactories[facetNames[0]]?.runner;
+      if (firstRunner && !(firstRunner instanceof NonceManager)) {
+        const nonceMgr = new NonceManager(firstRunner as Signer);
+        facetFactories = Object.fromEntries(
+          Object.entries(facetFactories).map(([name, factory]) => [name, factory.connect(nonceMgr)]),
+        );
+      }
+
       info(`Parallel mode: concurrency=${concurrency}, retries disabled`);
 
       // Process in chunks so we cap in-flight txs without losing the

--- a/packages/ats/contracts/scripts/infrastructure/operations/registerFacets.ts
+++ b/packages/ats/contracts/scripts/infrastructure/operations/registerFacets.ts
@@ -54,6 +54,14 @@ export interface RegisterFacetsOptions {
 
   /** Whether to verify facets exist before registration */
   verify?: boolean;
+
+  /**
+   * Number of facets registered per transaction. Defaults to
+   * {@link FACET_REGISTRATION_BATCH_SIZE} (10). Raise to 20 for nodes that
+   * can fit larger registration batches under their block gas limit (e.g.
+   * Besu) — typically combined with parallel facet deployment.
+   */
+  batchSize?: number;
 }
 
 /**
@@ -130,7 +138,7 @@ export async function registerFacets(
   blr: BusinessLogicResolver,
   options: RegisterFacetsOptions,
 ): Promise<RegisterFacetsResult> {
-  const { facets, overrides = {}, verify = true } = options;
+  const { facets, overrides = {}, verify = true, batchSize = FACET_REGISTRATION_BATCH_SIZE } = options;
 
   // Get BLR address from contract instance
   const blrAddress = await blr.getAddress();
@@ -214,16 +222,13 @@ export async function registerFacets(
       businessLogicName: facet.name,
     }));
 
-    const iterations = Math.ceil(businessLogics.length / FACET_REGISTRATION_BATCH_SIZE);
+    const iterations = Math.ceil(businessLogics.length / batchSize);
     const transactionHashes = [];
     const blockNumbers = [];
     const transactionGas = [];
 
     for (let i = 0; i < iterations; i++) {
-      const businessLogicsSlice = businessLogics.slice(
-        i * FACET_REGISTRATION_BATCH_SIZE,
-        (i + 1) * FACET_REGISTRATION_BATCH_SIZE,
-      );
+      const businessLogicsSlice = businessLogics.slice(i * batchSize, (i + 1) * batchSize);
 
       // Skip empty slices (defensive guard)
       if (businessLogicsSlice.length === 0) {

--- a/packages/ats/contracts/scripts/infrastructure/types/blr.ts
+++ b/packages/ats/contracts/scripts/infrastructure/types/blr.ts
@@ -75,7 +75,8 @@ export type ConfigurationError =
   | "INVALID_CONFIG_ID"
   | "FACET_NOT_FOUND"
   | "TRANSACTION_FAILED"
-  | "EVENT_PARSE_FAILED";
+  | "EVENT_PARSE_FAILED"
+  | "SKIPPED";
 
 /**
  * Configuration data returned on success.

--- a/packages/ats/contracts/scripts/infrastructure/types/checkpoint.ts
+++ b/packages/ats/contracts/scripts/infrastructure/types/checkpoint.ts
@@ -272,6 +272,10 @@ export interface DeploymentCheckpoint {
     partialBatchDeploy?: boolean;
     /** Number of facets per batch (default: DEFAULT_BATCH_SIZE) */
     batchSize?: number;
+    /** Submit facet deploys in parallel chunks (pipeline mode) */
+    parallelFacetDeployment?: boolean;
+    /** Max in-flight facet deploys when `parallelFacetDeployment` is on */
+    concurrency?: number;
 
     // existingBlr workflow options
     deployFacets?: boolean;

--- a/packages/ats/contracts/scripts/infrastructure/types/core.ts
+++ b/packages/ats/contracts/scripts/infrastructure/types/core.ts
@@ -686,6 +686,7 @@ export interface FacetMetadata {
   address: string;
   contractId?: string;
   key: string;
+  version?: number;
 }
 
 /**

--- a/packages/ats/contracts/scripts/infrastructure/utils/transaction.ts
+++ b/packages/ats/contracts/scripts/infrastructure/utils/transaction.ts
@@ -61,20 +61,21 @@ export async function waitForTransaction(
   confirmations: number = DEFAULT_TRANSACTION_CONFIRMATIONS,
   timeout: number = DEFAULT_TRANSACTION_TIMEOUT,
 ): Promise<ContractTransactionReceipt> {
+  let receipt: ContractTransactionReceipt | null;
   try {
-    const receipt = await Promise.race([
+    receipt = await Promise.race([
       tx.wait(confirmations),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Transaction timeout")), timeout)),
     ]);
-
-    if (!receipt || receipt.status === 0) {
-      throw new Error("Transaction failed");
-    }
-
-    return receipt;
   } catch (error) {
     throw new Error(`Transaction failed: ${error instanceof Error ? error.message : String(error)}`);
   }
+
+  if (!receipt || receipt.status === 0) {
+    throw new Error(`Transaction reverted (status=0): ${tx.hash}`);
+  }
+
+  return receipt;
 }
 
 /**

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithExistingBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithExistingBlr.ts
@@ -16,7 +16,7 @@
  */
 
 import { Signer, ContractFactory } from "ethers";
-import { ProxyAdmin__factory } from "@contract-types";
+import { ProxyAdmin__factory, IStaticFunctionSelectors__factory } from "@contract-types";
 import {
   deployFacets,
   registerFacets,
@@ -180,11 +180,8 @@ export interface DeploySystemWithExistingBlrOptions extends ResumeOptions {
   /** Existing ProxyAdmin address (optional, will deploy new one if not provided) */
   existingProxyAdminAddress?: string;
 
-  /** Number of confirmations for contract deployments — facets, factory (default: from network config) */
+  /** Number of confirmations for contract transactions */
   confirmations?: number;
-
-  /** Number of confirmations for contract call transactions — registerFacets, createConfiguration (default: from network config) */
-  txConfirmations?: number;
 
   /** Enable retry mechanism for failed deployments (default: from network config) */
   enableRetry?: boolean;
@@ -256,7 +253,6 @@ export async function deploySystemWithExistingBlr(
     batchSize, // Use defaults from createEquityConfiguration/createBondConfiguration if not provided
     existingProxyAdminAddress,
     confirmations = networkConfig.confirmations,
-    txConfirmations = networkConfig.txConfirmations,
     enableRetry = networkConfig.retryOptions.maxRetries > 0,
     verifyDeployment = networkConfig.verifyDeployment,
     resumeFrom,
@@ -280,7 +276,6 @@ export async function deploySystemWithExistingBlr(
   info(`🔷 BLR Address: ${blrAddress}`);
   info(`🔄 TimeTravel: ${useTimeTravel ? "Enabled" : "Disabled"}`);
   info(`⏱️  Confirmations (deploy): ${confirmations}`);
-  info(`⏱️  Confirmations (tx): ${txConfirmations}`);
   info(`🔁 Retry: ${enableRetry ? "Enabled" : "Disabled"}`);
   info(`✅ Verification: ${verifyDeployment ? "Enabled" : "Disabled"}`);
   info("═".repeat(60));
@@ -619,7 +614,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            txConfirmations,
+            confirmations,
           );
 
           if (!equityConfig.success) {
@@ -663,7 +658,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            txConfirmations,
+            confirmations,
           );
 
           if (!bondConfig.success) {
@@ -704,7 +699,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            txConfirmations,
+            confirmations,
           );
 
           if (!bondFixedRateConfig.success) {
@@ -747,7 +742,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            txConfirmations,
+            confirmations,
           );
 
           if (!bondKpiLinkedRateConfig.success) {
@@ -801,7 +796,7 @@ export async function deploySystemWithExistingBlr(
           useTimeTravel,
           false,
           batchSize,
-          txConfirmations,
+          confirmations,
         );
 
         if (!factoryConfig.success) {
@@ -934,8 +929,13 @@ export async function deploySystemWithExistingBlr(
                   ? bondKpiLinkedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
                   : undefined;
 
+                const staticFunctionSelectors = IStaticFunctionSelectors__factory.connect(facetAddress, signer);
                 const key =
-                  equityFacet?.key || bondFacet?.key || bondFixedRateFacet?.key || bondKpiLinkedRateFacet?.key || "";
+                  equityFacet?.key ||
+                  bondFacet?.key ||
+                  bondFixedRateFacet?.key ||
+                  bondKpiLinkedRateFacet?.key ||
+                  (await staticFunctionSelectors.getStaticResolverKey());
 
                 return { facetName, facetAddress, key };
               }),

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithExistingBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithExistingBlr.ts
@@ -180,8 +180,11 @@ export interface DeploySystemWithExistingBlrOptions extends ResumeOptions {
   /** Existing ProxyAdmin address (optional, will deploy new one if not provided) */
   existingProxyAdminAddress?: string;
 
-  /** Number of confirmations to wait for each deployment (default: from network config) */
+  /** Number of confirmations for contract deployments — facets, factory (default: from network config) */
   confirmations?: number;
+
+  /** Number of confirmations for contract call transactions — registerFacets, createConfiguration (default: from network config) */
+  txConfirmations?: number;
 
   /** Enable retry mechanism for failed deployments (default: from network config) */
   enableRetry?: boolean;
@@ -253,6 +256,7 @@ export async function deploySystemWithExistingBlr(
     batchSize, // Use defaults from createEquityConfiguration/createBondConfiguration if not provided
     existingProxyAdminAddress,
     confirmations = networkConfig.confirmations,
+    txConfirmations = networkConfig.txConfirmations,
     enableRetry = networkConfig.retryOptions.maxRetries > 0,
     verifyDeployment = networkConfig.verifyDeployment,
     resumeFrom,
@@ -275,7 +279,8 @@ export async function deploySystemWithExistingBlr(
   info(`👤 Deployer: ${deployer}`);
   info(`🔷 BLR Address: ${blrAddress}`);
   info(`🔄 TimeTravel: ${useTimeTravel ? "Enabled" : "Disabled"}`);
-  info(`⏱️  Confirmations: ${confirmations}`);
+  info(`⏱️  Confirmations (deploy): ${confirmations}`);
+  info(`⏱️  Confirmations (tx): ${txConfirmations}`);
   info(`🔁 Retry: ${enableRetry ? "Enabled" : "Disabled"}`);
   info(`✅ Verification: ${verifyDeployment ? "Enabled" : "Disabled"}`);
   info("═".repeat(60));
@@ -614,7 +619,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            confirmations,
+            txConfirmations,
           );
 
           if (!equityConfig.success) {
@@ -658,7 +663,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            confirmations,
+            txConfirmations,
           );
 
           if (!bondConfig.success) {
@@ -699,7 +704,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            confirmations,
+            txConfirmations,
           );
 
           if (!bondFixedRateConfig.success) {
@@ -742,7 +747,7 @@ export async function deploySystemWithExistingBlr(
             useTimeTravel,
             false,
             batchSize,
-            confirmations,
+            txConfirmations,
           );
 
           if (!bondKpiLinkedRateConfig.success) {
@@ -796,7 +801,7 @@ export async function deploySystemWithExistingBlr(
           useTimeTravel,
           false,
           batchSize,
-          confirmations,
+          txConfirmations,
         );
 
         if (!factoryConfig.success) {
@@ -909,32 +914,51 @@ export async function deploySystemWithExistingBlr(
       },
 
       facets: facetsResult
-        ? await Promise.all(
-            Array.from(facetsResult.deployed.entries()).map(async ([facetName, deploymentResult]) => {
-              const facetAddress = deploymentResult.address!;
+        ? await (async () => {
+            // Pass 1: resolve keys in parallel
+            const facetEntries = await Promise.all(
+              Array.from(facetsResult.deployed.entries()).map(async ([facetName, deploymentResult]) => {
+                const facetAddress = deploymentResult.address!;
 
-              // Find matching key from config
-              const equityFacet = equityConfig?.success
-                ? equityConfig.data.facetKeys.find((ef) => ef.address === facetAddress)
-                : undefined;
-              const bondFacet = bondConfig?.success
-                ? bondConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-                : undefined;
-              const bondFixedRateFacet = bondFixedRateConfig?.success
-                ? bondFixedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-                : undefined;
-              const bondKpiLinkedRateFacet = bondKpiLinkedRateConfig?.success
-                ? bondKpiLinkedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-                : undefined;
+                // Find matching key from config
+                const equityFacet = equityConfig?.success
+                  ? equityConfig.data.facetKeys.find((ef) => ef.address === facetAddress)
+                  : undefined;
+                const bondFacet = bondConfig?.success
+                  ? bondConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+                  : undefined;
+                const bondFixedRateFacet = bondFixedRateConfig?.success
+                  ? bondFixedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+                  : undefined;
+                const bondKpiLinkedRateFacet = bondKpiLinkedRateConfig?.success
+                  ? bondKpiLinkedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+                  : undefined;
 
-              return {
+                const key =
+                  equityFacet?.key || bondFacet?.key || bondFixedRateFacet?.key || bondKpiLinkedRateFacet?.key || "";
+
+                return { facetName, facetAddress, key };
+              }),
+            );
+
+            // Pass 2: single batch call for all known keys (skip empty keys — not in any config)
+            const blrForVersions = BusinessLogicResolver__factory.connect(blrAddress, signer);
+            const knownKeys = facetEntries.map((e) => e.key).filter((k) => k !== "");
+            const uniqueKeys = [...new Set(knownKeys)];
+            const rawVersions = uniqueKeys.length > 0 ? await blrForVersions.getLatestVersions(uniqueKeys) : [];
+            const versionByKey = new Map(uniqueKeys.map((k, i) => [k, Number(rawVersions[i])]));
+
+            // Pass 3: assemble final output with contractId (parallel) and version
+            return Promise.all(
+              facetEntries.map(async ({ facetName, facetAddress, key }) => ({
                 name: facetName,
                 address: facetAddress,
                 contractId: await getContractId(facetAddress),
-                key: equityFacet?.key || bondFacet?.key || bondFixedRateFacet?.key || bondKpiLinkedRateFacet?.key || "",
-              };
-            }),
-          )
+                key,
+                version: versionByKey.get(key) ?? 0,
+              })),
+            );
+          })()
         : [],
 
       configurations: {

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
@@ -43,6 +43,7 @@ import {
   toConfigurationData,
   convertCheckpointFacets,
   isSuccess,
+  err,
   resolveCheckpointForResume,
 } from "@scripts/infrastructure";
 import {
@@ -91,14 +92,25 @@ export interface DeploySystemWithNewBlrOptions extends ResumeOptions {
   /** Path to save deployment output (default: deployments/{network}/{network}-deployment-{timestamp}.json) */
   outputPath?: string;
 
-  /** Number of confirmations to wait for each deployment (default: 2 for Hedera reliability) */
+  /** Number of confirmations for contract deployments — facets, BLR, factory (default: from network config) */
   confirmations?: number;
+
+  /** Number of confirmations for contract call transactions — registerFacets, createConfiguration (default: from network config) */
+  txConfirmations?: number;
 
   /** Enable retry mechanism for failed deployments (default: true) */
   enableRetry?: boolean;
 
   /** Enable post-deployment bytecode verification (default: true) */
   verifyDeployment?: boolean;
+
+  /**
+   * When true, only the Bond configuration is created.
+   * Equity, Bond Fixed Rate, Bond KPI Linked Rate, Bond Sustainability Performance Target Rate,
+   * Loan, and Loans Portfolio configurations are skipped.
+   * Factory configuration and deployment are unaffected.
+   */
+  deployOnlyBondConfig?: boolean;
 }
 
 /**
@@ -161,8 +173,10 @@ export async function deploySystemWithNewBlr(
     batchSize = DEFAULT_BATCH_SIZE,
     outputPath,
     confirmations = networkConfig.confirmations,
+    txConfirmations = networkConfig.txConfirmations,
     enableRetry = networkConfig.retryOptions.maxRetries > 0,
     verifyDeployment = networkConfig.verifyDeployment,
+    deployOnlyBondConfig = false,
     resumeFrom,
     autoResume = true,
     ignoreCheckpoint = false,
@@ -179,9 +193,11 @@ export async function deploySystemWithNewBlr(
   info(`📡 Network: ${network}`);
   info(`👤 Deployer: ${deployer}`);
   info(`🔄 TimeTravel: ${useTimeTravel ? "Enabled" : "Disabled"}`);
-  info(`⏱️  Confirmations: ${confirmations}`);
+  info(`⏱️  Confirmations (deploy): ${confirmations}`);
+  info(`⏱️  Confirmations (tx): ${txConfirmations}`);
   info(`🔁 Retry: ${enableRetry ? "Enabled" : "Disabled"}`);
   info(`✅ Verification: ${verifyDeployment ? "Enabled" : "Disabled"}`);
+  if (deployOnlyBondConfig) info(`⚡ Mode: Bond-only (Equity, Bond variants, Loan, LoansPortfolio skipped)`);
   info("═".repeat(60));
 
   // Initialize checkpoint manager
@@ -224,8 +240,10 @@ export async function deploySystemWithNewBlr(
       options: {
         useTimeTravel,
         confirmations,
+        txConfirmations,
         enableRetry,
         verifyDeployment,
+        deployOnlyBondConfig,
         saveOutput,
         outputPath,
         partialBatchDeploy,
@@ -555,6 +573,11 @@ export async function deploySystemWithNewBlr(
 
       // Use converter to reconstruct full ConfigurationData from checkpoint
       equityConfig = toConfigurationData(equityConfigData);
+    } else if (deployOnlyBondConfig) {
+      info(`\n⏭️  Step 5/${totalSteps}: Equity configuration skipped (deployOnlyBondConfig)`);
+      equityConfig = err("SKIPPED", "Skipped by deployOnlyBondConfig");
+      checkpoint.currentStep = 4;
+      await checkpointManager.saveCheckpoint(checkpoint);
     } else {
       info(`\n💼 Step 5/${totalSteps}: Creating Equity configuration...`);
 
@@ -564,7 +587,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!equityConfig.success) {
@@ -615,7 +638,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!bondConfig.success) {
@@ -627,7 +650,8 @@ export async function deploySystemWithNewBlr(
       info(`✅ Bond Facets: ${bondConfig.data.facetKeys.length}`);
 
       // Save checkpoint
-      checkpoint.steps.configurations!.bond = {
+      if (!checkpoint.steps.configurations) checkpoint.steps.configurations = {};
+      checkpoint.steps.configurations.bond = {
         configId: bondConfig.data.configurationId,
         version: bondConfig.data.version,
         facetCount: bondConfig.data.facetKeys.length,
@@ -654,6 +678,11 @@ export async function deploySystemWithNewBlr(
 
       // Use converter to reconstruct full ConfigurationData from checkpoint
       bondFixedRateConfig = toConfigurationData(bondFixedRateConfigData);
+    } else if (deployOnlyBondConfig) {
+      info(`\n⏭️  Step 7/${totalSteps}: Bond FixedRate configuration skipped (deployOnlyBondConfig)`);
+      bondFixedRateConfig = err("SKIPPED", "Skipped by deployOnlyBondConfig");
+      checkpoint.currentStep = 6;
+      await checkpointManager.saveCheckpoint(checkpoint);
     } else {
       info(`\n🏦 Step 7/${totalSteps}: Creating Bond FixedRate configuration...`);
 
@@ -663,7 +692,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!bondFixedRateConfig.success) {
@@ -704,6 +733,11 @@ export async function deploySystemWithNewBlr(
 
       // Use converter to reconstruct full ConfigurationData from checkpoint
       bondKpiLinkedRateConfig = toConfigurationData(bondKpiLinkedRateConfigData);
+    } else if (deployOnlyBondConfig) {
+      info(`\n⏭️  Step 8/${totalSteps}: Bond KpiLinkedRate configuration skipped (deployOnlyBondConfig)`);
+      bondKpiLinkedRateConfig = err("SKIPPED", "Skipped by deployOnlyBondConfig");
+      checkpoint.currentStep = 7;
+      await checkpointManager.saveCheckpoint(checkpoint);
     } else {
       info(`\n🏦 Step 8/${totalSteps}: Creating Bond KpiLinkedRate configuration...`);
 
@@ -713,7 +747,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!bondKpiLinkedRateConfig.success) {
@@ -753,6 +787,11 @@ export async function deploySystemWithNewBlr(
       info(`✅ Loan Facets: ${loanConfigData.facetCount}`);
 
       loanConfig = toConfigurationData(loanConfigData);
+    } else if (deployOnlyBondConfig) {
+      info(`\n⏭️  Step 10/${totalSteps}: Loan configuration skipped (deployOnlyBondConfig)`);
+      loanConfig = err("SKIPPED", "Skipped by deployOnlyBondConfig");
+      checkpoint.currentStep = 9;
+      await checkpointManager.saveCheckpoint(checkpoint);
     } else {
       info(`\n📄 Step 9/${totalSteps}: Creating Loan configuration...`);
 
@@ -762,7 +801,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!loanConfig.success) {
@@ -801,6 +840,11 @@ export async function deploySystemWithNewBlr(
       info(`✅ Loans Portfolio Facets: ${loansPortfolioConfigData.facetCount}`);
 
       loansPortfolioConfig = toConfigurationData(loansPortfolioConfigData);
+    } else if (deployOnlyBondConfig) {
+      info(`\n⏭️  Step 11/${totalSteps}: Loans Portfolio configuration skipped (deployOnlyBondConfig)`);
+      loansPortfolioConfig = err("SKIPPED", "Skipped by deployOnlyBondConfig");
+      checkpoint.currentStep = 10;
+      await checkpointManager.saveCheckpoint(checkpoint);
     } else {
       info(`\n📄 Step 10/${totalSteps}: Creating Loans Portfolio configuration...`);
 
@@ -810,7 +854,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!loansPortfolioConfig.success) {
@@ -961,7 +1005,7 @@ export async function deploySystemWithNewBlr(
           facetVersions,
           partialBatchDeploy,
           batchSize,
-          confirmations,
+          txConfirmations,
         );
 
         if (!result.success) {
@@ -1023,7 +1067,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        confirmations,
+        txConfirmations,
       );
 
       if (!factoryConfig.success) {
@@ -1125,37 +1169,53 @@ export async function deploySystemWithNewBlr(
         },
       },
 
-      facets: await Promise.all(
-        Array.from(facetsResult.deployed.entries()).map(async ([facetName, deploymentResult]) => {
-          const facetAddress = deploymentResult.address!;
+      facets: await (async () => {
+        // Pass 1: resolve keys in parallel (some require an on-chain call)
+        const facetEntries = await Promise.all(
+          Array.from(facetsResult.deployed.entries()).map(async ([facetName, deploymentResult]) => {
+            const facetAddress = deploymentResult.address!;
 
-          // Find matching key from config (use type guard to access .data property)
-          const equityFacet = isSuccess(equityConfig)
-            ? equityConfig.data.facetKeys.find((ef) => ef.address === facetAddress)
-            : undefined;
-          const bondFacet = isSuccess(bondConfig)
-            ? bondConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-            : undefined;
-          const bondFixedRateFacet = isSuccess(bondFixedRateConfig)
-            ? bondFixedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-            : undefined;
-          const bondKpiLinkedRateFacet = isSuccess(bondKpiLinkedRateConfig)
-            ? bondKpiLinkedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
-            : undefined;
-          const staticFunctionSelectors = IStaticFunctionSelectors__factory.connect(facetAddress, signer);
-          return {
-            name: facetName,
-            address: facetAddress,
-            contractId: await getContractId(facetAddress),
-            key:
+            // Find matching key from config (use type guard to access .data property)
+            const equityFacet = isSuccess(equityConfig)
+              ? equityConfig.data.facetKeys.find((ef) => ef.address === facetAddress)
+              : undefined;
+            const bondFacet = isSuccess(bondConfig)
+              ? bondConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+              : undefined;
+            const bondFixedRateFacet = isSuccess(bondFixedRateConfig)
+              ? bondFixedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+              : undefined;
+            const bondKpiLinkedRateFacet = isSuccess(bondKpiLinkedRateConfig)
+              ? bondKpiLinkedRateConfig.data.facetKeys.find((bf) => bf.address === facetAddress)
+              : undefined;
+            const staticFunctionSelectors = IStaticFunctionSelectors__factory.connect(facetAddress, signer);
+            const key =
               equityFacet?.key ||
               bondFacet?.key ||
               bondFixedRateFacet?.key ||
               bondKpiLinkedRateFacet?.key ||
-              (await staticFunctionSelectors.getStaticResolverKey()),
-          };
-        }),
-      ),
+              (await staticFunctionSelectors.getStaticResolverKey());
+
+            return { facetName, facetAddress, key };
+          }),
+        );
+
+        // Pass 2: single batch call to fetch all registered versions from BLR
+        const allKeys = facetEntries.map((e) => e.key);
+        const rawVersions = await blrContract.getLatestVersions(allKeys);
+        const versionByKey = new Map(allKeys.map((k, i) => [k, Number(rawVersions[i])]));
+
+        // Pass 3: assemble final output with contractId (parallel) and version
+        return Promise.all(
+          facetEntries.map(async ({ facetName, facetAddress, key }) => ({
+            name: facetName,
+            address: facetAddress,
+            contractId: await getContractId(facetAddress),
+            key,
+            version: versionByKey.get(key) ?? 0,
+          })),
+        );
+      })(),
 
       configurations: {
         equity: isSuccess(equityConfig)
@@ -1215,7 +1275,8 @@ export async function deploySystemWithNewBlr(
       summary: {
         totalContracts: 3, // ProxyAdmin, BLR, Factory
         totalFacets: facetsResult.deployed.size,
-        totalConfigurations: 7, // Equity + Bond + BondFixedRate + BondKpiLinkedRate + Loan + LoansPortfolio + Factory
+        // Bond + Factory (bond-only) or Equity + Bond + BondFixedRate + BondKpiLinkedRate + Loan + LoansPortfolio + Factory
+        totalConfigurations: deployOnlyBondConfig ? 2 : 7,
         deploymentTime: Date.now() - startTime,
         gasUsed: totalGasUsed.toString(),
         success: true,

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
@@ -111,6 +111,20 @@ export interface DeploySystemWithNewBlrOptions extends ResumeOptions {
    * Factory configuration and deployment are unaffected.
    */
   deployOnlyBondConfig?: boolean;
+
+  /**
+   * Submit facet deploy transactions in parallel chunks (size: `concurrency`).
+   * Intended for pipeline runs against external nodes (e.g. Besu) where the
+   * per-block wait dominates wall time.
+   *
+   * Implies `ignoreCheckpoint = true`: a fresh deployment per pipeline run, no
+   * filesystem checkpoint I/O. Also disables facet-deploy retries internally
+   * (NonceManager + retries leave permanent nonce gaps on failure).
+   */
+  parallelFacetDeployment?: boolean;
+
+  /** Max in-flight deploy transactions when `parallelFacetDeployment` is on. Default: 20 */
+  concurrency?: number;
 }
 
 /**
@@ -177,12 +191,18 @@ export async function deploySystemWithNewBlr(
     enableRetry = networkConfig.retryOptions.maxRetries > 0,
     verifyDeployment = networkConfig.verifyDeployment,
     deployOnlyBondConfig = false,
+    parallelFacetDeployment = false,
+    concurrency = 20,
     resumeFrom,
     autoResume = true,
-    ignoreCheckpoint = false,
+    ignoreCheckpoint: rawIgnoreCheckpoint = false,
     deleteOnSuccess = false,
     checkpointDir,
   } = options;
+
+  // Parallel facet deployment is meant for pipeline use — skip checkpoint I/O
+  // so each run is a clean slate.
+  const ignoreCheckpoint = parallelFacetDeployment ? true : rawIgnoreCheckpoint;
 
   const startTime = Date.now();
   const deployer = await signer.getAddress();
@@ -198,6 +218,8 @@ export async function deploySystemWithNewBlr(
   info(`🔁 Retry: ${enableRetry ? "Enabled" : "Disabled"}`);
   info(`✅ Verification: ${verifyDeployment ? "Enabled" : "Disabled"}`);
   if (deployOnlyBondConfig) info(`⚡ Mode: Bond-only (Equity, Bond variants, Loan, LoansPortfolio skipped)`);
+  if (parallelFacetDeployment)
+    info(`⚡ Parallel facet deployment: concurrency=${concurrency} (retries off, checkpoint skipped)`);
   info("═".repeat(60));
 
   // Initialize checkpoint manager
@@ -248,6 +270,8 @@ export async function deploySystemWithNewBlr(
         outputPath,
         partialBatchDeploy,
         batchSize,
+        parallelFacetDeployment,
+        concurrency,
       },
     });
 
@@ -434,6 +458,8 @@ export async function deploySystemWithNewBlr(
           enableRetry,
           verifyDeployment,
           overrides: facetOverrides,
+          parallelFacetDeployment,
+          concurrency,
         });
 
         // Always save deployed facets to checkpoint (even if some failed)

--- a/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
+++ b/packages/ats/contracts/scripts/workflows/deploySystemWithNewBlr.ts
@@ -92,11 +92,8 @@ export interface DeploySystemWithNewBlrOptions extends ResumeOptions {
   /** Path to save deployment output (default: deployments/{network}/{network}-deployment-{timestamp}.json) */
   outputPath?: string;
 
-  /** Number of confirmations for contract deployments — facets, BLR, factory (default: from network config) */
+  /** Number of confirmations for contract transactions */
   confirmations?: number;
-
-  /** Number of confirmations for contract call transactions — registerFacets, createConfiguration (default: from network config) */
-  txConfirmations?: number;
 
   /** Enable retry mechanism for failed deployments (default: true) */
   enableRetry?: boolean;
@@ -187,7 +184,6 @@ export async function deploySystemWithNewBlr(
     batchSize = DEFAULT_BATCH_SIZE,
     outputPath,
     confirmations = networkConfig.confirmations,
-    txConfirmations = networkConfig.txConfirmations,
     enableRetry = networkConfig.retryOptions.maxRetries > 0,
     verifyDeployment = networkConfig.verifyDeployment,
     deployOnlyBondConfig = false,
@@ -214,12 +210,12 @@ export async function deploySystemWithNewBlr(
   info(`👤 Deployer: ${deployer}`);
   info(`🔄 TimeTravel: ${useTimeTravel ? "Enabled" : "Disabled"}`);
   info(`⏱️  Confirmations (deploy): ${confirmations}`);
-  info(`⏱️  Confirmations (tx): ${txConfirmations}`);
   info(`🔁 Retry: ${enableRetry ? "Enabled" : "Disabled"}`);
   info(`✅ Verification: ${verifyDeployment ? "Enabled" : "Disabled"}`);
   if (deployOnlyBondConfig) info(`⚡ Mode: Bond-only (Equity, Bond variants, Loan, LoansPortfolio skipped)`);
-  if (parallelFacetDeployment)
+  if (parallelFacetDeployment) {
     info(`⚡ Parallel facet deployment: concurrency=${concurrency} (retries off, checkpoint skipped)`);
+  }
   info("═".repeat(60));
 
   // Initialize checkpoint manager
@@ -262,7 +258,6 @@ export async function deploySystemWithNewBlr(
       options: {
         useTimeTravel,
         confirmations,
-        txConfirmations,
         enableRetry,
         verifyDeployment,
         deployOnlyBondConfig,
@@ -555,6 +550,9 @@ export async function deploySystemWithNewBlr(
 
       const registerResult = await registerFacets(blrContract, {
         facets: facetsToRegister,
+        // Besu/parallel-deploy nodes can fit a larger registration batch under
+        // their block gas limit; raise from the default 10 to 25
+        ...(parallelFacetDeployment ? { batchSize: 25 } : {}),
       });
 
       if (!registerResult.success) {
@@ -613,7 +611,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!equityConfig.success) {
@@ -664,7 +662,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!bondConfig.success) {
@@ -718,7 +716,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!bondFixedRateConfig.success) {
@@ -773,7 +771,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!bondKpiLinkedRateConfig.success) {
@@ -827,7 +825,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!loanConfig.success) {
@@ -880,7 +878,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!loansPortfolioConfig.success) {
@@ -1031,7 +1029,7 @@ export async function deploySystemWithNewBlr(
           facetVersions,
           partialBatchDeploy,
           batchSize,
-          txConfirmations,
+          confirmations,
         );
 
         if (!result.success) {
@@ -1093,7 +1091,7 @@ export async function deploySystemWithNewBlr(
         useTimeTravel,
         partialBatchDeploy,
         batchSize,
-        txConfirmations,
+        confirmations,
       );
 
       if (!factoryConfig.success) {
@@ -1238,7 +1236,7 @@ export async function deploySystemWithNewBlr(
             address: facetAddress,
             contractId: await getContractId(facetAddress),
             key,
-            version: versionByKey.get(key) ?? 0,
+            version: versionByKey.get(key) ?? undefined,
           })),
         );
       })(),

--- a/packages/ats/contracts/scripts/workflows/upgradeConfigurations.ts
+++ b/packages/ats/contracts/scripts/workflows/upgradeConfigurations.ts
@@ -928,18 +928,31 @@ async function buildOutput(
     return network.toLowerCase().includes("hedera") ? await fetchHederaContractId(network, address) : undefined;
   };
 
-  // Build facets array with contract IDs
-  const facets = await Promise.all(
-    Array.from(checkpoint.steps.facets?.entries() || []).map(async ([facetName, facetData]) => {
-      const facetAddress = facetData.address;
+  // Build facets array with contract IDs and registered versions
+  const facetEntries = Array.from(checkpoint.steps.facets?.entries() || []).map(([facetName, facetData]) => {
+    const baseName = facetName.replace(/TimeTravel$/, "");
+    let key = "";
+    try {
+      key = atsRegistry.getFacetDefinition(baseName)?.resolverKey?.value ?? "";
+    } catch {
+      // Facet not in registry — leave key empty
+    }
+    return { facetName, facetAddress: facetData.address, key };
+  });
 
-      return {
-        name: facetName,
-        address: facetAddress,
-        contractId: await getContractId(facetAddress),
-        key: "", // Key information not needed in output
-      };
-    }),
+  const blrForVersions = BusinessLogicResolver__factory.connect(blrAddress, ctx.signer);
+  const uniqueKeys = [...new Set(facetEntries.map((e) => e.key).filter((k) => k !== ""))];
+  const rawVersions = uniqueKeys.length > 0 ? await blrForVersions.getLatestVersions(uniqueKeys) : [];
+  const versionByKey = new Map(uniqueKeys.map((k, i) => [k, Number(rawVersions[i])]));
+
+  const facets = await Promise.all(
+    facetEntries.map(async ({ facetName, facetAddress, key }) => ({
+      name: facetName,
+      address: facetAddress,
+      contractId: await getContractId(facetAddress),
+      key,
+      version: versionByKey.get(key) ?? 0,
+    })),
   );
 
   const output: UpgradeConfigurationsOutput = {

--- a/packages/ats/contracts/test/scripts/unit/infrastructure/networkConfig.test.ts
+++ b/packages/ats/contracts/test/scripts/unit/infrastructure/networkConfig.test.ts
@@ -37,10 +37,10 @@ describe("Network Configuration", () => {
     it("should return local config for local network", () => {
       const config = getDeploymentConfig("local");
 
-      expect(config.confirmations).to.equal(1);
+      expect(config.confirmations).to.equal(0);
       expect(config.timeout).to.equal(10_000);
       expect(config.retryOptions.maxRetries).to.equal(0);
-      expect(config.verifyDeployment).to.be.true;
+      expect(config.verifyDeployment).to.be.false;
     });
 
     it("should return hedera-local config", () => {

--- a/packages/ats/contracts/test/scripts/unit/infrastructure/networkConfig.test.ts
+++ b/packages/ats/contracts/test/scripts/unit/infrastructure/networkConfig.test.ts
@@ -37,7 +37,7 @@ describe("Network Configuration", () => {
     it("should return local config for local network", () => {
       const config = getDeploymentConfig("local");
 
-      expect(config.confirmations).to.equal(0);
+      expect(config.confirmations).to.equal(1);
       expect(config.timeout).to.equal(10_000);
       expect(config.retryOptions.maxRetries).to.equal(0);
       expect(config.verifyDeployment).to.be.false;


### PR DESCRIPTION
## Description

Add facets' version to deployment output file and flag to deploy only a Bond Configuration and a flag to deploy facets in parallel.


## Type of change

- [ ] Bug fix 🐞
- [X] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

	•	Automated tests – npm run test
	•	Manual verification – deploy in besu network and hedera testnet
	•	Local GitHub Actions – act pull_request

**Node version**:

- [ ] 20
- [ ] 22
- [X] 24

## Checklist

- [X] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [X] **Linters** - No New Warnings ⚠️
- [X] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [X] No reduction of **Coverage** ✅
