### PR TITLE
fix: [FIND-070] _replaceTokenHolder Zero-Index Corruption

### DIFF
--- a/.changeset/fix-find-070-replace-token-holder-guard.md
+++ b/.changeset/fix-find-070-replace-token-holder-guard.md
@@ -1,0 +1,11 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-070: `replaceTokenHolder` silently corrupts `tokenHolders[0]` when `oldTokenHolder` is unregistered.
+
+`ERC1410StorageWrapper.replaceTokenHolder` looked up the old holder's index via `tokenHolderIndex[oldTokenHolder]`, which returns 0 for any unregistered address. Calling the function with an unregistered `oldTokenHolder` would overwrite `tokenHolders[0]` (the null slot, as valid indices start at 1) with `newTokenHolder` and zero out the old holder's mapping entry, corrupting the registry irreversibly without a manual storage fix.
+
+Added an existence check that reverts with `IERC1410Types.TokenHolderNotFound(oldTokenHolder)` when the resolved index is 0, before any storage mutation occurs. The new custom error `TokenHolderNotFound(address tokenHolder)` is declared in `IERC1410Types`.
+
+Added `MockERC1410StorageWrapper` test harness and three unit tests (two unhappy-path, one happy-path) covering the guard in the `SecurityHoldersFacet Tests` suite.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -130,6 +130,7 @@ library ERC1410StorageWrapper {
         ERC1410BasicStorage storage basicStorage = erc1410BasicStorage();
 
         uint256 index = basicStorage.tokenHolderIndex[oldTokenHolder];
+        if (index == 0) revert IERC1410Types.TokenHolderNotFound(oldTokenHolder);
         basicStorage.tokenHolderIndex[newTokenHolder] = index;
         basicStorage.tokenHolders[index] = newTokenHolder;
         basicStorage.tokenHolderIndex[oldTokenHolder] = 0;

--- a/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Types.sol
+++ b/packages/ats/contracts/contracts/facets/layer_1/ERC1400/ERC1410/IERC1410Types.sol
@@ -73,4 +73,6 @@ interface IERC1410Types {
     error InvalidPartition(address account, bytes32 partition);
 
     error Unauthorized(address operator, address tokenHolder, bytes32 partition);
+
+    error TokenHolderNotFound(address tokenHolder);
 }

--- a/packages/ats/contracts/contracts/test/mocks/MockERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockERC1410StorageWrapper.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/* solhint-disable */
+
+import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { IERC1410Types } from "../../facets/layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+
+/// @dev Test-only mock that exposes internal ERC1410StorageWrapper functions
+/// so that unit tests can exercise them directly without going through the full
+/// diamond infrastructure.
+contract MockERC1410StorageWrapper is IERC1410Types {
+    function exposed_addNewTokenHolder(address tokenHolder) external {
+        ERC1410StorageWrapper.addNewTokenHolder(tokenHolder);
+    }
+
+    function exposed_replaceTokenHolder(address newTokenHolder, address oldTokenHolder) external {
+        ERC1410StorageWrapper.replaceTokenHolder(newTokenHolder, oldTokenHolder);
+    }
+
+    function exposed_removeTokenHolder(address tokenHolder) external {
+        ERC1410StorageWrapper.removeTokenHolder(tokenHolder);
+    }
+
+    function exposed_getTokenHolder(uint256 index) external view returns (address) {
+        return ERC1410StorageWrapper.getTokenHolder(index);
+    }
+
+    function exposed_getTotalTokenHolders() external view returns (uint256) {
+        return ERC1410StorageWrapper.getTotalTokenHolders();
+    }
+
+    function exposed_getTokenHolderIndex(address tokenHolder) external view returns (uint256) {
+        return ERC1410StorageWrapper.getTokenHolderIndex(tokenHolder);
+    }
+}
+
+/* solhint-enable */

--- a/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { type ResolverProxy, type IAsset } from "@contract-types";
+import { type ResolverProxy, type IAsset, MockERC1410StorageWrapper } from "@contract-types";
 import { DEFAULT_PARTITION, ATS_ROLES, ZERO, EMPTY_HEX_BYTES } from "@scripts";
 import { deployEquityTokenFixture, executeRbac, MAX_UINT256 } from "@test";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
@@ -407,6 +407,46 @@ describe("SecurityHoldersFacet Tests", () => {
       const holders = await asset.getSecurityHolders(0, 10);
       expect(holders).to.include(signer_B.address);
       expect(holders).to.include(signer_C.address);
+    });
+  });
+
+  describe("replaceTokenHolder existence guard (audit fix)", () => {
+    let mock: MockERC1410StorageWrapper;
+
+    beforeEach(async () => {
+      const factory = await ethers.getContractFactory("MockERC1410StorageWrapper");
+      mock = (await factory.deploy()) as unknown as MockERC1410StorageWrapper;
+      await mock.waitForDeployment();
+    });
+
+    it("GIVEN oldTokenHolder is not registered (index == 0) WHEN replaceTokenHolder THEN reverts with TokenHolderNotFound", async () => {
+      await expect(mock.exposed_replaceTokenHolder(signer_B.address, signer_C.address))
+        .to.be.revertedWithCustomError(mock, "TokenHolderNotFound")
+        .withArgs(signer_C.address);
+    });
+
+    it("GIVEN oldTokenHolder was registered and then removed (index reset to 0) WHEN replaceTokenHolder THEN reverts with TokenHolderNotFound", async () => {
+      await mock.exposed_addNewTokenHolder(signer_B.address);
+      await mock.exposed_addNewTokenHolder(signer_C.address);
+      await mock.exposed_removeTokenHolder(signer_B.address);
+
+      expect(await mock.exposed_getTokenHolderIndex(signer_B.address)).to.equal(0);
+
+      await expect(mock.exposed_replaceTokenHolder(signer_D.address, signer_B.address))
+        .to.be.revertedWithCustomError(mock, "TokenHolderNotFound")
+        .withArgs(signer_B.address);
+    });
+
+    it("GIVEN a registered oldTokenHolder WHEN replaceTokenHolder THEN registry is updated and slot 0 is never corrupted", async () => {
+      await mock.exposed_addNewTokenHolder(signer_B.address);
+      const indexBefore = await mock.exposed_getTokenHolderIndex(signer_B.address);
+
+      await mock.exposed_replaceTokenHolder(signer_C.address, signer_B.address);
+
+      expect(await mock.exposed_getTokenHolderIndex(signer_B.address)).to.equal(0);
+      expect(await mock.exposed_getTokenHolderIndex(signer_C.address)).to.equal(indexBefore);
+      expect(await mock.exposed_getTokenHolder(Number(indexBefore))).to.equal(signer_C.address);
+      expect(await mock.exposed_getTokenHolder(0)).to.equal(ethers.ZeroAddress);
     });
   });
 


### PR DESCRIPTION
This pull request adds an important audit fix to the ERC1410 token holder management logic by ensuring that `replaceTokenHolder` correctly checks for the existence of the old token holder before attempting replacement. It also introduces a mock contract to facilitate direct testing of internal storage wrapper functions and adds comprehensive tests to verify the new guard logic.

**Audit fix and testing improvements:**

* Added a guard in `ERC1410StorageWrapper.replaceTokenHolder` to revert with `TokenHolderNotFound` if the `oldTokenHolder` does not exist (i.e., its index is zero), preventing accidental corruption of the token holder registry.
* Introduced the `TokenHolderNotFound` custom error to the `IERC1410Types` interface for clearer revert reasons.

**Testing infrastructure:**

* Created `MockERC1410StorageWrapper`, a test-only contract that exposes internal functions of `ERC1410StorageWrapper` for direct unit testing, bypassing the diamond infrastructure.
* Updated integration tests in `SecurityHolders.test.ts` to use the new mock contract and added tests that verify the new existence guard in `replaceTokenHolder`, including cases where the holder was never registered or was removed. [[1]](diffhunk://#diff-5766a1bab49d55298bbdb5eb8d852c290a39272a59753570987b0648e1d3e533L6-R6) [[2]](diffhunk://#diff-5766a1bab49d55298bbdb5eb8d852c290a39272a59753570987b0648e1d3e533R413-R452)

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
