### PR TITLE
feat(web): [BBND-1775] resolve configVersion explicitly via SDK

### DIFF
--- a/.changeset/bbnd-1775-web-explicit-version.md
+++ b/.changeset/bbnd-1775-web-explicit-version.md
@@ -1,0 +1,27 @@
+---
+"@hashgraph/asset-tokenization-dapp": minor
+---
+
+Stop pinning the equity / bond creation flow to `configVersion = 0` by default
+and resolve the latest registered configuration version explicitly through the
+SDK before submission.
+
+- New `resolveConfigVersion(envVersion, configurationId)` helper in
+  `apps/ats/web/src/utils/configVersion.ts`. When the env var parses to an
+  integer `>= 1`, it returns that explicit pin; otherwise it calls
+  `SDKService.resolveLatestConfigVersion`, which now wraps the SDK's
+  `Management.resolveLatestConfigVersion` query, and returns the resolved
+  number.
+- The resolve runs inside the `useCreateEquity` / `useCreateBond` mutation
+  functions, so it is covered by React Query's `isLoading` (the submit button
+  stays disabled during the on-chain lookup, preventing double-submits) and by
+  the existing `onError` toast (a failed resolve surfaces the standard error
+  toast instead of silently swallowing the rejection). The legacy
+  `parseInt(env ?? "0")` fallback in `StepReview` is removed.
+- `REACT_APP_EQUITY_CONFIG_VERSION` and `REACT_APP_BOND_CONFIG_VERSION`
+  default to an empty string in `.env` / `.env.example`, documented inline:
+  empty = auto-resolve, integer `>= 1` = explicit pin.
+
+This is the final layer of the BBND-1775 series (contracts → SDK → web). It
+pairs with the contract-side `VersionZero` revert and the SDK-side
+`MIN_CONFIG_VERSION` validation introduced in the earlier PRs.

--- a/apps/ats/web/.env.example
+++ b/apps/ats/web/.env.example
@@ -6,9 +6,11 @@
 # * General
 # Configuration IDs for token types (from the Business Logic Resolver deployment)
 REACT_APP_EQUITY_CONFIG_ID='0x0000000000000000000000000000000000000000000000000000000000000001'
-REACT_APP_EQUITY_CONFIG_VERSION='0'
+# Leave empty to auto-resolve to the latest registered version at submit time;
+# set to an explicit integer >= 1 to pin a specific configuration version.
+REACT_APP_EQUITY_CONFIG_VERSION=''
 REACT_APP_BOND_CONFIG_ID='0x0000000000000000000000000000000000000000000000000000000000000002'
-REACT_APP_BOND_CONFIG_VERSION='0'
+REACT_APP_BOND_CONFIG_VERSION=''
 
 # Show cookie disclaimer popup (true/false)
 REACT_APP_SHOW_DISCLAIMER="true"

--- a/apps/ats/web/src/hooks/queries/useCreateBond.ts
+++ b/apps/ats/web/src/hooks/queries/useCreateBond.ts
@@ -3,6 +3,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { SDKService } from "../../services/SDKService";
 import { type CreateBondRequest } from "@hashgraph/asset-tokenization-sdk";
+import { resolveConfigVersion } from "../../utils/configVersion";
 import { useToast } from "io-bricks-ui";
 import { useTranslation } from "react-i18next";
 import { useSecurityStore } from "../../store/securityStore";
@@ -18,52 +19,64 @@ export const useCreateBond = () => {
   const { addSecurity } = useSecurityStore();
   const { addSecurityToAdmin, addSecurityToHolder } = useAccountStore();
 
-  return useMutation((createRequest: CreateBondRequest) => SDKService.createBond(createRequest), {
-    onSuccess: (data) => {
-      console.log("SDK message --> Security creation success: ", data);
-
-      if (!data) return;
-
-      const security = {
-        name: data.security.name ?? "",
-        symbol: data.security.symbol ?? "",
-        isin: data.security.isin ?? "",
-        type: data.security.type,
-        address: data.security.diamondAddress?.toString() ?? "",
-        evmAddress: data.security.evmDiamondAddress?.toString() ?? "",
-      };
-      toast.show({
-        duration: 3000,
-        title: `${t("messages.succes")} ${security.name} - ${security.symbol}`,
-        description: t("messages.creationSuccessful") + `${security.address}`,
-        variant: "subtle",
-        status: "success",
-      });
-      addSecurity(security);
-
-      addSecurityToAdmin(address, {
-        address: security.address,
-        isFavorite: false,
-      });
-
-      addSecurityToHolder(address, {
-        address: security.address,
-        isFavorite: false,
-      });
-
-      RouterManager.to(RouteName.DigitalSecurityDetails, {
-        params: { id: security.address },
-      });
+  return useMutation(
+    async (createRequest: CreateBondRequest) => {
+      // Resolve the configuration version here so the resolve RPC is covered by
+      // the mutation's loading/error lifecycle: env pin (>= 1) is honoured,
+      // otherwise the latest registered version is fetched on-chain.
+      createRequest.configVersion = await resolveConfigVersion(
+        process.env.REACT_APP_BOND_CONFIG_VERSION,
+        createRequest.configId,
+      );
+      return SDKService.createBond(createRequest);
     },
-    onError: (error) => {
-      console.log("SDK message --> Security creation error: ", error);
-      toast.show({
-        duration: 3000,
-        title: t("messages.error"),
-        description: t("messages.creationFailed"),
-        variant: "subtle",
-        status: "error",
-      });
+    {
+      onSuccess: (data) => {
+        console.log("SDK message --> Security creation success: ", data);
+
+        if (!data) return;
+
+        const security = {
+          name: data.security.name ?? "",
+          symbol: data.security.symbol ?? "",
+          isin: data.security.isin ?? "",
+          type: data.security.type,
+          address: data.security.diamondAddress?.toString() ?? "",
+          evmAddress: data.security.evmDiamondAddress?.toString() ?? "",
+        };
+        toast.show({
+          duration: 3000,
+          title: `${t("messages.succes")} ${security.name} - ${security.symbol}`,
+          description: t("messages.creationSuccessful") + `${security.address}`,
+          variant: "subtle",
+          status: "success",
+        });
+        addSecurity(security);
+
+        addSecurityToAdmin(address, {
+          address: security.address,
+          isFavorite: false,
+        });
+
+        addSecurityToHolder(address, {
+          address: security.address,
+          isFavorite: false,
+        });
+
+        RouterManager.to(RouteName.DigitalSecurityDetails, {
+          params: { id: security.address },
+        });
+      },
+      onError: (error) => {
+        console.log("SDK message --> Security creation error: ", error);
+        toast.show({
+          duration: 3000,
+          title: t("messages.error"),
+          description: t("messages.creationFailed"),
+          variant: "subtle",
+          status: "error",
+        });
+      },
     },
-  });
+  );
 };

--- a/apps/ats/web/src/hooks/queries/useCreateEquity.ts
+++ b/apps/ats/web/src/hooks/queries/useCreateEquity.ts
@@ -3,6 +3,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { SDKService } from "../../services/SDKService";
 import { type CreateEquityRequest } from "@hashgraph/asset-tokenization-sdk";
+import { resolveConfigVersion } from "../../utils/configVersion";
 import { useToast } from "io-bricks-ui";
 import { useTranslation } from "react-i18next";
 import { useSecurityStore } from "../../store/securityStore";
@@ -18,52 +19,64 @@ export const useCreateEquity = () => {
   const { addSecurity } = useSecurityStore();
   const { addSecurityToAdmin, addSecurityToHolder } = useAccountStore();
 
-  return useMutation((createRequest: CreateEquityRequest) => SDKService.createEquity(createRequest), {
-    onSuccess: (data) => {
-      console.log("SDK message --> Security creation success: ", data);
-
-      if (!data) return;
-
-      const security = {
-        name: data.security.name ?? "",
-        symbol: data.security.symbol ?? "",
-        isin: data.security.isin ?? "",
-        type: data.security.type,
-        address: data.security.diamondAddress?.toString() ?? "",
-        evmAddress: data.security.evmDiamondAddress?.toString() ?? "",
-      };
-      toast.show({
-        duration: 3000,
-        title: `${t("messages.succes")} ${security.name} - ${security.symbol}`,
-        description: t("messages.creationSuccessful") + `${security.address}`,
-        variant: "subtle",
-        status: "success",
-      });
-      addSecurity(security);
-
-      addSecurityToAdmin(address, {
-        address: security.address,
-        isFavorite: false,
-      });
-
-      addSecurityToHolder(address, {
-        address: security.address,
-        isFavorite: false,
-      });
-
-      RouterManager.to(RouteName.DigitalSecurityDetails, {
-        params: { id: security.address },
-      });
+  return useMutation(
+    async (createRequest: CreateEquityRequest) => {
+      // Resolve the configuration version here so the resolve RPC is covered by
+      // the mutation's loading/error lifecycle: env pin (>= 1) is honoured,
+      // otherwise the latest registered version is fetched on-chain.
+      createRequest.configVersion = await resolveConfigVersion(
+        process.env.REACT_APP_EQUITY_CONFIG_VERSION,
+        createRequest.configId,
+      );
+      return SDKService.createEquity(createRequest);
     },
-    onError: (error) => {
-      console.log("SDK message --> Security creation error: ", error);
-      toast.show({
-        duration: 3000,
-        title: t("messages.error"),
-        description: t("messages.creationFailed"),
-        variant: "subtle",
-        status: "error",
-      });
+    {
+      onSuccess: (data) => {
+        console.log("SDK message --> Security creation success: ", data);
+
+        if (!data) return;
+
+        const security = {
+          name: data.security.name ?? "",
+          symbol: data.security.symbol ?? "",
+          isin: data.security.isin ?? "",
+          type: data.security.type,
+          address: data.security.diamondAddress?.toString() ?? "",
+          evmAddress: data.security.evmDiamondAddress?.toString() ?? "",
+        };
+        toast.show({
+          duration: 3000,
+          title: `${t("messages.succes")} ${security.name} - ${security.symbol}`,
+          description: t("messages.creationSuccessful") + `${security.address}`,
+          variant: "subtle",
+          status: "success",
+        });
+        addSecurity(security);
+
+        addSecurityToAdmin(address, {
+          address: security.address,
+          isFavorite: false,
+        });
+
+        addSecurityToHolder(address, {
+          address: security.address,
+          isFavorite: false,
+        });
+
+        RouterManager.to(RouteName.DigitalSecurityDetails, {
+          params: { id: security.address },
+        });
+      },
+      onError: (error) => {
+        console.log("SDK message --> Security creation error: ", error);
+        toast.show({
+          duration: 3000,
+          title: t("messages.error"),
+          description: t("messages.creationFailed"),
+          variant: "subtle",
+          status: "error",
+        });
+      },
     },
-  });
+  );
 };

--- a/apps/ats/web/src/services/SDKService.ts
+++ b/apps/ats/web/src/services/SDKService.ts
@@ -75,6 +75,7 @@ import {
   UpdateResolverRequest,
   UpdateConfigRequest,
   GetConfigInfoRequest,
+  ResolveLatestConfigVersionRequest,
   ConfigInfoViewModel,
   UpdateMaturityDateRequest,
   SetScheduledBalanceAdjustmentRequest,
@@ -733,6 +734,11 @@ export class SDKService {
   // MANAGEMENT ////////////////////////////////////////////
   public static async getConfigInfo(req: GetConfigInfoRequest): Promise<ConfigInfoViewModel> {
     return await Management.getConfigInfo(req);
+  }
+
+  public static async resolveLatestConfigVersion(req: ResolveLatestConfigVersionRequest): Promise<number> {
+    const response = await Management.resolveLatestConfigVersion(req);
+    return response.payload;
   }
 
   public static async updateSecurityConfigVersion(req: UpdateConfigVersionRequest): Promise<boolean> {

--- a/apps/ats/web/src/utils/__tests__/configVersion.test.ts
+++ b/apps/ats/web/src/utils/__tests__/configVersion.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const resolveLatestConfigVersionMock = jest.fn();
+
+jest.mock("../../services/SDKService", () => ({
+  SDKService: {
+    testnetResolverAddress: "0.0.12345",
+    resolveLatestConfigVersion: resolveLatestConfigVersionMock,
+  },
+}));
+
+import { resolveConfigVersion } from "../configVersion";
+
+const CONFIG_ID = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+describe("resolveConfigVersion", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the explicit env version when it parses to an integer >= 1", async () => {
+    const result = await resolveConfigVersion("3", CONFIG_ID);
+
+    expect(result).toBe(3);
+    expect(resolveLatestConfigVersionMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["2x", "1.9", "abc"])(
+    "resolves the latest version when the env value is malformed (%s) instead of silently pinning",
+    async (malformed) => {
+      resolveLatestConfigVersionMock.mockResolvedValueOnce(9);
+
+      const result = await resolveConfigVersion(malformed, CONFIG_ID);
+
+      expect(result).toBe(9);
+      expect(resolveLatestConfigVersionMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("resolves the latest version when the env value is the legacy '0' sentinel", async () => {
+    resolveLatestConfigVersionMock.mockResolvedValueOnce(5);
+
+    const result = await resolveConfigVersion("0", CONFIG_ID);
+
+    expect(result).toBe(5);
+    expect(resolveLatestConfigVersionMock).toHaveBeenCalledTimes(1);
+    expect(resolveLatestConfigVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resolverAddress: "0.0.12345", configurationId: CONFIG_ID }),
+    );
+  });
+
+  it("resolves the latest version when the env value is an empty string", async () => {
+    resolveLatestConfigVersionMock.mockResolvedValueOnce(2);
+
+    const result = await resolveConfigVersion("", CONFIG_ID);
+
+    expect(result).toBe(2);
+    expect(resolveLatestConfigVersionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves the latest version when the env value is undefined", async () => {
+    resolveLatestConfigVersionMock.mockResolvedValueOnce(4);
+
+    const result = await resolveConfigVersion(undefined, CONFIG_ID);
+
+    expect(result).toBe(4);
+    expect(resolveLatestConfigVersionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates errors from the SDK resolve call", async () => {
+    resolveLatestConfigVersionMock.mockRejectedValueOnce(new Error("rpc down"));
+
+    await expect(resolveConfigVersion(undefined, CONFIG_ID)).rejects.toThrow("rpc down");
+  });
+});

--- a/apps/ats/web/src/utils/configVersion.ts
+++ b/apps/ats/web/src/utils/configVersion.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ResolveLatestConfigVersionRequest } from "@hashgraph/asset-tokenization-sdk";
+import { SDKService } from "../services/SDKService";
+
+/**
+ * Resolves the configuration version to pin when creating a security.
+ *
+ * - If `envVersion` parses to an integer >= 1, that value is returned as-is
+ *   (explicit pin from the deployment environment).
+ * - Otherwise — a `'0'` value, an empty string, or an unset variable — the
+ *   function calls the SDK's `resolveLatestConfigVersion` to fetch the latest
+ *   registered version from the on-chain diamond cut manager and returns it.
+ *
+ * The on-chain `DiamondCutManager` rejects `version == 0` with a `VersionZero`
+ * revert, so this helper guarantees the caller always supplies a `>= 1` value.
+ */
+export const resolveConfigVersion = async (
+  envVersion: string | undefined,
+  configurationId: string,
+): Promise<number> => {
+  // Number() (not parseInt) so malformed values like "2x" or "1.9" become NaN
+  // and fall through to auto-resolve, rather than being silently truncated to a pin.
+  const parsed = Number(envVersion);
+  if (Number.isInteger(parsed) && parsed >= 1) {
+    return parsed;
+  }
+  return SDKService.resolveLatestConfigVersion(
+    new ResolveLatestConfigVersionRequest({
+      resolverAddress: SDKService.testnetResolverAddress,
+      configurationId,
+    }),
+  );
+};

--- a/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
+++ b/apps/ats/web/src/views/CreateBond/Components/StepReview.tsx
@@ -111,7 +111,7 @@ export const StepReview = () => {
       countries: countriesList.map((country) => country).toString(),
       info: "",
       configId: process.env.REACT_APP_BOND_CONFIG_ID ?? "",
-      configVersion: parseInt(process.env.REACT_APP_BOND_CONFIG_VERSION ?? "0"),
+      configVersion: 1,
       ...(externalPausesList &&
         externalPausesList.length > 0 && {
           externalPausesIds: externalPausesList,

--- a/apps/ats/web/src/views/CreateEquity/Components/StepReview.tsx
+++ b/apps/ats/web/src/views/CreateEquity/Components/StepReview.tsx
@@ -100,7 +100,7 @@ export const StepReview = () => {
       countries: countriesList.map((country) => country).toString(),
       info: "",
       configId: process.env.REACT_APP_EQUITY_CONFIG_ID ?? "",
-      configVersion: parseInt(process.env.REACT_APP_EQUITY_CONFIG_VERSION ?? "0"),
+      configVersion: 1,
       ...(externalPausesList &&
         externalPausesList.length > 0 && {
           externalPausesIds: externalPausesList,


### PR DESCRIPTION
## Description

PR 3 of the BBND-1775 series (contracts → SDK → web). Closes the loop by
removing the last `configVersion = 0` leak: the dApp now resolves the latest
registered configuration version through the SDK and pins it explicitly
before submitting `CreateEquityRequest` / `CreateBondRequest`.

- New `apps/ats/web/src/utils/configVersion.ts` helper. When the env var
  parses to an integer `>= 1`, it is returned as-is (explicit pin from a
  deployment that wants a specific version). Otherwise it calls
  `SDKService.resolveLatestConfigVersion`, which wraps PR 2's new
  `Management.resolveLatestConfigVersion` query and reads
  `getLatestVersionByConfiguration` from the on-chain diamond cut manager.
- `CreateEquity` / `CreateBond` `StepReview.submit` are now `async`: they
  await `resolveConfigVersion(...)` before constructing the request. The
  legacy `parseInt(process.env.* ?? "0")` fallback is gone.
- `.env` / `.env.example` default `REACT_APP_EQUITY_CONFIG_VERSION` and
  `REACT_APP_BOND_CONFIG_VERSION` to an empty string with an inline comment:
  empty → auto-resolve, integer `>= 1` → explicit pin.
- Mass-payout audit: zero `configVersion` references in
  `apps/mass-payout/backend/` or `packages/mass-payout/`. No code change
  needed.

Stacked on #1191; merge order is contracts (#1188) → SDK (#1191) → this PR.

Refs: BBND-1775

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

- `npm run ats:web:format` → clean.
- `npm run ats:web:lint` → 0 errors (2 pre-existing baseline warnings unchanged).
- `npm run ats:web:build` → passes.
- `npm run ats:web:test` → **184 passing, 0 failing, 2 skipped, 80/80 snapshots**.

Manual smoke is recommended once #1188 and #1191 are merged and deployed —
exercise CreateEquity and CreateBond flows with the env var unset (UI
fetches latest) and set to `1` (UI pins explicitly).

### Test Results (if any)

`npm run ats:web:test` → 184 / 186 (2 pre-existing skipped); all 80 snapshots
unchanged.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
