### PR TITLE
fix: [FIND-114] Diamond Configuration Accepts Zero Facets, Enabling Token Bricking via Auto-Upgrade

### DIFF
--- a/.changeset/fix-find-114-empty-facet-configuration.md
+++ b/.changeset/fix-find-114-empty-facet-configuration.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Prevent activation of diamond configurations with zero facets. `_activateConfiguration` now reverts with `EmptyFacetConfigurationNotPermitted` when the accumulated facet list for a batch version is empty, closing a vector where `createConfiguration` or `createBatchConfiguration` could register a configuration with no function selectors and brick any `ResolverProxy` following the latest version. [FIND-114]

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IDiamondCutManager.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IDiamondCutManager.sol
@@ -75,6 +75,13 @@ interface TRexIDiamondCutManager {
     error DefaultValueForConfigurationIdNotPermitted();
 
     /**
+     * @notice Thrown when attempting to activate a configuration that contains no facets,
+     *         which would brick any ResolverProxy following the latest version.
+     * @param configurationId Configuration key that was supplied with an empty facet list.
+     */
+    error EmptyFacetConfigurationNotPermitted(bytes32 configurationId);
+
+    /**
      * @notice Thrown when a configuration references a facet id that is not registered in
      *         the business-logic resolver.
      * @param configurationId Configuration being created or modified.

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -61,9 +61,7 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicR
     function _activateConfiguration(bytes32 _configurationId, bool _isLastBatch) internal {
         if (!_isLastBatch) return;
         DiamondCutManagerStorage storage _dcms = _diamondCutManagerStorage();
-        if (_dcms.facetIds[_buildHash(_configurationId, _dcms.batchVersion[_configurationId])].length == 0) {
-            revert EmptyFacetConfigurationNotPermitted(_configurationId);
-        }
+        _checkEmptyFacetConfiguration(_dcms, _configurationId);
         if (!_dcms.activeConfigurations[_configurationId]) {
             _dcms.configurations.push(_configurationId);
             _dcms.activeConfigurations[_configurationId] = true;
@@ -529,6 +527,15 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicR
         uint256 _version
     ) private view returns (uint256 version_) {
         version_ = _version > 0 ? _version : _dcms.latestVersion[_configurationId];
+    }
+
+    function _checkEmptyFacetConfiguration(
+        DiamondCutManagerStorage storage _dcms,
+        bytes32 _configurationId
+    ) private view {
+        if (_dcms.facetIds[_buildHash(_configurationId, _dcms.batchVersion[_configurationId])].length == 0) {
+            revert EmptyFacetConfigurationNotPermitted(_configurationId);
+        }
     }
 
     function _checkSelectorsBlacklist(bytes32 _configurationId, bytes4[] memory _selectors) private view {

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -61,6 +61,9 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicR
     function _activateConfiguration(bytes32 _configurationId, bool _isLastBatch) internal {
         if (!_isLastBatch) return;
         DiamondCutManagerStorage storage _dcms = _diamondCutManagerStorage();
+        if (_dcms.facetIds[_buildHash(_configurationId, _dcms.batchVersion[_configurationId])].length == 0) {
+            revert EmptyFacetConfigurationNotPermitted(_configurationId);
+        }
         if (!_dcms.activeConfigurations[_configurationId]) {
             _dcms.configurations.push(_configurationId);
             _dcms.activeConfigurations[_configurationId] = true;

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
@@ -70,6 +70,13 @@ interface IDiamondCutManager {
     error DefaultValueForConfigurationIdNotPermitted();
 
     /**
+     * @notice Thrown when attempting to activate a configuration that contains no facets,
+     *         which would brick any ResolverProxy following the latest version.
+     * @param configurationId Configuration key that was supplied with an empty facet list.
+     */
+    error EmptyFacetConfigurationNotPermitted(bytes32 configurationId);
+
+    /**
      * @notice Thrown when a configuration references a facet id that is not registered in
      *         the business-logic resolver.
      * @param configurationId Configuration being created or modified.

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -759,6 +759,22 @@ describe("DiamondCutManager", () => {
     ).to.be.revertedWithCustomError(diamondCutManager, "FacetIdNotRegistered");
   });
 
+  it("GIVEN a resolver WHEN creating a configuration with empty facet array THEN fails with EmptyFacetConfigurationNotPermitted", async () => {
+    const emptyConfigId = "0x0000000000000000000000000000000000000000000000000000000000000040";
+
+    await expect(diamondCutManager.connect(signer_A).createConfiguration(emptyConfigId, []))
+      .to.be.revertedWithCustomError(diamondCutManager, "EmptyFacetConfigurationNotPermitted")
+      .withArgs(emptyConfigId);
+  });
+
+  it("GIVEN a resolver WHEN finalising a batch configuration with no facets accumulated THEN fails with EmptyFacetConfigurationNotPermitted", async () => {
+    const emptyBatchConfigId = "0x0000000000000000000000000000000000000000000000000000000000000041";
+
+    await expect(diamondCutManager.connect(signer_A).createBatchConfiguration(emptyBatchConfigId, [], true))
+      .to.be.revertedWithCustomError(diamondCutManager, "EmptyFacetConfigurationNotPermitted")
+      .withArgs(emptyBatchConfigId);
+  });
+
   it("GIVEN a resolver WHEN adding configuration with overlapping selectors from different facets THEN fails with SelectorAlreadyRegistered", async () => {
     // Use the lightweight fixture that includes TransferFacet
     const fixture = await loadFixture(registerTransferFacetFixture);


### PR DESCRIPTION
This pull request introduces a safeguard to prevent activating diamond configurations with zero facets, which previously could have led to critical issues by bricking any `ResolverProxy` that followed the latest version. The key change is that the system now reverts with a new custom error, `EmptyFacetConfigurationNotPermitted`, if an attempt is made to activate or create a configuration with no facets. Additional tests and documentation have been added to ensure this behavior is enforced and clearly described.

**Core contract logic improvements:**

* Added a check in `_activateConfiguration` (in `DiamondCutManagerWrapper.sol`) to revert with `EmptyFacetConfigurationNotPermitted` if the facet list for a configuration is empty, preventing invalid configurations from being activated.
* Introduced the custom error `EmptyFacetConfigurationNotPermitted(bytes32 configurationId)` in both `IDiamondCutManager.sol` contract interfaces to standardize error handling for empty facet configurations. [[1]](diffhunk://#diff-117cd9e58454f1c22b0b899a1931d8095a0c23ed425331f1781b3d3bdc062fd5R77-R83) [[2]](diffhunk://#diff-6fe6344cf8b81b55151a3b4238ff189fc9ac3c418457729989ac395500ef1146R72-R78)

**Testing and documentation:**

* Added integration tests to ensure that creating or finalizing a configuration with an empty facet array correctly reverts with the new error, including validation of the error arguments.
* Updated the changeset documentation to describe the new restriction and its rationale, referencing the related issue.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
