### PR TITLE
fix: [FIND-115] createConfiguration Prematurely Finalizes In-Progress Batch Configuration

### DIFF
--- a/.changeset/fix-find-115-create-configuration-ongoing-batch.md
+++ b/.changeset/fix-find-115-create-configuration-ongoing-batch.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Prevent `createConfiguration` from prematurely finalising an in-progress batch. `_createConfiguration` now reverts with `OngoingBatchConfigurationNotPermitted` when `_isOngoingConfiguration` returns true, closing a vector where calling `createConfiguration` on an open batch would absorb partial state and immediately activate the configuration — potentially missing facets intended for subsequent batch additions. [FIND-115]

--- a/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IDiamondCutManager.sol
+++ b/packages/ats/contracts/contracts/factory/ERC3643/interfaces/IDiamondCutManager.sol
@@ -96,6 +96,14 @@ interface TRexIDiamondCutManager {
     error DuplicatedFacetInConfiguration(bytes32 facetId);
 
     /**
+     * @notice Thrown when {createConfiguration} is called for a configuration id that already
+     *         has an in-progress batch, which would prematurely finalise the incomplete batch
+     *         and absorb any facets that were intended for subsequent batch additions.
+     * @param configurationId Configuration key whose batch is currently open.
+     */
+    error OngoingBatchConfigurationNotPermitted(bytes32 configurationId);
+
+    /**
      * @notice Thrown when a (configurationId, version) pair is referenced but has not been
      *         registered (or is still mid-batch and therefore not yet finalised).
      * @param resolverProxyConfigurationId Configuration key that was looked up.

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -42,9 +42,8 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicR
         bytes32 _configurationId,
         FacetConfiguration[] calldata _facetConfigurations
     ) internal returns (uint256 latestVersion_) {
-        latestVersion_ = _isOngoingConfiguration(_configurationId)
-            ? _getBatchConfigurationVersion(_configurationId)
-            : _startBatchConfiguration(_configurationId);
+        if (_isOngoingConfiguration(_configurationId)) revert OngoingBatchConfigurationNotPermitted(_configurationId);
+        latestVersion_ = _startBatchConfiguration(_configurationId);
         _addFacetsToBatchConfiguration(_configurationId, _facetConfigurations, latestVersion_);
         _activateConfiguration(_configurationId, true);
     }

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
@@ -91,6 +91,14 @@ interface IDiamondCutManager {
     error DuplicatedFacetInConfiguration(bytes32 facetId);
 
     /**
+     * @notice Thrown when {createConfiguration} is called for a configuration id that already
+     *         has an in-progress batch, which would prematurely finalise the incomplete batch
+     *         and absorb any facets that were intended for subsequent batch additions.
+     * @param configurationId Configuration key whose batch is currently open.
+     */
+    error OngoingBatchConfigurationNotPermitted(bytes32 configurationId);
+
+    /**
      * @notice Thrown when a (configurationId, version) pair is referenced but has not been
      *         registered (or is still mid-batch and therefore not yet finalised).
      * @param resolverProxyConfigurationId Configuration key that was looked up.

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -554,7 +554,7 @@ describe("DiamondCutManager", () => {
       .withArgs(blackListedSelectors[0]);
   });
 
-  it("GIVEN a resolver WHEN creating configuration on an ongoing batch THEN uses the batch version", async () => {
+  it("GIVEN a resolver WHEN creating configuration on an ongoing batch THEN fails with OngoingBatchConfigurationNotPermitted", async () => {
     const testConfigId = "0x0000000000000000000000000000000000000000000000000000000000000010";
 
     const firstBatchFacets: IDiamondCutManager.FacetConfigurationStruct[] = [
@@ -573,45 +573,9 @@ describe("DiamondCutManager", () => {
       },
     ];
 
-    await diamondCutManager.connect(signer_A).createConfiguration(testConfigId, secondBatchFacets);
-
-    const latestVersion = Number(await diamondCutManager.getLatestVersionByConfiguration(testConfigId));
-    expect(latestVersion).to.equal(1);
-
-    const facetsLength = Number(await diamondCutManager.getFacetsLengthByConfigurationIdAndVersion(testConfigId, 1));
-    expect(facetsLength).to.equal(2);
-  });
-
-  it("GIVEN an ongoing batch configuration WHEN createConfiguration is called with different facets THEN silently merges into the batch", async () => {
-    const testConfigId = "0x000000000000000000000000000000000000000000000000000000000000001a";
-
-    const facet1: IDiamondCutManager.FacetConfigurationStruct[] = [
-      {
-        id: equityFacetIdList[0],
-        version: 1,
-      },
-    ];
-
-    // Step 1: Start an incomplete batch (_isLastBatch: false leaves batch open)
-    await diamondCutManager.connect(signer_A).createBatchConfiguration(testConfigId, facet1, false);
-
-    const facet2: IDiamondCutManager.FacetConfigurationStruct[] = [
-      {
-        id: equityFacetIdList[1],
-        version: 1,
-      },
-    ];
-
-    // Step 2: Call createConfiguration with a different facet — no explicit confirmation of merge
-    // ⚠️ BUG: This test documents silent batch re-use. facet2 was merged into an incomplete batch without explicit confirmation.
-    await diamondCutManager.connect(signer_A).createConfiguration(testConfigId, facet2);
-
-    // Step 3: Verify BOTH facets are now in the same configuration version
-    const latestVersion = Number(await diamondCutManager.getLatestVersionByConfiguration(testConfigId));
-    expect(latestVersion).to.equal(1);
-
-    const facetsLength = Number(await diamondCutManager.getFacetsLengthByConfigurationIdAndVersion(testConfigId, 1));
-    expect(facetsLength).to.equal(2);
+    await expect(diamondCutManager.connect(signer_A).createConfiguration(testConfigId, secondBatchFacets))
+      .to.be.revertedWithCustomError(diamondCutManager, "OngoingBatchConfigurationNotPermitted")
+      .withArgs(testConfigId);
   });
 
   it("GIVEN a resolver and a non admin user WHEN canceling a batch configuration THEN fails with AccountHasNoRole", async () => {


### PR DESCRIPTION
This pull request introduces a stricter validation for configuration batch management in the DiamondCutManager, preventing accidental merging or finalization of incomplete batches. The key change is that calling `createConfiguration` on a configuration ID with an ongoing (incomplete) batch will now revert with a custom error, enforcing explicit batch management and avoiding silent merges.

Batch management and error handling improvements:

* Added a new custom error `OngoingBatchConfigurationNotPermitted` to both `IDiamondCutManager` interface files, which is thrown when `createConfiguration` is called for a configuration ID that already has an in-progress batch. This prevents premature finalization and unintended facet absorption. [[1]](diffhunk://#diff-117cd9e58454f1c22b0b899a1931d8095a0c23ed425331f1781b3d3bdc062fd5R98-R105) [[2]](diffhunk://#diff-6fe6344cf8b81b55151a3b4238ff189fc9ac3c418457729989ac395500ef1146R93-R100)
* Updated the internal logic in `DiamondCutManagerWrapper` to revert with the new error if `createConfiguration` is called on an ongoing batch, instead of silently continuing or merging facets into the existing batch.

Test updates:

* Modified the integration tests for `DiamondCutManager` to expect the new error when attempting to create a configuration on an ongoing batch, replacing previous tests that allowed silent merges. This ensures the new validation logic is enforced and tested. [[1]](diffhunk://#diff-68dfa528a94cde10cac456e424ffa0d4afd35473720c5c1d2f5cacb9b3890bfbL557-R557) [[2]](diffhunk://#diff-68dfa528a94cde10cac456e424ffa0d4afd35473720c5c1d2f5cacb9b3890bfbL576-R578)

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
