### PR TITLE
fix(ci): fetch main branch for changeset status check

### DIFF
--- a/.github/workflows/000-flow-changeset-check.yaml
+++ b/.github/workflows/000-flow-changeset-check.yaml
@@ -45,6 +45,16 @@ jobs:
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
           git branch -a
 
+      - name: Fetch changeset base branch (main)
+        if: ${{ github.base_ref != 'main' }}
+        run: |
+          # `npx changeset status` reads `baseBranch` from .changeset/config.json
+          # (currently "main") and resolves it locally via `getDivergedCommit`. The
+          # previous "Fetch base branch" step only fetches the PR base, so `main`
+          # is absent for PRs targeting `development` and the status command
+          # fails with "Failed to find where HEAD diverged from 'main'".
+          git fetch origin main:main
+
       - name: Setup NodeJS Environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:


### PR DESCRIPTION
## Description

Since e8525c03e landed the \`Validate changeset contents\` step (which calls \`npx changeset status\`), **every PR targeting \`development\` has been failing CI** on that step. The root cause: \`npx changeset status\` resolves \`baseBranch\` from \`.changeset/config.json\` (currently \`"main"\`) via an internal \`getDivergedCommit("main")\` call. The existing "Fetch base branch" step only fetches the PR's target ref (\`development\` for virtually every PR), so \`main\` is absent from the runner's shallow checkout and the command fails with:

```
Failed to find where HEAD diverged from "main".
Does "main" exist and it's synced with remote?
```

This then surfaces misleadingly as a "package name not in workspace" error, making it look like the changeset itself is wrong even when it's perfectly valid. Symptoms confirmed in PR #1213 (run [26570454443 / job 78275937248](https://github.com/hashgraph/asset-tokenization-studio/actions/runs/26570454443/job/78275937248)).

Fix: adds a dedicated **"Fetch changeset base branch (main)"** step immediately after "Fetch base branch", gated by \`github.base_ref != 'main'\` so release PRs targeting \`main\` don't double-fetch their own base.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

This is a workflow-only change (`.github/workflows/000-flow-changeset-check.yaml`, 10 insertions). No local repro is possible without simulating the runner's shallow fetch environment.

Primary verification: merge this PR and rerun the `Changeset Check` workflow on PR #1213 (or any open PR targeting `development`). The `Validate changeset contents` step should now pass instead of failing with the "diverged from main" error.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅