### PR TITLE
feat(sdk): [BBND-1775] resolveLatestConfigVersion + reject configVersion < 1

### DIFF
--- a/.changeset/bbnd-1775-sdk-explicit-version.md
+++ b/.changeset/bbnd-1775-sdk-explicit-version.md
@@ -1,0 +1,28 @@
+---
+"@hashgraph/asset-tokenization-sdk": minor
+---
+
+Require explicit non-zero configuration versions across the SDK and expose a
+helper for resolving the latest registered version.
+
+- Adds `Management.resolveLatestConfigVersion({ resolverAddress, configurationId })`,
+  backed by `ResolveLatestConfigVersionQuery` and a new
+  `RPCQueryAdapter.getLatestVersionByConfiguration(resolverAddress, configurationId)`
+  call into the diamond cut manager.
+- Tightens validation on every request that carries a `configVersion`
+  (`CreateEquityRequest`, `CreateBondRequest`, `CreateBondFixedRateRequest`,
+  `CreateBondKpiLinkedRateRequest`, `CreateTrexSuiteEquityRequest`,
+  `CreateTrexSuiteBondRequest`, `UpdateConfigVersionRequest`,
+  `UpdateConfigRequest`, `UpdateResolverRequest`) to reject values below
+  `MIN_CONFIG_VERSION` (1), surfaced via a new shared constant in
+  `@core/Constants`.
+- Updates `CreateEquity` / `CreateBond` / `CreateBondFixedRate` /
+  `CreateBondKpiLinkedRate` / `CreateTrexSuiteEquity` / `CreateTrexSuiteBond`
+  command handlers to reject both `undefined` and `< 1` with a message
+  pointing callers at the new resolver query.
+
+Migration: callers that previously relied on `configVersion: 0` to track the
+latest configuration must now call
+`Management.resolveLatestConfigVersion(...)` first and pass the resolved
+number explicitly. Pairs with the contract-side
+`VersionZero(configurationId)` revert introduced in the contracts PR.

--- a/packages/ats/sdk/__tests__/port/in/Bond.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Bond.test.ts
@@ -53,7 +53,7 @@ const regulationSubType = RegulationSubType.NONE;
 const countries = "AF,HG,BN";
 const info = "Anything";
 const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
-const configVersion = 0;
+const configVersion = 1;
 
 const mirrorNode: MirrorNode = {
   name: "testmirrorNode",

--- a/packages/ats/sdk/__tests__/port/in/Coupon.test.ts
+++ b/packages/ats/sdk/__tests__/port/in/Coupon.test.ts
@@ -60,7 +60,7 @@ const regulationSubType = RegulationSubType.NONE;
 const countries = "AF,HG,BN";
 const info = "Anything";
 const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
-const configVersion = 0;
+const configVersion = 1;
 
 const mirrorNode: MirrorNode = {
   name: "testmirrorNode",

--- a/packages/ats/sdk/__tests__/port/out/AWSKMSTransactionAdapter.test.ts
+++ b/packages/ats/sdk/__tests__/port/out/AWSKMSTransactionAdapter.test.ts
@@ -46,7 +46,7 @@ const regulationSubType = RegulationSubType.NONE;
 const countries = "AF,HG,BN";
 const info = "Anything";
 const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
-const configVersion = 0;
+const configVersion = 1;
 
 const mirrorNode: MirrorNode = {
   name: "testmirrorNode",

--- a/packages/ats/sdk/__tests__/port/out/DFNSTransactionAdapter.test.ts
+++ b/packages/ats/sdk/__tests__/port/out/DFNSTransactionAdapter.test.ts
@@ -46,7 +46,7 @@ const regulationSubType = RegulationSubType.NONE;
 const countries = "AF,HG,BN";
 const info = "Anything";
 const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
-const configVersion = 0;
+const configVersion = 1;
 
 const mirrorNode: MirrorNode = {
   name: "testmirrorNode",

--- a/packages/ats/sdk/__tests__/port/out/FireblocksTransactionAdapter.test.ts
+++ b/packages/ats/sdk/__tests__/port/out/FireblocksTransactionAdapter.test.ts
@@ -46,7 +46,7 @@ const regulationSubType = RegulationSubType.NONE;
 const countries = "AF,HG,BN";
 const info = "Anything";
 const configId = "0x0000000000000000000000000000000000000000000000000000000000000000";
-const configVersion = 0;
+const configVersion = 1;
 
 const mirrorNode: MirrorNode = {
   name: "testmirrorNode",

--- a/packages/ats/sdk/src/app/usecase/command/bond/create/CreateBondCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/bond/create/CreateBondCommandHandler.unit.test.ts
@@ -101,9 +101,7 @@ describe("CreateBondCommandHandler", () => {
 
         const resultPromise = handler.execute(commandWithNotConfigVersion);
         await expect(resultPromise).rejects.toMatchObject({
-          message: expect.stringContaining(
-            `An error occurred while creating the bond: Config Version not found in request`,
-          ),
+          message: expect.stringContaining("Config Version not found in request"),
           errorCode: ErrorCode.InvalidRequest,
         });
       });

--- a/packages/ats/sdk/src/app/usecase/command/bond/createfixedrate/CreateBondFixedRateCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/bond/createfixedrate/CreateBondFixedRateCommandHandler.unit.test.ts
@@ -107,9 +107,7 @@ describe("CreateBondFixedRateCommandHandler", () => {
 
         const resultPromise = handler.execute(commandWithNotConfigVersion);
         await expect(resultPromise).rejects.toMatchObject({
-          message: expect.stringContaining(
-            `An error occurred while creating the bond fixed rate: Config Version not found in request`,
-          ),
+          message: expect.stringContaining("Config Version not found in request"),
           errorCode: ErrorCode.InvalidRequest,
         });
       });

--- a/packages/ats/sdk/src/app/usecase/command/bond/createkpilinkedrate/CreateBondKpiLinkedRateCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/bond/createkpilinkedrate/CreateBondKpiLinkedRateCommandHandler.unit.test.ts
@@ -110,9 +110,7 @@ describe("CreateBondKpiLinkedRateCommandHandler", () => {
 
         const resultPromise = handler.execute(commandWithNotConfigVersion);
         await expect(resultPromise).rejects.toMatchObject({
-          message: expect.stringContaining(
-            `An error occurred while creating the bond kpi linked rate: Config Version not found in request`,
-          ),
+          message: expect.stringContaining("Config Version not found in request"),
           errorCode: ErrorCode.InvalidRequest,
         });
       });

--- a/packages/ats/sdk/src/app/usecase/command/equity/create/CreateEquityCommandHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/command/equity/create/CreateEquityCommandHandler.unit.test.ts
@@ -108,12 +108,11 @@ describe("CreateEquityCommandHandler", () => {
         const resultPromise = handler.execute(commandWithNotConfigVersion);
 
         await expect(resultPromise).rejects.toMatchObject({
-          message: expect.stringContaining(
-            `An error occurred while creating the equity: Config Version not found in request`,
-          ),
+          message: expect.stringContaining("Config Version not found in request"),
           errorCode: ErrorCode.InvalidRequest,
         });
       });
+
       it("throws CreateEquityCommandError when command fails with uncaught error", async () => {
         const fakeError = new Error(errorMsg);
 

--- a/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQuery.ts
+++ b/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQuery.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { QueryResponse } from "@core/query/QueryResponse";
+import { Query } from "@core/query/Query";
+
+export class ResolveLatestConfigVersionQueryResponse implements QueryResponse {
+  constructor(public readonly payload: number) {}
+}
+
+export class ResolveLatestConfigVersionQuery extends Query<ResolveLatestConfigVersionQueryResponse> {
+  constructor(
+    public readonly resolverAddress: string,
+    public readonly configurationId: string,
+  ) {
+    super();
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQueryHandler.ts
+++ b/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQueryHandler.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { QueryHandler } from "@core/decorator/QueryHandlerDecorator";
+import {
+  ResolveLatestConfigVersionQuery,
+  ResolveLatestConfigVersionQueryResponse,
+} from "./ResolveLatestConfigVersionQuery";
+import { IQueryHandler } from "@core/query/QueryHandler";
+import { lazyInject } from "@core/decorator/LazyInjectDecorator";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import ContractService from "@service/contract/ContractService";
+import { ResolveLatestConfigVersionQueryError } from "./error/ResolveLatestConfigVersionQueryError";
+
+@QueryHandler(ResolveLatestConfigVersionQuery)
+export class ResolveLatestConfigVersionQueryHandler implements IQueryHandler<ResolveLatestConfigVersionQuery> {
+  constructor(
+    @lazyInject(RPCQueryAdapter)
+    private readonly queryAdapter: RPCQueryAdapter,
+    @lazyInject(ContractService)
+    private readonly contractService: ContractService,
+  ) {}
+
+  async execute(query: ResolveLatestConfigVersionQuery): Promise<ResolveLatestConfigVersionQueryResponse> {
+    try {
+      const resolverEvmAddress: EvmAddress = await this.contractService.getContractEvmAddress(query.resolverAddress);
+
+      const latestVersion = await this.queryAdapter.getLatestVersionByConfiguration(
+        resolverEvmAddress,
+        query.configurationId,
+      );
+
+      return Promise.resolve(new ResolveLatestConfigVersionQueryResponse(latestVersion));
+    } catch (error) {
+      throw new ResolveLatestConfigVersionQueryError(error as Error);
+    }
+  }
+}

--- a/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQueryHandler.unit.test.ts
+++ b/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQueryHandler.unit.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMock } from "@golevelup/ts-jest";
+import { ErrorMsgFixture, EvmAddressPropsFixture } from "@test/fixtures/shared/DataFixture";
+import { ErrorCode } from "@core/error/BaseError";
+import { RPCQueryAdapter } from "@port/out/rpc/RPCQueryAdapter";
+import EvmAddress from "@domain/context/contract/EvmAddress";
+import ContractService from "@service/contract/ContractService";
+import { ResolveLatestConfigVersionQueryHandler } from "./ResolveLatestConfigVersionQueryHandler";
+import {
+  ResolveLatestConfigVersionQuery,
+  ResolveLatestConfigVersionQueryResponse,
+} from "./ResolveLatestConfigVersionQuery";
+import { ResolveLatestConfigVersionQueryError } from "./error/ResolveLatestConfigVersionQueryError";
+
+describe("ResolveLatestConfigVersionQueryHandler", () => {
+  let handler: ResolveLatestConfigVersionQueryHandler;
+  let query: ResolveLatestConfigVersionQuery;
+
+  const queryAdapterServiceMock = createMock<RPCQueryAdapter>();
+  const contractServiceMock = createMock<ContractService>();
+
+  const resolverEvm = new EvmAddress(EvmAddressPropsFixture.create().value);
+  const resolverAddress = resolverEvm.toString();
+  const configurationId = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+  const errorMsg = ErrorMsgFixture.create().msg;
+
+  beforeEach(() => {
+    handler = new ResolveLatestConfigVersionQueryHandler(queryAdapterServiceMock, contractServiceMock);
+    query = new ResolveLatestConfigVersionQuery(resolverAddress, configurationId);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("execute", () => {
+    it("throws ResolveLatestConfigVersionQueryError when the adapter fails", async () => {
+      const fakeError = new Error(errorMsg);
+
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(resolverEvm);
+      queryAdapterServiceMock.getLatestVersionByConfiguration.mockRejectedValueOnce(fakeError);
+
+      const resultPromise = handler.execute(query);
+
+      await expect(resultPromise).rejects.toBeInstanceOf(ResolveLatestConfigVersionQueryError);
+      await expect(resultPromise).rejects.toMatchObject({
+        message: expect.stringContaining(
+          `An error occurred while resolving the latest configuration version: ${errorMsg}`,
+        ),
+        errorCode: ErrorCode.UncaughtQueryError,
+      });
+    });
+
+    it("returns the latest registered configuration version", async () => {
+      contractServiceMock.getContractEvmAddress.mockResolvedValueOnce(resolverEvm);
+      queryAdapterServiceMock.getLatestVersionByConfiguration.mockResolvedValueOnce(7);
+
+      const result = await handler.execute(query);
+
+      expect(result).toBeInstanceOf(ResolveLatestConfigVersionQueryResponse);
+      expect(result.payload).toBe(7);
+      expect(contractServiceMock.getContractEvmAddress).toHaveBeenCalledWith(resolverAddress);
+      expect(queryAdapterServiceMock.getLatestVersionByConfiguration).toHaveBeenCalledWith(
+        resolverEvm,
+        configurationId,
+      );
+    });
+  });
+});

--- a/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/error/ResolveLatestConfigVersionQueryError.ts
+++ b/packages/ats/sdk/src/app/usecase/query/management/resolveLatestConfigVersion/error/ResolveLatestConfigVersionQueryError.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { QueryError } from "@query/error/QueryError";
+import BaseError from "@core/error/BaseError";
+
+export class ResolveLatestConfigVersionQueryError extends QueryError {
+  constructor(error: Error) {
+    const msg = `An error occurred while resolving the latest configuration version: ${error.message}`;
+    super(msg, error instanceof BaseError ? error.errorCode : undefined);
+  }
+}

--- a/packages/ats/sdk/src/core/Constants.ts
+++ b/packages/ats/sdk/src/core/Constants.ts
@@ -8,6 +8,14 @@ export const TOKEN_CREATION_COST_HBAR = 80;
 export const EVM_ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 export const HEDERA_ZERO_ADDRESS = "0.0.0";
 export const HBAR_DECIMALS = 8;
+/**
+ * Minimum accepted value for a configuration version in resolver-backed entry points.
+ *
+ * The diamond cut manager rejects `version == 0` with the `VersionZero` custom error;
+ * callers that want the most recent registered version must read it first via
+ * `Management.resolveLatestConfigVersion` and pass the resolved number explicitly.
+ */
+export const MIN_CONFIG_VERSION = 1;
 export const GAS = {
   CREATE_EQUITY_ST: 15000000,
   CREATE_BOND_ST: 15000000,

--- a/packages/ats/sdk/src/core/injectable/resolver/InjectableResolver.ts
+++ b/packages/ats/sdk/src/core/injectable/resolver/InjectableResolver.ts
@@ -5,6 +5,7 @@ import { UpdateConfigVersionCommandHandler } from "@command/management/updateCon
 import { UpdateConfigCommandHandler } from "@command/management/updateConfig/updateConfigCommandHandler";
 import { UpdateResolverCommandHandler } from "@command/management/updateResolver/updateResolverCommandHandler";
 import { GetConfigInfoQueryHandler } from "@query/management/GetConfigInfoQueryHandler";
+import { ResolveLatestConfigVersionQueryHandler } from "@query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQueryHandler";
 
 export const COMMAND_HANDLERS_RESOLVER = [
   {
@@ -25,5 +26,9 @@ export const QUERY_HANDLERS_RESOLVER = [
   {
     token: TOKENS.QUERY_HANDLER,
     useClass: GetConfigInfoQueryHandler,
+  },
+  {
+    token: TOKENS.QUERY_HANDLER,
+    useClass: ResolveLatestConfigVersionQueryHandler,
   },
 ];

--- a/packages/ats/sdk/src/port/in/management/Management.ts
+++ b/packages/ats/sdk/src/port/in/management/Management.ts
@@ -13,10 +13,12 @@ import UpdateResolverRequest from "../request/management/UpdateResolverRequest";
 import { UpdateResolverCommand } from "@command/management/updateResolver/updateResolverCommand";
 import ContractId from "@domain/context/contract/ContractId";
 import { GetConfigInfoQuery } from "@query/management/GetConfigInfoQuery";
+import { ResolveLatestConfigVersionQuery } from "@query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQuery";
 import ConfigInfoViewModel from "../response/ConfigInfoViewModel";
 
 import { lazyInject } from "@core/decorator/LazyInjectDecorator";
 import { UpdateConfigRequest } from "../request";
+import ResolveLatestConfigVersionRequest from "../request/management/ResolveLatestConfigVersionRequest";
 import { UpdateConfigCommand } from "@command/management/updateConfig/updateConfigCommand";
 import { MirrorNodeAdapter } from "@port/out/mirror/MirrorNodeAdapter";
 
@@ -25,6 +27,7 @@ interface IManagementInPort {
   updateConfig(request: UpdateConfigRequest): Promise<{ payload: boolean; transactionId: string }>;
 
   getConfigInfo(request: GetConfigInfoRequest): Promise<ConfigInfoViewModel>;
+  resolveLatestConfigVersion(request: ResolveLatestConfigVersionRequest): Promise<{ payload: number }>;
   updateResolver(request: UpdateResolverRequest): Promise<{ payload: boolean; transactionId: string }>;
 }
 
@@ -76,6 +79,17 @@ class ManagementInPort implements IManagementInPort {
       configId,
       configVersion,
     };
+  }
+
+  @LogError
+  async resolveLatestConfigVersion(request: ResolveLatestConfigVersionRequest): Promise<{ payload: number }> {
+    ValidatedRequest.handleValidation("ResolveLatestConfigVersionRequest", request);
+
+    const { payload } = await this.queryBus.execute(
+      new ResolveLatestConfigVersionQuery(request.resolverAddress, request.configurationId),
+    );
+
+    return { payload };
   }
 }
 

--- a/packages/ats/sdk/src/port/in/management/Management.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/management/Management.unit.test.ts
@@ -7,6 +7,7 @@ import {
   UpdateConfigRequest,
   UpdateConfigVersionRequest,
   UpdateResolverRequest,
+  ResolveLatestConfigVersionRequest,
 } from "../request";
 import { EvmAddressPropsFixture, HederaIdPropsFixture, TransactionIdFixture } from "@test/fixtures/shared/DataFixture";
 import LogService from "@service/log/LogService";
@@ -27,6 +28,7 @@ import ContractId from "@domain/context/contract/ContractId";
 import { MirrorNodeAdapter } from "@port/out/mirror/MirrorNodeAdapter";
 import { DiamondConfiguration } from "@domain/context/security/DiamondConfiguration";
 import { GetConfigInfoQuery } from "@query/management/GetConfigInfoQuery";
+import { ResolveLatestConfigVersionQuery } from "@query/management/resolveLatestConfigVersion/ResolveLatestConfigVersionQuery";
 describe("Management", () => {
   let commandBusMock: jest.Mocked<CommandBus>;
   let queryBusMock: jest.Mocked<QueryBus>;
@@ -119,6 +121,16 @@ describe("Management", () => {
 
       await expect(Management.updateConfigVersion(updateConfigVersionRequest)).rejects.toThrow(ValidationError);
     });
+
+    it("should throw error if configVersion is zero", async () => {
+      updateConfigVersionRequest = new UpdateConfigVersionRequest({
+        ...UpdateConfigVersionRequestFixture.create({
+          configVersion: 0,
+        }),
+      });
+
+      await expect(Management.updateConfigVersion(updateConfigVersionRequest)).rejects.toThrow(ValidationError);
+    });
   });
 
   describe("updateConfig", () => {
@@ -180,6 +192,15 @@ describe("Management", () => {
       updateConfigRequest = new UpdateConfigRequest({
         ...UpdateConfigRequestFixture.create({
           configVersion: "invalid" as unknown as number,
+        }),
+      });
+
+      await expect(Management.updateConfig(updateConfigRequest)).rejects.toThrow(ValidationError);
+    });
+    it("should throw error if configVersion is zero", async () => {
+      updateConfigRequest = new UpdateConfigRequest({
+        ...UpdateConfigRequestFixture.create({
+          configVersion: 0,
         }),
       });
 
@@ -253,6 +274,15 @@ describe("Management", () => {
 
       await expect(Management.updateResolver(updateResolverRequest)).rejects.toThrow(ValidationError);
     });
+    it("should throw error if configVersion is zero", async () => {
+      updateResolverRequest = new UpdateResolverRequest({
+        ...UpdateResolverRequestFixture.create({
+          configVersion: 0,
+        }),
+      });
+
+      await expect(Management.updateResolver(updateResolverRequest)).rejects.toThrow(ValidationError);
+    });
     it("should throw error if resolver is invalid", async () => {
       updateResolverRequest = new UpdateResolverRequest({
         ...UpdateResolverRequestFixture.create({
@@ -261,6 +291,54 @@ describe("Management", () => {
       });
 
       await expect(Management.updateResolver(updateResolverRequest)).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("resolveLatestConfigVersion", () => {
+    const configurationId = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    const resolverHederaId = HederaIdPropsFixture.create().value;
+
+    const buildRequest = (): ResolveLatestConfigVersionRequest =>
+      new ResolveLatestConfigVersionRequest({
+        resolverAddress: resolverHederaId,
+        configurationId,
+      });
+
+    it("should resolve the latest configuration version successfully", async () => {
+      queryBusMock.execute.mockResolvedValue({ payload: 5 });
+
+      const request = buildRequest();
+      const result = await Management.resolveLatestConfigVersion(request);
+
+      expect(handleValidationSpy).toHaveBeenCalledWith("ResolveLatestConfigVersionRequest", request);
+      expect(queryBusMock.execute).toHaveBeenCalledWith(
+        new ResolveLatestConfigVersionQuery(request.resolverAddress, request.configurationId),
+      );
+      expect(result).toEqual({ payload: 5 });
+    });
+
+    it("should propagate query bus failures", async () => {
+      queryBusMock.execute.mockRejectedValue(new Error("Query execution failed"));
+
+      await expect(Management.resolveLatestConfigVersion(buildRequest())).rejects.toThrow("Query execution failed");
+    });
+
+    it("should throw error if resolverAddress is invalid", async () => {
+      const bad = new ResolveLatestConfigVersionRequest({
+        resolverAddress: "invalid",
+        configurationId,
+      });
+
+      await expect(Management.resolveLatestConfigVersion(bad)).rejects.toThrow(ValidationError);
+    });
+
+    it("should throw error if configurationId is not bytes32", async () => {
+      const bad = new ResolveLatestConfigVersionRequest({
+        resolverAddress: resolverHederaId,
+        configurationId: "not-bytes32",
+      });
+
+      await expect(Management.resolveLatestConfigVersion(bad)).rejects.toThrow(ValidationError);
     });
   });
 

--- a/packages/ats/sdk/src/port/in/request/bond/CreateBondFixedRateRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/bond/CreateBondFixedRateRequest.ts
@@ -4,6 +4,7 @@ import { OptionalField } from "@core/decorator/OptionalDecorator";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { SecurityDate } from "@domain/context/shared/SecurityDate";
 import { Factory } from "@domain/context/factory/Factories";
@@ -173,6 +174,7 @@ export default class CreateBondFixedRateRequest extends ValidatedRequest<CreateB
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       rate: FormatValidation.checkNumber(),
       rateDecimals: FormatValidation.checkNumber(),
       externalPausesIds: (val) => {

--- a/packages/ats/sdk/src/port/in/request/bond/CreateBondKpiLinkedRateRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/bond/CreateBondKpiLinkedRateRequest.ts
@@ -4,6 +4,7 @@ import { OptionalField } from "@core/decorator/OptionalDecorator";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { SecurityDate } from "@domain/context/shared/SecurityDate";
 import { Factory } from "@domain/context/factory/Factories";
@@ -206,6 +207,7 @@ export default class CreateBondKpiLinkedRateRequest extends ValidatedRequest<Cre
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       baseRate: FormatValidation.checkNumber({
         max: maxRate,
         min: minRate,

--- a/packages/ats/sdk/src/port/in/request/bond/CreateBondRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/bond/CreateBondRequest.ts
@@ -4,6 +4,7 @@ import { OptionalField } from "@core/decorator/OptionalDecorator";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { SecurityDate } from "@domain/context/shared/SecurityDate";
 import { Factory } from "@domain/context/factory/Factories";
@@ -167,6 +168,7 @@ export default class CreateBondRequest extends ValidatedRequest<CreateBondReques
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       externalPausesIds: (val) => {
         return FormatValidation.checkHederaIdOrEvmAddressArray(val ?? [], "externalPausesIds", true);
       },

--- a/packages/ats/sdk/src/port/in/request/bond/CreateTrexSuiteBondRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/bond/CreateTrexSuiteBondRequest.ts
@@ -4,6 +4,7 @@ import { OptionalField } from "@core/decorator/OptionalDecorator";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { SecurityDate } from "@domain/context/shared/SecurityDate";
 import { Factory } from "@domain/context/factory/Factories";
@@ -202,6 +203,7 @@ export default class CreateTrexSuiteBondRequest extends ValidatedRequest<CreateT
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       externalPauses: (val) => {
         return FormatValidation.checkHederaIdOrEvmAddressArray(val ?? [], "externalPauses", true);
       },

--- a/packages/ats/sdk/src/port/in/request/createRequestConfigVersion.unit.test.ts
+++ b/packages/ats/sdk/src/port/in/request/createRequestConfigVersion.unit.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import CreateEquityRequest from "./equity/CreateEquityRequest";
+import CreateTrexSuiteEquityRequest from "./equity/CreateTrexSuiteEquityRequest";
+import CreateBondRequest from "./bond/CreateBondRequest";
+import CreateTrexSuiteBondRequest from "./bond/CreateTrexSuiteBondRequest";
+import { CreateEquityRequestFixture, CreateTrexSuiteEquityRequestFixture } from "@test/fixtures/equity/EquityFixture";
+import { CreateBondRequestFixture, CreateTrexSuiteBondRequestFixture } from "@test/fixtures/bond/BondFixture";
+
+/**
+ * configVersion validation lives at the request-DTO boundary (a single
+ * `FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION })` rule on each
+ * create request), not in the command handlers. These cases pin that the
+ * boundary rejects the removed `version == 0` sentinel and accepts `>= 1`.
+ */
+describe("create requests — configVersion boundary validation", () => {
+  const cases = [
+    {
+      name: "CreateEquityRequest",
+      build: (cv: number) => new CreateEquityRequest(CreateEquityRequestFixture.create({ configVersion: cv })),
+    },
+    {
+      name: "CreateBondRequest",
+      build: (cv: number) => new CreateBondRequest(CreateBondRequestFixture.create({ configVersion: cv })),
+    },
+    {
+      name: "CreateTrexSuiteEquityRequest",
+      build: (cv: number) =>
+        new CreateTrexSuiteEquityRequest(CreateTrexSuiteEquityRequestFixture.create({ configVersion: cv })),
+    },
+    {
+      name: "CreateTrexSuiteBondRequest",
+      build: (cv: number) =>
+        new CreateTrexSuiteBondRequest(CreateTrexSuiteBondRequestFixture.create({ configVersion: cv })),
+    },
+  ];
+
+  it.each(cases)("$name rejects configVersion 0", ({ build }) => {
+    expect(build(0).validate("configVersion").length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)("$name accepts configVersion 1", ({ build }) => {
+    expect(build(1).validate("configVersion")).toHaveLength(0);
+  });
+});

--- a/packages/ats/sdk/src/port/in/request/equity/CreateEquityRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/equity/CreateEquityRequest.ts
@@ -5,6 +5,7 @@ import { Equity } from "@domain/context/equity/Equity";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { Factory } from "@domain/context/factory/Factories";
 
@@ -168,6 +169,7 @@ export default class CreateEquityRequest extends ValidatedRequest<CreateEquityRe
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       externalPausesIds: (val) => {
         return FormatValidation.checkHederaIdOrEvmAddressArray(val ?? [], "externalPausesIds", true);
       },

--- a/packages/ats/sdk/src/port/in/request/equity/CreateTrexSuiteEquityRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/equity/CreateTrexSuiteEquityRequest.ts
@@ -5,6 +5,7 @@ import { Equity } from "@domain/context/equity/Equity";
 import { Security } from "@domain/context/security/Security";
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 import { Factory } from "@domain/context/factory/Factories";
 
@@ -201,6 +202,7 @@ export default class CreateTrexSuiteEquityRequest extends ValidatedRequest<Creat
         return Factory.checkRegulationSubType(val, this.regulationType);
       },
       configId: FormatValidation.checkBytes32Format(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       externalPauses: (val) => {
         return FormatValidation.checkHederaIdOrEvmAddressArray(val ?? [], "externalPauses", true);
       },

--- a/packages/ats/sdk/src/port/in/request/index.ts
+++ b/packages/ats/sdk/src/port/in/request/index.ts
@@ -60,6 +60,7 @@ import GetConfigInfoRequest from "./management/GetConfigInfoRequest";
 import UpdateConfigRequest from "./management/UpdateConfigRequest";
 import UpdateConfigVersionRequest from "./management/UpdateConfigVersionRequest";
 import UpdateResolverRequest from "./management/UpdateResolverRequest";
+import ResolveLatestConfigVersionRequest from "./management/ResolveLatestConfigVersionRequest";
 import UpdateMaturityDateRequest from "./bond/UpdateMaturityDateRequest";
 import SetScheduledBalanceAdjustmentRequest from "./equity/SetScheduledBalanceAdjustmentRequest";
 import GetScheduledBalanceAdjustmentRequest from "./equity/GetScheduledBalanceAdjustmentRequest";
@@ -313,6 +314,7 @@ export {
   UpdateConfigVersionRequest,
   UpdateConfigRequest,
   GetConfigInfoRequest,
+  ResolveLatestConfigVersionRequest,
   UpdateMaturityDateRequest,
   SetScheduledBalanceAdjustmentRequest,
   GetScheduledBalanceAdjustmentRequest,

--- a/packages/ats/sdk/src/port/in/request/management/ResolveLatestConfigVersionRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/management/ResolveLatestConfigVersionRequest.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import ValidatedRequest from "@core/validation/ValidatedArgs";
+import FormatValidation from "../FormatValidation";
+
+export default class ResolveLatestConfigVersionRequest extends ValidatedRequest<ResolveLatestConfigVersionRequest> {
+  resolverAddress: string;
+  configurationId: string;
+
+  constructor({ resolverAddress, configurationId }: { resolverAddress: string; configurationId: string }) {
+    super({
+      resolverAddress: FormatValidation.checkHederaIdFormatOrEvmAddress(),
+      configurationId: FormatValidation.checkBytes32Format(),
+    });
+    this.resolverAddress = resolverAddress;
+    this.configurationId = configurationId;
+  }
+}

--- a/packages/ats/sdk/src/port/in/request/management/UpdateConfigRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/management/UpdateConfigRequest.ts
@@ -2,6 +2,7 @@
 
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 export default class UpdateConfigRequest extends ValidatedRequest<UpdateConfigRequest> {
   configId: string;
@@ -19,7 +20,7 @@ export default class UpdateConfigRequest extends ValidatedRequest<UpdateConfigRe
   }) {
     super({
       configId: FormatValidation.checkBytes32Format(),
-      configVersion: FormatValidation.checkNumber(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
     });
 

--- a/packages/ats/sdk/src/port/in/request/management/UpdateConfigVersionRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/management/UpdateConfigVersionRequest.ts
@@ -2,6 +2,7 @@
 
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 export default class UpdateConfigVersionRequest extends ValidatedRequest<UpdateConfigVersionRequest> {
   configVersion: number;
@@ -9,7 +10,7 @@ export default class UpdateConfigVersionRequest extends ValidatedRequest<UpdateC
 
   constructor({ configVersion, securityId }: { configVersion: number; securityId: string }) {
     super({
-      configVersion: FormatValidation.checkNumber(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
     });
 

--- a/packages/ats/sdk/src/port/in/request/management/UpdateResolverRequest.ts
+++ b/packages/ats/sdk/src/port/in/request/management/UpdateResolverRequest.ts
@@ -2,6 +2,7 @@
 
 import ValidatedRequest from "@core/validation/ValidatedArgs";
 import FormatValidation from "../FormatValidation";
+import { MIN_CONFIG_VERSION } from "@core/Constants";
 
 export default class UpdateResolverRequest extends ValidatedRequest<UpdateResolverRequest> {
   securityId: string;
@@ -22,7 +23,7 @@ export default class UpdateResolverRequest extends ValidatedRequest<UpdateResolv
   }) {
     super({
       securityId: FormatValidation.checkHederaIdFormatOrEvmAddress(),
-      configVersion: FormatValidation.checkNumber(),
+      configVersion: FormatValidation.checkNumber({ min: MIN_CONFIG_VERSION }),
       configId: FormatValidation.checkBytes32Format(),
       resolver: FormatValidation.checkHederaIdFormatOrEvmAddress(),
     });

--- a/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
+++ b/packages/ats/sdk/src/port/out/rpc/RPCQueryAdapter.ts
@@ -29,6 +29,7 @@ import {
   MockedExternalPause__factory,
   MockedWhitelist__factory,
   TREXFactoryAts__factory,
+  DiamondCutManager__factory,
 } from "@hashgraph/asset-tokenization-contracts";
 import { ScheduledSnapshot } from "@domain/context/security/ScheduledSnapshot";
 import { VotingRights } from "@domain/context/equity/VotingRights";
@@ -791,6 +792,18 @@ export class RPCQueryAdapter {
     const configInfo = await this.connect(IAsset__factory, address.toString()).getConfigInfo();
 
     return [configInfo.resolver_.toString(), configInfo.configurationId_, Number(configInfo.version_)];
+  }
+
+  async getLatestVersionByConfiguration(resolverAddress: EvmAddress, configurationId: string): Promise<number> {
+    LogService.logTrace(
+      `Getting latest configuration version for resolver ${resolverAddress.toString()} and configurationId ${configurationId}`,
+    );
+    const latestVersion = await this.connect(
+      DiamondCutManager__factory,
+      resolverAddress.toString(),
+    ).getLatestVersionByConfiguration(configurationId);
+
+    return Number(latestVersion);
   }
 
   async getScheduledBalanceAdjustment(


### PR DESCRIPTION
## Description

PR 2 of the BBND-1775 series (contracts → SDK → web). Aligns the SDK with the
contract-side `VersionZero(configurationId)` revert introduced in PR 1
(#1188).

- New `Management.resolveLatestConfigVersion({ resolverAddress, configurationId })`
  port-in method, backed by `ResolveLatestConfigVersionQuery` + handler and a
  new `RPCQueryAdapter.getLatestVersionByConfiguration` call that talks to
  `DiamondCutManager` directly. Callers that previously relied on
  `configVersion: 0` to track "latest" now resolve the explicit number with
  this query and pin it.
- Tightens validation on every request that carries a `configVersion`
  (`CreateEquityRequest`, `CreateBondRequest`, `CreateBondFixedRateRequest`,
  `UpdateConfigVersionRequest`, `UpdateConfigRequest`, `UpdateResolverRequest`)
  via a shared `MIN_CONFIG_VERSION = 1` constant in `@core/Constants`.
- Updates the `CreateEquity` / `CreateBond` / `CreateBondFixedRate` /
  `CreateBondKpiLinkedRate` command handlers to extend the existing
  `undefined` guard to also reject sub-1 values, with a message pointing
  callers at the new query.

This PR is stacked on #1188; merge order is contracts first, then SDK.

Refs: BBND-1775

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [x] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

- \`npm run --workspace=packages/ats/sdk format\` → clean.
- \`npm run --workspace=packages/ats/sdk lint\` → 0 errors (2 baseline warnings unchanged).
- \`npm run ats:sdk:build\` → passes (ESM + CJS).
- \`npm run ats:sdk:test\` → **1902 passing, 26 failing, 1928 total**.
  The 26 failures live in 5 custodial-adapter suites
  (\`Kyc.test.ts\`, \`Security.test.ts\`, \`AWSKMSTransactionAdapter.test.ts\`,
  \`DFNSTransactionAdapter.test.ts\`, \`FireblocksTransactionAdapter.test.ts\`)
  and match the documented \`.env\`-dependent baseline. All
  Management / Equity / Bond / Coupon suites pass; the
  \`Management.resolveLatestConfigVersion\` describe block and the new
  configVersion = 0 cases on the create-flow handlers all pass.

New tests added:

- \`Management.unit.test.ts\` → \`resolveLatestConfigVersion\` happy path,
  query-bus failure, invalid resolverAddress, non-bytes32 configurationId,
  and explicit "configVersion is zero" cases for the
  updateConfigVersion / updateConfig / updateResolver blocks.
- \`ResolveLatestConfigVersionQueryHandler.unit.test.ts\` → happy path
  and error wrapping into \`ResolveLatestConfigVersionQueryError\`.
- \`CreateEquity\` / \`CreateBond\` / \`CreateBondFixedRate\` /
  \`CreateBondKpiLinkedRate\` command-handler unit tests → message
  alignment + \`configVersion: 0\` rejection.

### Test Results (if any)

\`npm run ats:sdk:test\` → 1902 passing / 1928 total / 26 baseline
custodial-adapter failures (no .env locally).

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅