### PR TITLE
fix: [FIND-071] _removeTokenHolder Missing Existence Check

### DIFF
--- a/.changeset/find-071-remove-token-holder-validation.md
+++ b/.changeset/find-071-remove-token-holder-validation.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Fix FIND-071: `removeTokenHolder` did not validate that the holder was registered before executing removal, causing silent state corruption and incorrect holder count when called for non-existent holders. Add `_checkUnexpectedError` guard on `tokenHolderIndex == 0` using new `KPI_ERC1410_REMOVE_HOLDER` error ID.

--- a/packages/ats/contracts/contracts/constants/values.sol
+++ b/packages/ats/contracts/contracts/constants/values.sol
@@ -90,6 +90,9 @@ bytes4 constant KPI_LINKED_RATE_COUPON = 0x0000000A;
 /// @dev ID for ClearingOps.clearingHoldCreationExecution()
 bytes4 constant CLEARING_HOLD_CREATION = 0x0000000B;
 
+/// @dev ID for ERC1410StorageWrapper.removeTokenHolder()
+bytes4 constant KPI_ERC1410_REMOVE_HOLDER = 0x0000000C;
+
 /// @dev Precomputed constants for powers of 10 (0-18)
 uint256 constant POW10_0 = 1;
 uint256 constant POW10_1 = 10;

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -21,8 +21,9 @@ import { ScheduledTasksStorageWrapper } from "./ScheduledTasksStorageWrapper.sol
 import { ScheduledTasksOps } from "../orchestrator/ScheduledTasksOps.sol";
 import { SnapshotsStorageWrapper } from "./SnapshotsStorageWrapper.sol";
 import { TimeTravelStorageWrapper } from "../../test/testTimeTravel/timeTravel/TimeTravelStorageWrapper.sol";
-import { _DEFAULT_PARTITION } from "../../constants/values.sol";
+import { _DEFAULT_PARTITION, KPI_ERC1410_REMOVE_HOLDER } from "../../constants/values.sol";
 import { _checkNonceAndDeadline } from "../../infrastructure/utils/EIP712.sol";
+import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 
 /// @custom:hash storage Erc1410Basic
 bytes32 constant STORAGE_LOCATION_ERC1410_BASIC = 0x2b7b9d433e782d7e5384db9a591ac5085e24b04d9aa9a09e22954f9f253cf000;
@@ -149,8 +150,9 @@ library ERC1410StorageWrapper {
         ERC1410BasicStorage storage basicStorage = erc1410BasicStorage();
 
         uint256 lastIndex = basicStorage.totalTokenHolders;
+        uint256 tokenHolderIndex = basicStorage.tokenHolderIndex[tokenHolder];
+        _checkUnexpectedError(tokenHolderIndex == 0, KPI_ERC1410_REMOVE_HOLDER);
         if (lastIndex > 1) {
-            uint256 tokenHolderIndex = basicStorage.tokenHolderIndex[tokenHolder];
             if (tokenHolderIndex < lastIndex) {
                 address lastTokenHolder = basicStorage.tokenHolders[lastIndex];
 

--- a/packages/ats/contracts/contracts/test/mocks/MockERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockERC1410StorageWrapper.sol
@@ -5,11 +5,12 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
 import { IERC1410Types } from "../../facets/layer_1/ERC1400/ERC1410/IERC1410Types.sol";
+import { ICommonErrors } from "../../infrastructure/errors/ICommonErrors.sol";
 
 /// @dev Test-only mock that exposes internal ERC1410StorageWrapper functions
 /// so that unit tests can exercise them directly without going through the full
 /// diamond infrastructure.
-contract MockERC1410StorageWrapper is IERC1410Types {
+contract MockERC1410StorageWrapper is IERC1410Types, ICommonErrors {
     function exposed_addNewTokenHolder(address tokenHolder) external {
         ERC1410StorageWrapper.addNewTokenHolder(tokenHolder);
     }

--- a/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/SecurityHolders.test.ts
@@ -493,4 +493,31 @@ describe("SecurityHoldersFacet Tests", () => {
       expect(slotValue).to.equal(ethers.ZeroHash);
     });
   });
+
+  describe("removeTokenHolder unregistered holder guard", () => {
+    let mock: MockERC1410StorageWrapper;
+
+    beforeEach(async () => {
+      const factory = await ethers.getContractFactory("MockERC1410StorageWrapper");
+      mock = (await factory.deploy()) as unknown as MockERC1410StorageWrapper;
+      await mock.waitForDeployment();
+    });
+
+    it("GIVEN an unregistered address WHEN removeTokenHolder is called THEN reverts with UnexpectedError", async () => {
+      await expect(mock.exposed_removeTokenHolder(signer_B.address))
+        .to.be.revertedWithCustomError(mock, "UnexpectedError")
+        .withArgs("0x0000000c");
+    });
+
+    it("GIVEN a registered holder WHEN removeTokenHolder is called THEN succeeds and holder count decrements", async () => {
+      await mock.exposed_addNewTokenHolder(signer_B.address);
+
+      expect(await mock.exposed_getTotalTokenHolders()).to.equal(1);
+
+      await mock.exposed_removeTokenHolder(signer_B.address);
+
+      expect(await mock.exposed_getTotalTokenHolders()).to.equal(0);
+      expect(await mock.exposed_getTokenHolderIndex(signer_B.address)).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
This pull request addresses a bug in the `removeTokenHolder` function of the ERC1410 token contract, where previously it was possible to attempt to remove a token holder who was not actually registered, leading to silent state corruption and incorrect holder counts. The fix introduces a validation check with a new error ID to prevent this condition and improve contract safety.

**Bug fix and validation improvements:**

* Added a guard in `ERC1410StorageWrapper.removeTokenHolder` to ensure the holder is registered before removal, using `_checkUnexpectedError` and the new `KPI_ERC1410_REMOVE_HOLDER` error ID. This prevents silent state corruption and incorrect holder counts when attempting to remove non-existent holders. [[1]](diffhunk://#diff-70656b98471e35757a5011a441e7bc382ffa6764ed4fbf602fe5237e7a7b908cL152-R155) [[2]](diffhunk://#diff-29b352da87221adbdc82b0d1d47fbe059b23ba0055607061f7cc266851497e6cR1-R5)

**Constants and utility updates:**

* Introduced the `KPI_ERC1410_REMOVE_HOLDER` error ID constant in `values.sol` to uniquely identify this validation error.
* Updated imports in `ERC1410StorageWrapper.sol` to include `KPI_ERC1410_REMOVE_HOLDER` and `_checkUnexpectedError` for the new validation logic.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
