### PR TITLE
fix: [FIND-031] Zero-Amount Clearing/Hold/Lock Operations Enable Storage Pollution

### DIFF
--- a/.changeset/fix-find-031-zero-amount-clearing.md
+++ b/.changeset/fix-find-031-zero-amount-clearing.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-031: clearing transfer and redeem creation entry points did not validate that `_amount > 0`, allowing zero-amount operations that increment storage counters and pollute on-chain state with no economic effect. Add `InvalidClearingAmount` custom error to `IClearingTypes`, add `checkNonZeroClearingAmount` helper to `ClearingStorageWrapper`, and call it as the first guard in `ClearingOps.clearingTransferCreation` and `ClearingOps.clearingRedeemCreation`.

--- a/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
@@ -567,4 +567,8 @@ library ClearingStorageWrapper {
                 destination: data.holdTo
             });
     }
+
+    function checkNonZeroClearingAmount(uint256 _amount) internal pure {
+        if (_amount == 0) revert IClearingTypes.InvalidClearingAmount();
+    }
 }

--- a/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
@@ -568,6 +568,10 @@ library ClearingStorageWrapper {
             });
     }
 
+    /**
+     * @notice Reverts with `InvalidClearingAmount` if the supplied token amount is zero.
+     * @param _amount Token quantity to validate before registering a clearing operation.
+     */
     function checkNonZeroClearingAmount(uint256 _amount) internal pure {
         if (_amount == 0) revert IClearingTypes.InvalidClearingAmount();
     }

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
@@ -65,6 +65,8 @@ library ClearingOps {
         bytes memory _operatorData,
         ThirdPartyType _thirdPartyType
     ) external returns (bool success_, uint256 clearingId_) {
+        ClearingStorageWrapper.checkNonZeroClearingAmount(_amount);
+
         bytes32 partition = _clearingOperation.partition;
 
         clearingId_ = ClearingStorageWrapper.increaseClearingId(
@@ -142,6 +144,8 @@ library ClearingOps {
         bytes memory _operatorData,
         ThirdPartyType _thirdPartyType
     ) external returns (bool success_, uint256 clearingId_) {
+        ClearingStorageWrapper.checkNonZeroClearingAmount(_amount);
+
         bytes32 partition = _clearingOperation.partition;
 
         clearingId_ = ClearingStorageWrapper.increaseClearingId(

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTypes.sol
@@ -4,7 +4,19 @@ pragma solidity >=0.8.0 <0.9.0;
 import { ThirdPartyType } from "../../../domain/asset/types/ThirdPartyType.sol";
 import { IHoldTypes } from "../hold/IHoldTypes.sol";
 
-// Hold struct definition for event parameter (mirrors IHold.Hold to avoid circular dependency)
+/**
+ * @notice Snapshot of a hold used as an event parameter in clearing operations.
+ * @dev Mirrors `IHoldTypes.Hold` to avoid a circular import dependency between the
+ *      clearing and hold facet modules. Keep fields in sync with `IHoldTypes.Hold`
+ *      whenever that struct changes.
+ * @param amount              Token quantity locked by the hold.
+ * @param expirationTimestamp Unix timestamp at which the hold expires and may be
+ *                            reclaimed by the token holder.
+ * @param escrow              Address of the escrow agent that may execute or release
+ *                            the hold.
+ * @param to                  Intended recipient of the tokens if the hold is executed.
+ * @param data                Arbitrary caller-supplied data attached to the hold.
+ */
 struct ClearingHold {
     uint256 amount;
     uint256 expirationTimestamp;
@@ -13,37 +25,105 @@ struct ClearingHold {
     bytes data;
 }
 
+/**
+ * @title IClearingTypes
+ * @author Asset Tokenization Studio Team
+ * @notice Defines all shared types — enums, structs, events, and errors — for the
+ *         clearing mechanism of the Asset Tokenization Studio.
+ * @dev Clearing is a settlement layer that places token operations (transfers, redeems,
+ *      and hold creations) in a pending state before final execution. A designated
+ *      operator may then approve, cancel, or reclaim each pending operation within
+ *      its expiration window.
+ *
+ *      This interface is inherited by every facet that participates in the clearing
+ *      flow so that a single, consistent set of types and events is emitted across
+ *      the diamond.
+ */
 interface IClearingTypes {
+    // -------------------------------------------------------------------------
+    // Enums
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Classifies the token operation that has been placed under clearing.
+     * @dev Used as a discriminant when inspecting a stored `ClearingOperation` to
+     *      determine which concrete data struct (transfer / redeem / hold-creation)
+     *      accompanies it.
+     */
     enum ClearingOperationType {
         Transfer,
         Redeem,
         HoldCreation
     }
 
+    /**
+     * @notice Represents the action that an authorised party may perform on a pending
+     *         clearing operation.
+     * @dev `Approve` finalises the underlying token operation; `Cancel` voids it while
+     *      within the expiration window; `Reclaim` voids it after the window has elapsed.
+     */
     enum ClearingActionType {
         Approve,
         Cancel,
         Reclaim
     }
 
+    // -------------------------------------------------------------------------
+    // Structs
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Lightweight summary of a clearing operation, used to avoid loading the
+     *         full operation storage slot when only basic details are needed.
+     * @param expirationTimestamp Unix timestamp after which the operation may be reclaimed.
+     * @param amount              Token quantity covered by the operation.
+     * @param destination         Address that will receive the tokens upon approval.
+     */
     struct ClearingOperationBasicInfo {
         uint256 expirationTimestamp;
         uint256 amount;
         address destination;
     }
 
+    /**
+     * @notice Core descriptor of a pending clearing operation submitted by a token holder.
+     * @param partition           ERC-1400 partition the tokens belong to.
+     * @param expirationTimestamp Unix timestamp after which the operation expires.
+     * @param data                Arbitrary caller-supplied data forwarded to the final
+     *                            token operation on approval.
+     */
     struct ClearingOperation {
         bytes32 partition;
         uint256 expirationTimestamp;
         bytes data;
     }
 
+    /**
+     * @notice Extends `ClearingOperation` with the originating address and optional
+     *         operator data, used when a third party submits the operation on behalf of
+     *         the token holder.
+     * @param clearingOperation Base operation descriptor.
+     * @param from              Address of the token holder on whose behalf the operation
+     *                          is submitted.
+     * @param operatorData      Arbitrary data provided by the calling operator, forwarded
+     *                          to the underlying token operation on approval.
+     */
     struct ClearingOperationFrom {
         ClearingOperation clearingOperation;
         address from;
         bytes operatorData;
     }
 
+    /**
+     * @notice EIP-712 protected variant of a clearing operation, enabling gasless or
+     *         meta-transaction submission via an off-chain signature.
+     * @dev `deadline` and `nonce` enforce replay protection. The signing party must be
+     *      the token holder identified by `from` inside the embedded `clearingOperation`.
+     * @param clearingOperation Base operation descriptor.
+     * @param from              Token holder that signed the permit.
+     * @param deadline          Unix timestamp before which the signature remains valid.
+     * @param nonce             Holder's current nonce; incremented on each successful use.
+     */
     struct ProtectedClearingOperation {
         ClearingOperation clearingOperation;
         address from;
@@ -51,6 +131,15 @@ interface IClearingTypes {
         uint256 nonce;
     }
 
+    /**
+     * @notice Uniquely identifies a stored clearing operation across all operation types
+     *         and partitions.
+     * @param clearingOperationType Discriminant indicating the kind of pending operation.
+     * @param partition             ERC-1400 partition the tokens belong to.
+     * @param tokenHolder           Address of the holder whose tokens are pending.
+     * @param clearingId            Sequential identifier assigned when the operation was
+     *                              registered.
+     */
     struct ClearingOperationIdentifier {
         ClearingOperationType clearingOperationType;
         bytes32 partition;
@@ -58,6 +147,15 @@ interface IClearingTypes {
         uint256 clearingId;
     }
 
+    /**
+     * @notice Full payload for a clearing-guarded token transfer.
+     * @param amount              Token quantity to transfer upon approval.
+     * @param expirationTimestamp Unix timestamp after which the operation expires.
+     * @param destination         Recipient address for the transferred tokens.
+     * @param data                Caller-supplied data forwarded to the transfer call.
+     * @param operatorData        Data provided by the operator, forwarded on approval.
+     * @param operatorType        Classification of the submitting third party.
+     */
     struct ClearingTransferData {
         uint256 amount;
         uint256 expirationTimestamp;
@@ -67,6 +165,14 @@ interface IClearingTypes {
         ThirdPartyType operatorType;
     }
 
+    /**
+     * @notice Full payload for a clearing-guarded token redemption.
+     * @param amount              Token quantity to redeem upon approval.
+     * @param expirationTimestamp Unix timestamp after which the operation expires.
+     * @param data                Caller-supplied data forwarded to the redeem call.
+     * @param operatorData        Data provided by the operator, forwarded on approval.
+     * @param operatorType        Classification of the submitting third party.
+     */
     struct ClearingRedeemData {
         uint256 amount;
         uint256 expirationTimestamp;
@@ -75,6 +181,22 @@ interface IClearingTypes {
         ThirdPartyType operatorType;
     }
 
+    /**
+     * @notice Full payload for a clearing-guarded hold creation.
+     * @dev On approval the hold is created with the embedded hold parameters; the
+     *      clearing expiration and the hold expiration are independent timestamps.
+     * @param amount                  Token quantity to place under hold upon approval.
+     * @param expirationTimestamp     Unix timestamp after which the clearing operation
+     *                                expires and may be reclaimed.
+     * @param data                    Caller-supplied data forwarded to the hold-creation
+     *                                call.
+     * @param holdEscrow              Escrow agent for the resulting hold.
+     * @param holdExpirationTimestamp Unix timestamp at which the resulting hold expires.
+     * @param holdTo                  Intended recipient if the hold is later executed.
+     * @param holdData                Arbitrary data attached to the hold itself.
+     * @param operatorData            Data provided by the operator, forwarded on approval.
+     * @param operatorType            Classification of the submitting third party.
+     */
     struct ClearingHoldCreationData {
         uint256 amount;
         uint256 expirationTimestamp;
@@ -87,6 +209,22 @@ interface IClearingTypes {
         ThirdPartyType operatorType;
     }
 
+    // -------------------------------------------------------------------------
+    // Events — operation registration
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Emitted when a token holder registers a clearing-guarded redemption on a
+     *         partition.
+     * @param operator       Address that submitted the clearing operation.
+     * @param tokenHolder    Address of the holder whose tokens are pending redemption.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending redemption.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedRedeemByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -98,6 +236,19 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when a clearing-guarded redemption is registered on behalf of a
+     *         token holder via `redeemFromByPartition`.
+     * @param operator       Address that submitted the clearing operation on behalf of
+     *                       the holder.
+     * @param tokenHolder    Address of the holder whose tokens are pending redemption.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending redemption.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedRedeemFromByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -109,6 +260,18 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when an operator registers a clearing-guarded redemption using
+     *         operator-level permissions.
+     * @param operator       Authorised operator that submitted the clearing operation.
+     * @param tokenHolder    Address of the holder whose tokens are pending redemption.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending redemption.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedOperatorRedeemByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -120,6 +283,20 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when a token holder registers a clearing-guarded hold creation on
+     *         a partition.
+     * @param operator       Address that submitted the clearing operation.
+     * @param tokenHolder    Address of the holder whose tokens are to be placed under
+     *                       hold.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param hold           Hold parameters that will be used on approval.
+     * @param expirationDate Unix timestamp after which the clearing operation may be
+     *                       reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedHoldByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -131,6 +308,21 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when a clearing-guarded hold creation is registered on behalf of a
+     *         token holder via `holdFromByPartition`.
+     * @param operator       Address that submitted the clearing operation on behalf of
+     *                       the holder.
+     * @param tokenHolder    Address of the holder whose tokens are to be placed under
+     *                       hold.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param hold           Hold parameters that will be used on approval.
+     * @param expirationDate Unix timestamp after which the clearing operation may be
+     *                       reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedHoldFromByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -142,6 +334,19 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when a token holder registers a clearing-guarded transfer on a
+     *         partition.
+     * @param operator       Address that submitted the clearing operation.
+     * @param tokenHolder    Address of the holder whose tokens are pending transfer.
+     * @param to             Intended recipient of the tokens upon approval.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending transfer.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedTransferByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -154,6 +359,20 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when a clearing-guarded transfer is registered on behalf of a
+     *         token holder via `transferFromByPartition`.
+     * @param operator       Address that submitted the clearing operation on behalf of
+     *                       the holder.
+     * @param tokenHolder    Address of the holder whose tokens are pending transfer.
+     * @param to             Intended recipient of the tokens upon approval.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending transfer.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedTransferFromByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -166,6 +385,19 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    /**
+     * @notice Emitted when an operator registers a clearing-guarded transfer using
+     *         operator-level permissions.
+     * @param operator       Authorised operator that submitted the clearing operation.
+     * @param tokenHolder    Address of the holder whose tokens are pending transfer.
+     * @param to             Intended recipient of the tokens upon approval.
+     * @param partition      ERC-1400 partition the tokens belong to.
+     * @param clearingId     Sequential identifier for the registered operation.
+     * @param amount         Token quantity pending transfer.
+     * @param expirationDate Unix timestamp after which the operation may be reclaimed.
+     * @param data           Caller-supplied data attached to the operation.
+     * @param operatorData   Data provided by the operator.
+     */
     event ClearedOperatorTransferByPartition(
         address indexed operator,
         address indexed tokenHolder,
@@ -178,9 +410,36 @@ interface IClearingTypes {
         bytes operatorData
     );
 
+    // -------------------------------------------------------------------------
+    // Events — feature lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Emitted when the clearing feature is enabled for the token.
+     * @param operator Address of the administrator that activated clearing.
+     */
     event ClearingActivated(address indexed operator);
+
+    /**
+     * @notice Emitted when the clearing feature is disabled for the token.
+     * @param operator Address of the administrator that deactivated clearing.
+     */
     event ClearingDeactivated(address indexed operator);
 
+    // -------------------------------------------------------------------------
+    // Events — operation lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Emitted when a pending clearing operation is approved and the underlying
+     *         token operation is executed.
+     * @param operator              Address that approved the operation.
+     * @param tokenHolder           Address of the holder whose tokens were pending.
+     * @param partition             ERC-1400 partition the tokens belong to.
+     * @param clearingId            Sequential identifier of the approved operation.
+     * @param clearingOperationType Discriminant indicating the kind of operation approved.
+     * @param operationData         Encoded data forwarded to the underlying token call.
+     */
     event ClearingOperationApproved(
         address indexed operator,
         address indexed tokenHolder,
@@ -190,6 +449,14 @@ interface IClearingTypes {
         bytes operationData
     );
 
+    /**
+     * @notice Emitted when a pending clearing operation is cancelled before it expires.
+     * @param operator              Address that cancelled the operation.
+     * @param tokenHolder           Address of the holder whose tokens were pending.
+     * @param partition             ERC-1400 partition the tokens belong to.
+     * @param clearingId            Sequential identifier of the cancelled operation.
+     * @param clearingOperationType Discriminant indicating the kind of operation cancelled.
+     */
     event ClearingOperationCanceled(
         address indexed operator,
         address indexed tokenHolder,
@@ -198,6 +465,15 @@ interface IClearingTypes {
         ClearingOperationType clearingOperationType
     );
 
+    /**
+     * @notice Emitted when an expired clearing operation is reclaimed, releasing the
+     *         locked tokens back to the holder.
+     * @param operator              Address that reclaimed the operation.
+     * @param tokenHolder           Address of the holder whose tokens were pending.
+     * @param partition             ERC-1400 partition the tokens belong to.
+     * @param clearingId            Sequential identifier of the reclaimed operation.
+     * @param clearingOperationType Discriminant indicating the kind of operation reclaimed.
+     */
     event ClearingOperationReclaimed(
         address indexed operator,
         address indexed tokenHolder,
@@ -206,10 +482,43 @@ interface IClearingTypes {
         ClearingOperationType clearingOperationType
     );
 
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Thrown when the supplied `clearingId` does not correspond to an existing
+     *         or active clearing operation for the given holder and partition.
+     */
     error WrongClearingId();
+
+    /**
+     * @notice Thrown when a clearing-dependent operation is attempted while the clearing
+     *         feature is disabled on the token.
+     */
     error ClearingIsDisabled();
+
+    /**
+     * @notice Thrown when an administration action requires clearing to be inactive but
+     *         it is currently enabled.
+     */
     error ClearingIsActivated();
+
+    /**
+     * @notice Thrown when an action requires the clearing operation to still be within
+     *         its validity window but its expiration timestamp has already passed.
+     */
     error ExpirationDateReached();
+
+    /**
+     * @notice Thrown when an action requires the clearing operation to have expired
+     *         (e.g., a reclaim attempt) but the expiration timestamp has not yet passed.
+     */
     error ExpirationDateNotReached();
+
+    /**
+     * @notice Thrown when the token amount supplied for a clearing operation is invalid
+     *         (e.g., zero or exceeding the holder's available balance).
+     */
     error InvalidClearingAmount();
 }

--- a/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTypes.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/clearing/IClearingTypes.sol
@@ -211,4 +211,5 @@ interface IClearingTypes {
     error ClearingIsActivated();
     error ExpirationDateReached();
     error ExpirationDateNotReached();
+    error InvalidClearingAmount();
 }

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-18T14:40:43.633Z
+ * Generated: 2026-05-18T14:56:17.955Z
  * Facets: 120
  * Infrastructure: 2
  *
@@ -2551,6 +2551,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
+      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
@@ -2802,6 +2807,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
+      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "WrongClearingId",
@@ -2990,6 +3000,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "ExpirationDateReached",
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
+      },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -9816,6 +9831,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
+      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionNotAllowedInSinglePartitionMode",
@@ -10036,6 +10056,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "ExpirationDateReached",
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
+      },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
@@ -11063,6 +11088,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
       },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
+      },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "PartitionsAreUnProtected",
@@ -11274,6 +11304,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         name: "ExpirationDateReached",
         signature: { full: "error ExpirationDateReached()", canonical: "ExpirationDateReached()" },
         selector: "0x5ea0e3b0",
+      },
+      {
+        name: "InvalidClearingAmount",
+        signature: { full: "error InvalidClearingAmount()", canonical: "InvalidClearingAmount()" },
+        selector: "0x9437a6a1",
       },
       { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {

--- a/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.data.ts
@@ -10,7 +10,7 @@
  *
  * Import from '@scripts/domain' instead of this file directly.
  *
- * Generated: 2026-05-18T14:56:17.955Z
+ * Generated: 2026-05-19T07:17:18.918Z
  * Facets: 120
  * Infrastructure: 2
  *
@@ -3658,6 +3658,11 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
           canonical: "AccountHasNoRole(address,bytes32)",
         },
         selector: "0xa1180aad",
+      },
+      {
+        name: "ClearingIsActivated",
+        signature: { full: "error ClearingIsActivated()", canonical: "ClearingIsActivated()" },
+        selector: "0x5b2e3086",
       },
       {
         name: "Deactivated",
@@ -11839,6 +11844,7 @@ export const FACET_REGISTRY: Record<string, FacetDefinition> = {
         },
         selector: "0xbf84f4ec",
       },
+      { name: "IsPaused", signature: { full: "error IsPaused()", canonical: "IsPaused()" }, selector: "0x1309a563" },
       {
         name: "NotAllowedInMultiPartitionMode",
         signature: { full: "error NotAllowedInMultiPartitionMode()", canonical: "NotAllowedInMultiPartitionMode()" },

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -223,6 +223,17 @@ describe("ClearingByPartitionFacet Tests", () => {
         asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
       ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
     });
+
+    it("GIVEN amount is zero WHEN clearingRedeemByPartition THEN reverts with InvalidClearingAmount", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, 0),
+      ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
+    });
   });
 
   // ─── clearingRedeemFromByPartition ────────────────────────────────────────
@@ -437,6 +448,21 @@ describe("ClearingByPartitionFacet Tests", () => {
         asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
       ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
     });
+
+    it("GIVEN amount is zero WHEN clearingRedeemFromByPartition THEN reverts with InvalidClearingAmount", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, 0),
+      ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
+    });
   });
 
   // ─── clearingTransferByPartition ──────────────────────────────────────────
@@ -586,6 +612,17 @@ describe("ClearingByPartitionFacet Tests", () => {
       await expect(
         asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
       ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+
+    it("GIVEN amount is zero WHEN clearingTransferByPartition THEN reverts with InvalidClearingAmount", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_A).clearingTransferByPartition(clearingOperation, 0, signer_B.address),
+      ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
     });
   });
 
@@ -836,6 +873,21 @@ describe("ClearingByPartitionFacet Tests", () => {
       await expect(
         asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
       ).to.be.revertedWithCustomError(asset, "WrongExpirationTimestamp");
+    });
+
+    it("GIVEN amount is zero WHEN clearingTransferFromByPartition THEN reverts with InvalidClearingAmount", async () => {
+      const clearingOperationFrom = {
+        clearingOperation: {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        },
+        from: signer_A.address,
+        operatorData: EMPTY_HEX_BYTES,
+      };
+      await expect(
+        asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, 0, signer_C.address),
+      ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
     });
   });
 

--- a/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
@@ -197,6 +197,13 @@ describe("OperatorClearingByPartition Tests", () => {
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
       });
+
+      it("GIVEN amount is zero WHEN operatorClearingTransferByPartition THEN transaction fails with InvalidClearingAmount", async () => {
+        await asset.connect(signer_A).authorizeOperator(signer_B.address);
+        await expect(
+          asset.connect(signer_B).operatorClearingTransferByPartition(clearingOperationFrom, 0, signer_C.address),
+        ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
+      });
     });
 
     describe("operatorClearingRedeemByPartition", () => {
@@ -266,6 +273,13 @@ describe("OperatorClearingByPartition Tests", () => {
             asset.connect(signer_B).operatorClearingRedeemByPartition(clearingOperationFrom, _AMOUNT),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
+      });
+
+      it("GIVEN amount is zero WHEN operatorClearingRedeemByPartition THEN transaction fails with InvalidClearingAmount", async () => {
+        await asset.connect(signer_A).authorizeOperator(signer_B.address);
+        await expect(
+          asset.connect(signer_B).operatorClearingRedeemByPartition(clearingOperationFrom, 0),
+        ).to.be.revertedWithCustomError(asset, "InvalidClearingAmount");
       });
     });
   });


### PR DESCRIPTION
This pull request addresses a security and correctness issue (FIND-031) in the clearing flow for asset tokenization contracts by ensuring that zero-amount clearing operations are not permitted. It also significantly enhances the documentation and structure of the `IClearingTypes` interface, adding detailed comments and organizing types, events, and errors for clarity and maintainability.

**Validation and Security Improvements:**

* Added a new guard function `checkNonZeroClearingAmount` in `ClearingStorageWrapper` that reverts with a custom error `InvalidClearingAmount` if a zero amount is supplied, preventing zero-amount clearing operations that could pollute on-chain state. This guard is now called at the start of both `clearingTransferCreation` and `clearingRedeemCreation` entry points. [[1]](diffhunk://#diff-50de51048045db07fc3c118dc454b3e7b1b7250925db2935a29893e3b1fd9e9dR570-R577) [[2]](diffhunk://#diff-5afa74df0a0ad47409d4e2fc5f06826ec66a5770efb812bc17807b843912e40cR68-R69) [[3]](diffhunk://#diff-5afa74df0a0ad47409d4e2fc5f06826ec66a5770efb812bc17807b843912e40cR147-R148) [[4]](diffhunk://#diff-14301bb8f403d9a38e2cade63c64fc6170666eaeff1437c1f326854d22a48221R1-R5)

**Interface and Documentation Enhancements:**

* Introduced the `InvalidClearingAmount` custom error to `IClearingTypes` for clearer revert reasons related to invalid clearing amounts.
* Significantly expanded comments and documentation throughout `IClearingTypes.sol`, providing clear descriptions for all enums, structs, and events related to the clearing mechanism. This improves code readability and maintainability for all contributors. [[1]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6L7-R19) [[2]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R28-R158) [[3]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R168-R175) [[4]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R184-R199) [[5]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R212-R227)
* Organized and documented all clearing-related events, ensuring each event is clearly described and its parameters are well-defined. This includes events for transfer, redeem, and hold creation operations, as well as their variants (from, operator, etc.). [[1]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R239-R251) [[2]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R263-R274) [[3]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R286-R299) [[4]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R311-R325) [[5]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R337-R349) [[6]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R362-R375) [[7]](diffhunk://#diff-667e4bc49c56e61ef4be015abeb6a0e004cfbe82f2f0b06a433020a15ceed0b6R388-R400)

These changes collectively improve the security, clarity, and maintainability of the clearing flow in the asset tokenization contracts.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
