### PR TITLE
fix(contracts): bootstrap orchestrator library addresses in unit suite

### DIFF
--- a/packages/ats/contracts/test/scripts/unit/domain/atsRegistry.generated.test.ts
+++ b/packages/ats/contracts/test/scripts/unit/domain/atsRegistry.generated.test.ts
@@ -30,6 +30,8 @@ import {
   getStorageWrapperRegistryCount,
   atsRegistry,
   isLibraryDependentFacet,
+  hasOrchestratorLibraryAddresses,
+  setOrchestratorLibraryAddresses,
 } from "@scripts/domain";
 
 describe("atsRegistry.generated - Factory Functions", () => {
@@ -40,6 +42,26 @@ describe("atsRegistry.generated - Factory Functions", () => {
 
   before(async () => {
     [signer] = await ethers.getSigners();
+    // Self-sufficient unit-suite bootstrap: when this file runs in isolation
+    // (e.g. `npm test -- test/scripts/unit/...`) no upstream integration fixture
+    // has primed the orchestrator-library module state, so factory branches
+    // that transitively call `getLibLinks()` revert with "addresses not set".
+    // Seed zero-address placeholders — no deployment happens here, the factories
+    // are only constructed, never invoked. Guarded so integration runs that
+    // already set real addresses are left untouched.
+    if (!hasOrchestratorLibraryAddresses()) {
+      const zero = ethers.ZeroAddress;
+      setOrchestratorLibraryAddresses({
+        tokenCoreOps: zero,
+        holdOps: zero,
+        clearingOps: zero,
+        clearingLifecycleOps: zero,
+        clearingReadOps: zero,
+        clearingProtectedOps: zero,
+        scheduledTasksOps: zero,
+        scheduledTasksDispatchOps: zero,
+      });
+    }
   });
 
   // Helper to check if a facet can be safely instantiated without library addresses


### PR DESCRIPTION
## Description

Fixes a latent test-order dependency in
`packages/ats/contracts/test/scripts/unit/domain/atsRegistry.generated.test.ts`.
The suite exercises every facet's TypeChain factory; for a handful of facets the
generated registry's factory closure transitively calls `getLibLinks()`, which
throws `Orchestrator library addresses not set` unless
`setOrchestratorLibraryAddresses()` has already been invoked elsewhere.

Today the suite passes only because `npm test` runs integration fixtures first,
which populate the module-level state in
`scripts/domain/orchestratorLibraries.ts`. Running the unit suite in isolation
(`npx hardhat test test/scripts/unit/domain/atsRegistry.generated.test.ts`, IDE
single-file runs, any future split `test:unit` CI job) surfaces six failures.
Reproduced on `origin/development` @ 163f5cdb8.

Adds a self-sufficient `before()` bootstrap that seeds `ethers.ZeroAddress`
placeholders via `setOrchestratorLibraryAddresses(...)` when no real addresses
have been set yet. The factories are only constructed in this suite (never
invoked), so zero-address placeholders are inert. Integration runs that have
already set real addresses are left untouched (guarded by
`hasOrchestratorLibraryAddresses()`).

Note: `npm run ats:contracts:test` (and CI's `ats:test:ci` -> `ats:contracts:test:ci`)
already include this file via
`bash -c 'npx hardhat test $(find test/contracts/integration test/scripts -name "*.test.ts")'`.
Coverage is fine; the bug is purely an ordering accident, not a CI gap.

Surfaced during BBND-1672 baseline-comparison work.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Reproduced baseline: stashed the fix, ran
`npx hardhat test test/scripts/unit/domain/atsRegistry.generated.test.ts` from
`packages/ats/contracts/` -> 6 failures, all "Orchestrator library addresses
not set".

With the fix applied: same command -> 108 passing, 0 failing.

`npm run ats:contracts:format` + `npm run ats:contracts:lint` clean.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
