### PR TITLE
ci(workflows): fix hash-change labeller false-positive on every PR

### DIFF
--- a/.github/workflows/105-flow-ats-static-checks.yaml
+++ b/.github/workflows/105-flow-ats-static-checks.yaml
@@ -96,11 +96,17 @@ jobs:
           fi
 
           # Step C — decide whether to label. Touching anything under
-          # scripts/codegen counts; otherwise grep the local checked-out files
-          # for hash-bearing signatures.
+          # scripts/codegen counts; otherwise grep the DIFF (not the file
+          # contents) for hash-bearing line changes vs the base ref.
+          # Containment-grep false-positives any .sol file that merely
+          # declares a hash constant — and ~25% of .sol files do, so an
+          # unrelated NatSpec/event edit was triggering the label.
+          # `git diff -G <re>` matches files where an added/removed line
+          # hits the regex, which is what we actually want.
+          hash_re='@custom:hash|bytes32[[:space:]]+constant[[:space:]]+[A-Z_]+[[:space:]]*=[[:space:]]*0x[0-9a-fA-F]{64}'
           if echo "${changed}" | grep -qE 'scripts/codegen/' \
-             || grep -lE '@custom:hash|bytes32[[:space:]]+constant[[:space:]]+[A-Z_]+[[:space:]]*=[[:space:]]*0x[0-9a-fA-F]{64}' ${changed} >/dev/null 2>&1; then
-            echo "Hash-bearing files were modified — applying 'hash-change' label."
+             || [[ -n "$(git diff --name-only "origin/${{ github.base_ref }}" HEAD -G "${hash_re}" -- ${changed} 2>/dev/null)" ]]; then
+            echo "Hash-bearing changes detected — applying 'hash-change' label."
             # Use the REST Labels API directly. `gh pr edit --add-label` works
             # but its underlying GraphQL query touches the deprecated
             # `repository.pullRequest.projectCards` field, which makes the gh


### PR DESCRIPTION
## Description

The `hash-change` labeller in `105-flow-ats-static-checks.yaml` used `grep -lE` over
the **current file contents** of every changed `.sol` file. Because ~25% of `.sol` files
in the repo declare a `bytes32 constant = 0x<64-hex>` (resolver keys, ERC-7201 storage
slots, role hashes, etc.), nearly every contract PR was receiving the `hash-change` label
regardless of whether an actual hash value was added, removed, or modified.

Fix: switch to `git diff --name-only origin/<base> HEAD -G <hash_re>` so the label only
fires when an **added or removed line** in the PR diff itself matches the hash pattern.
The `scripts/codegen/` short-circuit is preserved unchanged.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Workflow-only change — no application code was modified.

Verified the `git diff -G` regex logic locally against several PRs:
- A PR that only adds NatSpec to a file with a `bytes32 constant` declaration → label NOT applied (was previously a false-positive).
- A PR that modifies a `bytes32 constant` value → label IS applied correctly.
- A PR touching `scripts/codegen/` → label IS applied via the short-circuit path.

CI will validate workflow YAML syntax on this PR.

**Node version**: N/A — workflow-only change.

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅