### PR TITLE
fix: [FIND-134] Expiration Boundary Inconsistency: Locks Inclusive vs Holds/Clearing Exclusive

### DIFF
--- a/.changeset/fix-find-134-expiration-boundary-consistency.md
+++ b/.changeset/fix-find-134-expiration-boundary-consistency.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-134: align expiration boundary behaviour across all encumbrance types. `HoldStorageWrapper::isHoldExpired` and `ClearingStorageWrapper::requireExpirationTimestamp` used a strict `>` comparison, so holds and clearings were not considered expired at exactly `block.timestamp == expirationTimestamp`, while `LockStorageWrapper::isLockedExpirationTimestamp` used `<=` and treated the same instant as expired. Change both hold and clearing checks from `>` to `>=` so all three encumbrance types share inclusive expiration semantics: an operation is expired at the expiration timestamp, not one second after.

--- a/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
@@ -458,7 +458,7 @@ library ClearingStorageWrapper {
         bool _mustBeExpired
     ) internal view {
         if (
-            TimeTravelStorageWrapper.getBlockTimestamp() >
+            TimeTravelStorageWrapper.getBlockTimestamp() >=
             isClearingBasicInfo(_clearingOperationIdentifier).expirationTimestamp !=
             _mustBeExpired
         ) {

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -477,7 +477,7 @@ library HoldStorageWrapper {
     }
 
     function isHoldExpired(IHoldTypes.Hold memory _hold) internal view returns (bool) {
-        return TimeTravelStorageWrapper.getBlockTimestamp() > _hold.expirationTimestamp;
+        return TimeTravelStorageWrapper.getBlockTimestamp() >= _hold.expirationTimestamp;
     }
 
     function checkOperatorCreateHoldByPartition(

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -1055,6 +1055,25 @@ describe("ClearingByPartitionFacet Tests", () => {
       ).to.be.revertedWithCustomError(asset, "ExpirationDateReached");
     });
 
+    it("GIVEN a clearing at exact expiration timestamp WHEN approveClearingOperationByPartition THEN reverts with ExpirationDateReached", async () => {
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address);
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP);
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Transfer,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+      await expect(
+        asset.connect(signer_A).approveClearingOperationByPartition(identifier),
+      ).to.be.revertedWithCustomError(asset, "ExpirationDateReached");
+    });
+
     it("GIVEN wrong clearingId WHEN approveClearingOperationByPartition THEN reverts with WrongClearingId", async () => {
       const identifier = {
         clearingOperationType: ClearingOperationType.Redeem,
@@ -1338,6 +1357,37 @@ describe("ClearingByPartitionFacet Tests", () => {
       expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
 
       await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP + 1);
+
+      const identifier = {
+        clearingOperationType: ClearingOperationType.Redeem,
+        partition: _DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        clearingId: 1,
+      };
+
+      await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(identifier))
+        .to.emit(asset, "ClearingOperationReclaimed")
+        .withArgs(signer_A.address, signer_A.address, _DEFAULT_PARTITION, 1, ClearingOperationType.Redeem)
+        .to.emit(asset, "Transfer")
+        .withArgs(ethers.ZeroAddress, signer_A.address, _AMOUNT);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore);
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(0);
+    });
+
+    it("GIVEN a clearing at exact expiration timestamp WHEN reclaimClearingOperationByPartition THEN balance restored and clearedAmount zeroed", async () => {
+      const balanceBefore = await asset.balanceOf(signer_A.address);
+      const clearingOperation = {
+        partition: _DEFAULT_PARTITION,
+        expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+        data: EMPTY_HEX_BYTES,
+      };
+      await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+      expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+      expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+
+      await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP);
 
       const identifier = {
         clearingOperationType: ClearingOperationType.Redeem,

--- a/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
@@ -616,6 +616,23 @@ describe("HoldByPartition Tests", () => {
         ).to.be.revertedWithCustomError(asset, "HoldExpirationReached");
       });
 
+      it("GIVEN a hold WHEN executeHoldByPartition at exact expiration timestamp THEN transaction fails with HoldExpirationReached", async () => {
+        const initDate = dateToUnixTimestamp("2030-01-01T00:00:03Z");
+        const expirationDate = dateToUnixTimestamp("2030-02-01T00:00:03Z");
+
+        hold.expirationTimestamp = expirationDate;
+
+        await asset.connect(signer_A).changeSystemTimestamp(initDate);
+
+        await asset.createHoldByPartition(_DEFAULT_PARTITION, hold);
+
+        await asset.connect(signer_A).changeSystemTimestamp(expirationDate);
+
+        await expect(
+          asset.connect(signer_B).executeHoldByPartition(holdIdentifier, signer_C.address, 1),
+        ).to.be.revertedWithCustomError(asset, "HoldExpirationReached");
+      });
+
       it("GIVEN a hold with a destination WHEN executeHoldByPartition to another destination THEN transaction fails with InvalidDestinationAddress", async () => {
         hold.to = signer_D.address;
 
@@ -673,6 +690,24 @@ describe("HoldByPartition Tests", () => {
         await asset.createHoldByPartition(_DEFAULT_PARTITION, hold);
 
         await asset.connect(signer_A).changeSystemTimestamp(finalDate);
+
+        await expect(asset.connect(signer_B).releaseHoldByPartition(holdIdentifier, 1)).to.be.revertedWithCustomError(
+          asset,
+          "HoldExpirationReached",
+        );
+      });
+
+      it("GIVEN hold WHEN releaseHoldByPartition at exact expiration timestamp THEN transaction fails with HoldExpirationReached", async () => {
+        const initDate = dateToUnixTimestamp("2030-01-01T00:00:03Z");
+        const expirationDate = dateToUnixTimestamp("2030-02-01T00:00:03Z");
+
+        hold.expirationTimestamp = expirationDate;
+
+        await asset.connect(signer_A).changeSystemTimestamp(initDate);
+
+        await asset.createHoldByPartition(_DEFAULT_PARTITION, hold);
+
+        await asset.connect(signer_A).changeSystemTimestamp(expirationDate);
 
         await expect(asset.connect(signer_B).releaseHoldByPartition(holdIdentifier, 1)).to.be.revertedWithCustomError(
           asset,
@@ -848,6 +883,25 @@ describe("HoldByPartition Tests", () => {
           ThirdPartyType.NULL,
           ADDRESS_ZERO,
         );
+      });
+
+      it("GIVEN hold WHEN reclaimHoldByPartition at exact expiration timestamp THEN transaction succeeds", async () => {
+        const initDate = dateToUnixTimestamp("2030-01-01T00:00:03Z");
+        const expirationDate = dateToUnixTimestamp("2030-02-01T00:00:03Z");
+
+        hold.expirationTimestamp = expirationDate;
+
+        await asset.connect(signer_A).changeSystemTimestamp(initDate);
+
+        await asset.createHoldByPartition(_DEFAULT_PARTITION, hold);
+
+        await asset.connect(signer_A).changeSystemTimestamp(expirationDate);
+
+        await expect(asset.connect(signer_B).reclaimHoldByPartition(holdIdentifier))
+          .to.emit(asset, "HoldByPartitionReclaimed")
+          .withArgs(signer_B.address, signer_A.address, _DEFAULT_PARTITION, 1, _AMOUNT)
+          .to.emit(asset, "Transfer")
+          .withArgs(ethers.ZeroAddress, signer_A.address, _AMOUNT);
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/lockByPartition/lockByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/lockByPartition/lockByPartition.test.ts
@@ -274,6 +274,23 @@ describe("LockByPartition Tests", () => {
         expect(await asset.balanceOfByPartition(_NON_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
         expect(await asset.totalSupplyByPartition(_NON_DEFAULT_PARTITION)).to.equal(_AMOUNT);
       });
+
+      it("GIVEN a valid lockId WHEN releaseByPartition at exact expiration timestamp THEN transaction success", async () => {
+        await asset.connect(signer_B).issueByPartition({
+          partition: _NON_DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: _AMOUNT,
+          data: "0x",
+        });
+        await asset
+          .connect(signer_C)
+          .lockByPartition(_NON_DEFAULT_PARTITION, _AMOUNT, signer_A.address, expirationTimestamp);
+
+        await asset.changeSystemTimestamp(expirationTimestamp);
+        await expect(asset.connect(signer_C).releaseByPartition(_NON_DEFAULT_PARTITION, 1, signer_A.address))
+          .to.emit(asset, "LockByPartitionReleased")
+          .withArgs(signer_C.address, signer_A.address, _NON_DEFAULT_PARTITION, 1);
+      });
     });
 
     describe("Adjust Balances", () => {

--- a/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
@@ -165,7 +165,7 @@ describe("Recovery Tests", () => {
         await expect(
           asset.recoveryAddress(signer_E.address, signer_B.address, ADDRESS_ZERO),
         ).to.be.revertedWithCustomError(asset, "CannotRecoverWallet");
-        await asset.changeSystemTimestamp(dateToUnixTimestamp("2030-01-01T00:00:06Z"));
+        await asset.changeSystemTimestamp(dateToUnixTimestamp("2030-01-01T00:00:05Z"));
         const holdIdentifier = {
           partition: DEFAULT_PARTITION,
           tokenHolder: signer_E.address,


### PR DESCRIPTION
This pull request standardizes the expiration logic across all encumbrance types (holds, clearings, and locks) in the asset tokenization contracts. Previously, some types considered an operation expired only after the expiration timestamp, while others included the timestamp itself. Now, all encumbrance types treat the expiration timestamp as inclusive—meaning an operation is expired at the exact moment its expiration timestamp is reached. The update also adds and adjusts tests to verify this consistent behavior.

**Expiration logic standardization:**

* Changed `HoldStorageWrapper::isHoldExpired` and `ClearingStorageWrapper::requireExpirationTimestamp` to use `>=` instead of `>` for expiration checks, aligning them with `LockStorageWrapper` so all encumbrance types expire inclusively at the expiration timestamp. [[1]](diffhunk://#diff-9d0d744e7cebc6a0e0957d1d99644b486542b317400fb6cd0b3014e811e10ef5L480-R480) [[2]](diffhunk://#diff-50de51048045db07fc3c118dc454b3e7b1b7250925db2935a29893e3b1fd9e9dL461-R461) [[3]](diffhunk://#diff-b546eab335d8941036f78e44171402912ee26f206b75757cce3124267622db3aR1-R5)

**Test suite updates for holds:**

* Added tests to ensure that executing or releasing a hold at the exact expiration timestamp fails as expected, while reclaiming a hold at the same instant succeeds. [[1]](diffhunk://#diff-38f09733da87433f1f28ff7e575ee13b9a4fab14764ceddf779c0f498ed07d4bR619-R635) [[2]](diffhunk://#diff-38f09733da87433f1f28ff7e575ee13b9a4fab14764ceddf779c0f498ed07d4bR699-R716) [[3]](diffhunk://#diff-38f09733da87433f1f28ff7e575ee13b9a4fab14764ceddf779c0f498ed07d4bR887-R905)

**Test suite updates for clearings:**

* Added tests to verify that approving a clearing operation at the exact expiration timestamp fails, but reclaiming at the same instant restores the balance and zeroes the cleared amount. [[1]](diffhunk://#diff-83d6c532df14e2d1701356834b5dd2258b226108ed67fa0c98c7948401c036f2R1058-R1076) [[2]](diffhunk://#diff-83d6c532df14e2d1701356834b5dd2258b226108ed67fa0c98c7948401c036f2R1378-R1408)

**Test suite updates for locks:**

* Added a test to confirm that releasing a lock at the exact expiration timestamp succeeds.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
