### PR TITLE
fix(contracts): clean up erc3643-clone-interfaces task

### DIFF
--- a/packages/ats/contracts/tasks/compile.ts
+++ b/packages/ats/contracts/tasks/compile.ts
@@ -9,7 +9,8 @@ import path from "path";
 
 task(
   TASK_COMPILE,
-  "Replace 'interface' with 'interfaces' in TypeChain generated files to avoid compilation errors",
+  "🛠  Compile, clone neutral interfaces into the ERC3643 subtree, patch the TypeChain " +
+    "'interface' keyword collision, and regenerate the contract registry.",
   async function (taskArguments, hre, runSuper) {
     await runSuper(taskArguments);
 
@@ -59,14 +60,14 @@ function injectHeader(source: string, header: string): string {
 }
 
 task("erc3643-clone-interfaces", async (_, hre) => {
-  interface DataSustitution {
+  interface DataSubstitution {
     original: string;
     removeImports?: boolean;
     changePragma?: boolean;
     removeHierarchy?: boolean;
   }
   const targetDir = hre.config.paths.sources + "/factory/ERC3643/interfaces";
-  const interfacesToClone: DataSustitution[] = [
+  const interfacesToClone: DataSubstitution[] = [
     { original: "IAccessControl" },
     { original: "IBondTypes" },
     { original: "IBondRead", removeImports: false, removeHierarchy: false },
@@ -113,7 +114,6 @@ task("erc3643-clone-interfaces", async (_, hre) => {
       src: "facets/layer_2/scheduledTask/scheduledTasksCommon/IScheduledTasksCommon",
       dst: "IScheduledTasksCommon",
     },
-    { src: "infrastructure/errors/CommonErrors", dst: "CommonErrors" },
   ];
 
   function rewriteImports(source: string): string {
@@ -141,8 +141,8 @@ task("erc3643-clone-interfaces", async (_, hre) => {
     );
   }
 
-  await Promise.all(
-    normalized.map(async (i) => {
+  const interfaceResults = await Promise.all(
+    normalized.map(async (i): Promise<boolean> => {
       const originalArtifact = await hre.artifacts.readArtifact(i.original);
       let erc3643Artifact: Artifact | undefined;
       try {
@@ -157,7 +157,7 @@ task("erc3643-clone-interfaces", async (_, hre) => {
 
       if (!shouldGenerate) {
         console.log(`Did not generate ${i.original} because an up-to-date version already exists`);
-        return;
+        return false;
       }
 
       let source = fs.readFileSync(originalArtifact.sourceName, "utf8");
@@ -182,25 +182,44 @@ task("erc3643-clone-interfaces", async (_, hre) => {
       const header = autoGenHeader(originalArtifact.sourceName);
       fs.writeFileSync(targetPath, injectHeader(source, header), "utf8");
       console.log(`Generated: ${targetPath}`);
+      return true;
     }),
   );
+  let anyRegenerated = interfaceResults.some(Boolean);
 
   for (const c of constants) {
     const src = path.join(hre.config.paths.sources, `${c.src}.sol`);
     const dst = path.join(targetDir, `${c.dst}.sol`);
 
-    if (fs.existsSync(src)) {
-      let content = fs.readFileSync(src, "utf8");
-
-      content = content.replace(/^pragma solidity\s+[^;]+;/m, "pragma solidity ^0.8.17;");
-
-      const header = autoGenHeader(`contracts/${c.src}.sol`);
-      fs.writeFileSync(dst, injectHeader(content, header), "utf8");
-      console.log(`Copied constant with updated pragma: ${dst}`);
-    } else {
-      console.warn(`Not found: ${src}`);
+    if (!fs.existsSync(src)) {
+      throw new Error(
+        `❌ erc3643-clone-interfaces: declared constant source not found: ${src}. ` +
+          "Remove the entry from `constants` or restore the file.",
+      );
     }
+
+    let content = fs.readFileSync(src, "utf8");
+    content = content.replace(/^pragma solidity\s+[^;]+;/m, "pragma solidity ^0.8.17;");
+    const header = autoGenHeader(`contracts/${c.src}.sol`);
+    const next = injectHeader(content, header);
+
+    // Skip write when the on-disk copy already matches — avoids touching mtimes
+    // and forces Prettier to revisit a file with no semantic delta.
+    if (fs.existsSync(dst) && fs.readFileSync(dst, "utf8") === next) {
+      console.log(`Constant up-to-date, skipped: ${dst}`);
+      continue;
+    }
+
+    fs.writeFileSync(dst, next, "utf8");
+    console.log(`Copied constant with updated pragma: ${dst}`);
+    anyRegenerated = true;
   }
+
+  if (!anyRegenerated) {
+    console.log("⏭  No ERC3643 interface or constant regenerated — skipping Prettier pass");
+    return;
+  }
+
   const { execWithErrorHandling } = await import("./utils/errorHandling");
 
   try {


### PR DESCRIPTION
## Description

Removes the dead \`constants\` entry in \`tasks/compile.ts\` that pointed at \`infrastructure/errors/CommonErrors\`, renamed to \`ICommonErrors.sol\` in an earlier branch. The source no longer existed — every \`hardhat compile\` emitted \`Not found: …/CommonErrors.sol\`. Nothing under \`contracts/factory/ERC3643/\` consumed the cloned constant (verified by repo-wide grep — zero importers, none of its 16 errors used in the T-REX subtree), so the entry is removed rather than re-pointed.

Bundled small improvements in the same task file (opportunistic, no dedicated ticket):

- Silent \`console.warn("Not found: ...")\` → thrown error so a missing constant source fails the build instead of rotting unnoticed; prefixed with ❌ to match the existing ✅/📋 style.
- Refreshed the misleading \`TASK_COMPILE\` description string — it claimed only to patch the TypeChain \`interface\` keyword, but the task also clones ERC3643 interfaces and regenerates the contract registry.
- Fixed \`DataSustitution\` interface typo (file-local).
- Idempotent-compile fast path: constants loop skips writes when the destination already matches; the final \`npx prettier --write …/interfaces\` subprocess is skipped entirely when no interface or constant was regenerated.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- \`npx hardhat compile\` — clean, no \`Not found: …/CommonErrors.sol\` warning.
- Ran twice; second pass logs \`Constant up-to-date, skipped: …\` for regulation.sol / roles.sol / IScheduledTasksCommon.sol (idempotent fast path confirmed working).
- \`npm run ats:contracts:format\` — clean.
- \`npm run ats:contracts:lint\` — 0 errors (2634 baseline NatSpec warnings, unchanged).

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅