### PR TITLE
fix(changeset): correct package names and add CI validation guard

### DIFF
--- a/.changeset/maf-split-snapshotsByPartition.md
+++ b/.changeset/maf-split-snapshotsByPartition.md
@@ -1,5 +1,5 @@
 ---
-"@asset-tokenization-studio/ats-contracts": major
+"@hashgraph/asset-tokenization-contracts": major
 ---
 
 MAF split: extract `partitionsOfAtSnapshot` from `SnapshotsFacet` into a new `SnapshotsByPartitionFacet`.

--- a/.changeset/maf-split-transferByPartition.md
+++ b/.changeset/maf-split-transferByPartition.md
@@ -1,5 +1,5 @@
 ---
-"@asset-tokenization-studio/ats-contracts": major
+"@hashgraph/asset-tokenization-contracts": major
 ---
 
 MAF split: extract `transferByPartition` from `ERC1410TokenHolderFacet` into a new `TransferByPartitionFacet`, draining the source facet.

--- a/.github/workflows/000-flow-changeset-check.yaml
+++ b/.github/workflows/000-flow-changeset-check.yaml
@@ -115,6 +115,26 @@ jobs:
             exit 1
           fi
 
+      - name: Validate changeset contents
+        if: ${{ steps.bypass.outputs.bypass == 'false' }}
+        run: |
+          echo "🔍 Validating that all pending changesets reference known workspace packages..."
+          if ! npx changeset status; then
+            echo ""
+            echo "❌ CHANGESET CONTENT VALIDATION FAILED"
+            echo ""
+            echo "One or more .changeset/*.md files reference a package name that does not"
+            echo "exist in this workspace (see .changeset/config.json 'fixed' groups for the"
+            echo "authoritative names). Open the failing changeset and replace the package"
+            echo "name with the correct workspace name, e.g.:"
+            echo ""
+            echo "  @asset-tokenization-studio/ats-contracts  ->  @hashgraph/asset-tokenization-contracts"
+            echo ""
+            echo "Then re-run \`npx changeset status\` locally to confirm before pushing."
+            exit 1
+          fi
+          echo "✅ All pending changesets reference valid workspace packages"
+
       - name: Success summary
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
## Description

Two pending changesets referenced `@asset-tokenization-studio/ats-contracts`, which is not a workspace package name. The authoritative names are defined in the `fixed` group of `.changeset/config.json`; the correct name for the ATS contracts package is `@hashgraph/asset-tokenization-contracts`.

Left uncorrected, `npx changeset status` errors out with _"Found changeset … for package … which is not in the workspace"_ and the release flow either fails or silently skips the changeset, causing the intended version bump to be missed. This surfaced while reviewing baseline test results on the BBND-1672 branch.

This PR delivers two changes:

1. **Data fix** — corrects the package name in `.changeset/maf-split-snapshotsByPartition.md` (contributed in #1063 by @mamoralesiob) and `.changeset/maf-split-transferByPartition.md`. Both now declare `@hashgraph/asset-tokenization-contracts: major`.

2. **CI guard** — adds a `Validate changeset contents` step to `000-flow-changeset-check.yaml` that runs `npx changeset status` after the existing new-changeset detection. The command exits non-zero when any pending changeset references an unknown package name, breaking CI early with a hint at the most common typo and a reminder to consult `.changeset/config.json`. The step is gated on `bypass.outputs.bypass == 'false'`, consistent with the surrounding steps, so bypassed PRs (no-changeset / docs-only / chore / hotfix) skip it.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

`npx changeset status` at repo root — passes (previously errored on the two malformed changeset files). The new CI step replicates this check on every non-bypassed PR to prevent a recurrence.

### Test Results (if any)

```
$ npx changeset status
🦋  Found 12 changesets
```
(Previously terminated with an error on the two files corrected here.)

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅