### PR TITLE
refactor(contracts): normalise ERC-7201 storage structs to canonical 5-region layout

### DIFF
--- a/.changeset/storage-5region-normalization.md
+++ b/.changeset/storage-5region-normalization.md
@@ -1,0 +1,7 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+Normalise every ERC-7201 storage struct to the canonical 5-region banner layout and remove dead per-struct `initialized` fields (now owned by the centralised initializer).
+
+Breaking: reordering the business-logic resolver's `initialized` flag and dropping the dead flags on NominalValue, KpiLinkedRate and InterestRateType shift in-namespace field offsets — existing deployments must be redeployed, not upgraded in place.

--- a/docs/ats/developer-guides/contracts/adding-facets.md
+++ b/docs/ats/developer-guides/contracts/adding-facets.md
@@ -135,6 +135,10 @@ If your facet requires custom storage, create a storage wrapper under
 → **R3 Single-slot scalars (uint256, bytes32, string)** → **R4 Aggregates
 (mapping, array, EnumerableSet, checkpoint arrays)** → **APPEND-ONLY ZONE**.
 New fields go below the marker — the boundary is greppable and audit-visible.
+All four region banners are **always present, in canonical order, even when a region has no
+fields** — the empty banners are scaffolding that fixes each field's insertion point and the
+region numbering. Never renumber a region when its only field is removed; leave the empty
+banner in place.
 
 **File**: `contracts/domain/asset/rewards/RewardsStorageWrapper.sol`
 
@@ -151,9 +155,10 @@ bytes32 constant STORAGE_LOCATION_REWARDS = 0x0000000000000000000000000000000000
 struct RewardsDataStorage {
   // ─── R1 Lifecycle (bool flags) ───────────────────────────
   bool initialized;
+  // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
   // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
   uint256 totalDistributed;
-  // ─── R4 Aggregates (mapping, array, EnumerableSet, checkpoint arrays) ──
+  // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
   mapping(address => uint256) totalRewards;
   mapping(address => uint256) lastDistribution;
   // ─── APPEND-ONLY ZONE BELOW ───

--- a/docs/ats/developer-guides/contracts/documenting-contracts.md
+++ b/docs/ats/developer-guides/contracts/documenting-contracts.md
@@ -128,7 +128,7 @@ modifier onlyBondManager() {
 
 ### Storage Documentation
 
-Storage structs live at **file scope** in `*StorageWrapper.sol` (never inside a contract or interface) and carry an ERC-7201 `@custom:storage-location erc7201:security.token.standard.storage.<PascalName>` annotation. The annotation argument shares the same PascalCase suffix as the paired `STORAGE_LOCATION_*` bytes32 constant — see `.claude/rules/20-solidity/conventions.md` §6 and `hash-constants-naming.md` §3 for the full 5-region layout convention.
+Storage structs live at **file scope** in `*StorageWrapper.sol` (never inside a contract or interface) and carry an ERC-7201 `@custom:storage-location erc7201:security.token.standard.storage.<PascalName>` annotation. The annotation argument shares the same PascalCase suffix as the paired `STORAGE_LOCATION_*` bytes32 constant — see `.claude/rules/20-solidity/conventions.md` §6 and `hash-constants-naming.md` §3 for the full 5-region layout convention. All four region banners are **always present, in canonical order, even when a region has no fields** (empty-region banners are mandatory scaffolding); the region number ↔ meaning mapping is fixed and must never be renumbered.
 
 ```solidity
 /// @custom:hash storage Bond
@@ -140,7 +140,8 @@ struct BondDataStorage {
   bool initialized;
   // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
   address defaultPaymentToken;
-  // ─── R4 Aggregates (mapping, array, EnumerableSet, checkpoint arrays) ──
+  // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+  // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
   mapping(address => BondConfig) bondConfigs;
   mapping(address => mapping(uint256 => CouponPayment)) couponPayments;
   // ─── APPEND-ONLY ZONE BELOW ───

--- a/docs/ats/developer-guides/contracts/overview.md
+++ b/docs/ats/developer-guides/contracts/overview.md
@@ -126,7 +126,7 @@ contracts/
 
 ### Domain: Storage Wrappers (formerly Layer 0)
 
-Provide type-safe access to Diamond storage, split into **core** and **asset** subdomains. Every storage struct lives at file scope in `*StorageWrapper.sol` and is anchored at a deterministic slot via the ERC-7201 `@custom:storage-location erc7201:security.token.standard.storage.<PascalName>` annotation; the struct body follows the 5-region layout (R1 lifecycle bools → R2 packed scalars → R3 single-slot scalars → R4 aggregates → APPEND-ONLY ZONE).
+Provide type-safe access to Diamond storage, split into **core** and **asset** subdomains. Every storage struct lives at file scope in `*StorageWrapper.sol` and is anchored at a deterministic slot via the ERC-7201 `@custom:storage-location erc7201:security.token.standard.storage.<PascalName>` annotation; the struct body follows the 5-region layout (R1 lifecycle bools → R2 packed scalars → R3 single-slot scalars → R4 aggregates → APPEND-ONLY ZONE), with all four region banners always present even when a region is empty.
 
 **Core** (cross-cutting concerns):
 

--- a/packages/ats/contracts/contracts/domain/asset/AdjustBalancesStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/AdjustBalancesStorageWrapper.sol
@@ -26,6 +26,8 @@ bytes32 constant STORAGE_LOCATION_ADJUST_BALANCES = 0x155c219135942fbe253879a75d
  * @custom:storage-location erc7201:security.token.standard.storage.AdjustBalances
  */
 struct AdjustBalancesStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 abaf;
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────

--- a/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
@@ -43,8 +43,11 @@ struct AmortizationHoldInfo {
  * @custom:storage-location erc7201:security.token.standard.storage.Amortization
  */
 struct AmortizationDataStorage {
-    // solhint-disable max-line-length
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
+    // solhint-disable-next-line max-line-length
     mapping(bytes32 corporateActionId => mapping(address tokenHolder => AmortizationHoldInfo)) amortizationHolds;
     mapping(bytes32 corporateActionId => EnumerableSet.AddressSet) activeHoldHolders;
     EnumerableSet.UintSet activeAmortizationIds;

--- a/packages/ats/contracts/contracts/domain/asset/BondStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/BondStorageWrapper.sol
@@ -24,9 +24,11 @@ bytes32 constant STORAGE_LOCATION_BOND = 0xa99cdff87e8b13602d53b3661888bce1eb21f
 struct BondDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool initialized;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 startingDate;
     uint256 maturityDate;
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
@@ -14,7 +14,6 @@ import { ThirdPartyType } from "./types/ThirdPartyType.sol";
 /// @custom:hash storage Clearing
 bytes32 constant STORAGE_LOCATION_CLEARING = 0xd7a6e2f3304ec7238486e8af625921e3cfd501a713f0b2036d4a701fd3e81800;
 
-// solhint-disable max-line-length
 /**
  * @notice Persistent storage layout for the Clearing facet.
  * @dev Holds the activation flags, aggregate cleared amounts per holder and partition,
@@ -26,21 +25,20 @@ bytes32 constant STORAGE_LOCATION_CLEARING = 0xd7a6e2f3304ec7238486e8af625921e3c
  */
 struct ClearingDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
-    bool activated; // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
+    bool activated;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) totalClearedAmountByAccount;
     mapping(address => mapping(bytes32 => uint256)) totalClearedAmountByAccountAndPartition;
-    // solhint-disable-next-line max-line-length
+    // solhint-disable max-line-length
     mapping(address => mapping(bytes32 => mapping(IClearingTypes.ClearingOperationType => EnumerableSet.UintSet))) clearingIdsByAccountAndPartitionAndTypes;
-    // solhint-disable-next-line max-line-length
     mapping(address => mapping(bytes32 => mapping(IClearingTypes.ClearingOperationType => uint256))) nextClearingIdByAccountPartitionAndType;
-    // solhint-disable-next-line max-line-length
     mapping(address => mapping(bytes32 => mapping(uint256 => IClearingTypes.ClearingTransferData))) clearingTransferByAccountPartitionAndId;
-    // solhint-disable-next-line max-line-length
     mapping(address => mapping(bytes32 => mapping(uint256 => IClearingTypes.ClearingRedeemData))) clearingRedeemByAccountPartitionAndId;
-    // solhint-disable-next-line max-line-length
     mapping(address => mapping(bytes32 => mapping(uint256 => IClearingTypes.ClearingHoldCreationData))) clearingHoldCreationByAccountPartitionAndId;
-    // solhint-disable-next-line max-line-length
     mapping(address => mapping(bytes32 => mapping(IClearingTypes.ClearingOperationType => mapping(uint256 => address)))) clearingThirdPartyByAccountPartitionTypeAndId;
+    // solhint-enable max-line-length
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 // solhint-enable max-line-length

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -47,6 +47,7 @@ struct Partition {
 struct ERC1410BasicStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool multiPartition;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 totalTokenHolders;
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
@@ -69,6 +70,9 @@ struct ERC1410BasicStorage {
  * @custom:storage-location erc7201:security.token.standard.storage.Erc1410Operator
  */
 struct ERC1410OperatorStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     /// @dev Mapping from (investor, partition, operator) to approved status
     mapping(address => mapping(bytes32 => mapping(address => bool))) partitionApprovals;

--- a/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
@@ -36,7 +36,9 @@ bytes32 constant STORAGE_LOCATION_ERC1594 = 0x6bb5986b529cbe1ac563af7efd06b91a80
 struct ERC1594Storage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool issuance;
-
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/ERC1644StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1644StorageWrapper.sol
@@ -17,7 +17,9 @@ bytes32 constant STORAGE_LOCATION_ERC1644 = 0x96356235f59c9d131a29a98816b8ce8d9e
 struct ERC1644Storage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool isControllable;
-
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -25,15 +25,16 @@ bytes32 constant STORAGE_LOCATION_ERC20 = 0xba2beddc557de36eb4836f4ff1fd9d33a28d
  * @custom:storage-location erc7201:security.token.standard.storage.Erc20
  */
 struct ERC20Storage {
-    // ─── R1 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     uint8 decimals;
     IFactory.SecurityType securityType;
-    // ─── R2 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     string name;
     string symbol;
     string isin;
     uint256 totalSupply;
-    // ─── R3 Aggregates (mapping, array, EnumerableSet) ───────
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) balances;
     mapping(address => mapping(address => uint256)) allowed;
 

--- a/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
@@ -25,6 +25,8 @@ bytes32 constant STORAGE_LOCATION_ERC20VOTES = 0xb9759d8916f84f61d52de275f833caf
 struct ERC20VotesStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool activated;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => address) delegates;
     mapping(address => Checkpoints.Checkpoint[]) checkpoints;

--- a/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/EquityStorageWrapper.sol
@@ -40,7 +40,8 @@ struct EquityDataStorage {
     bool putRight;
     // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     IEquity.DividendType dividendRight;
-
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -34,6 +34,9 @@ bytes32 constant STORAGE_LOCATION_HOLD = 0xaee7bac248b1ceeb630aa06b36647d0582529
  * @custom:storage-location erc7201:security.token.standard.storage.Hold
  */
 struct HoldDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) totalHeldAmountByAccount;
     mapping(address => mapping(bytes32 => uint256)) totalHeldAmountByAccountAndPartition;

--- a/packages/ats/contracts/contracts/domain/asset/InterestRateStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/InterestRateStorageWrapper.sol
@@ -16,21 +16,20 @@ bytes32 constant STORAGE_LOCATION_FIXED_RATE = 0x577d3b71f198de7595699f8f2861298
 
 /**
  * @title FixedRateDataStorage
- * @notice Struct holding the fixed interest rate value and its decimal precision,
- *         along with an initialisation flag.
+ * @notice Struct holding the fixed interest rate value and its decimal precision.
  * @dev Backing storage for the fixed-rate coupon model; mutated only by
  *      `InterestRateStorageWrapper` via the deterministic ERC-7201 slot.
- * @param initialized Whether the fixed rate data has been initialised.
  * @param decimals Number of decimal places for the rate.
  * @param rate The fixed interest rate value.
  * @custom:storage-location erc7201:security.token.standard.storage.FixedRate
  */
 struct FixedRateDataStorage {
-    // ─── R1 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     uint8 decimals;
-    // ─── R2 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 rate;
-
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 
@@ -41,7 +40,6 @@ struct FixedRateDataStorage {
  * @dev Backing storage for the KPI-linked coupon model; mutated only by
  *      `InterestRateStorageWrapper`. Rate ordering (`minRate ≤ baseRate ≤ maxRate`)
  *      and impact bound strict-ordering invariants are enforced at write time.
- * @param initialized Whether the KPI-linked rate data has been initialised.
  * @param rateDecimals Number of decimals for rate values.
  * @param impactDataDecimals Number of decimals for impact data fields.
  * @param maxRate Upper bound for the KPI-linked rate.
@@ -59,7 +57,6 @@ struct FixedRateDataStorage {
  */
 struct KpiLinkedRateDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
-    bool initialized;
     // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     uint8 rateDecimals;
     uint8 impactDataDecimals;
@@ -75,25 +72,24 @@ struct KpiLinkedRateDataStorage {
     uint256 baseLine;
     uint256 maxDeviationFloor;
     uint256 adjustmentPrecision;
-
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 
 /**
  * @title InterestRateTypeDataStorage
- * @notice Stores the selected coupon rate type discriminator and its initialisation flag.
+ * @notice Stores the selected coupon rate type discriminator.
  * @dev Decoupled from the rate-specific storages so the active model can be queried
  *      without touching the fixed-rate or KPI-linked storage slots.
- * @param initialized Whether the coupon rate type has been initialised.
  * @param rateType The `IInterestRate.RateType` discriminator selected by the admin.
  * @custom:storage-location erc7201:security.token.standard.storage.InterestRateType
  */
 struct InterestRateTypeDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
-    bool initialized;
     // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     IInterestRate.RateType rateType;
-
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 
@@ -151,15 +147,13 @@ library InterestRateStorageWrapper {
     }
 
     /**
-     * @notice Writes the coupon rate type and sets the initialisation flag.
+     * @notice Writes the coupon rate type during one-time initialisation.
      * @dev Called only once during asset deployment. Reverts via the caller's modifier
      *      if already initialised.
      * @param _rateType The `IInterestRate.RateType` to persist.
      */
     function initializeCouponRateType(IInterestRate.RateType _rateType) internal {
-        InterestRateTypeDataStorage storage s = interestRateTypeStorage();
-        s.rateType = _rateType;
-        s.initialized = true;
+        interestRateTypeStorage().rateType = _rateType;
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
@@ -24,6 +24,8 @@ bytes32 constant STORAGE_LOCATION_KPIS = 0x0016dc918f7b373bc12e22119ae85cf4b20c3
  * @custom:storage-location erc7201:security.token.standard.storage.Kpis
  */
 struct KpisDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 minDate;
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────

--- a/packages/ats/contracts/contracts/domain/asset/LoanStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LoanStorageWrapper.sol
@@ -76,7 +76,7 @@ struct LoanDataStorage {
     uint256 totalCollateralValue;
     uint256 loanToValue;
     uint256 daysPastDue;
-
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/LoansPortfolioStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LoansPortfolioStorageWrapper.sol
@@ -37,10 +37,12 @@ bytes32 constant STORAGE_LOCATION_LOANS_PORTFOLIO = 0x5981f3997a6cf8235e2e8b5dd3
  * @custom:storage-location erc7201:security.token.standard.storage.LoansPortfolio
  */
 struct LoansPortfolioDataStorage {
-    // ─── R1 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     ILoansPortfolio.PortfolioType portfolioType;
     ILoansPortfolio.DistributionPolicy distributionPolicy;
-    // ─── R3 Aggregates (mapping, array, EnumerableSet) ───────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     EnumerableSet.AddressSet holdingsAssets;
     EnumerableSet.AddressSet loanHoldingsAssets;
     EnumerableSet.AddressSet cashHoldingsAssets;

--- a/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
@@ -26,6 +26,9 @@ bytes32 constant STORAGE_LOCATION_LOCK = 0xd42ee8bdd326f30f9a4764fdaf28dd7191689
  * @custom:storage-location erc7201:security.token.standard.storage.Lock
  */
 struct LockDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) totalLockedAmountByAccount;
     mapping(address => mapping(bytes32 => uint256)) totalLockedAmountByAccountAndPartition;

--- a/packages/ats/contracts/contracts/domain/asset/NominalValueStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/NominalValueStorageWrapper.sol
@@ -12,7 +12,6 @@ bytes32 constant STORAGE_LOCATION_NOMINAL_VALUE = 0xf4ae98634996e72bf90c5471fce1
  * @notice Backing storage for nominal value, decimals, and ISO 4217 currency code.
  * @dev Sole source of truth for nominal-value fields on this asset; mutated only via
  *      `NominalValueStorageWrapper` against the deterministic ERC-7201 slot.
- * @param initialized Whether the nominal value data has been initialised.
  * @param nominalValueDecimals Number of decimals applied to `nominalValue`.
  * @param nominalValueCurrency ISO 4217 currency code (`0x000000` when unset).
  * @param nominalValue Nominal value amount expressed with `nominalValueDecimals` precision.
@@ -20,13 +19,12 @@ bytes32 constant STORAGE_LOCATION_NOMINAL_VALUE = 0xf4ae98634996e72bf90c5471fce1
  */
 struct NominalValueDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
-    bool initialized;
     // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     uint8 nominalValueDecimals;
     bytes3 nominalValueCurrency;
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 nominalValue;
-
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/asset/ProceedRecipientsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ProceedRecipientsStorageWrapper.sol
@@ -22,6 +22,9 @@ bytes32 constant STORAGE_LOCATION_PROCEED_RECIPIENTS_DATA = 0xc68f265b7453bab62d
  * @custom:storage-location erc7201:security.token.standard.storage.ProceedRecipientsData
  */
 struct ProceedRecipientsDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => bytes) proceedRecipientData;
     // ─── APPEND-ONLY ZONE BELOW ───

--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -42,6 +42,8 @@ bytes32 constant STORAGE_LOCATION_SCHEDULED_CROSS_ORDERED_TASKS = 0xc0ba5b9a8206
  *      constants in this file directly.
  */
 struct ScheduledTasksDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 scheduledTaskCount;
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────

--- a/packages/ats/contracts/contracts/domain/asset/SecurityStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/SecurityStorageWrapper.sol
@@ -11,10 +11,15 @@ bytes32 constant STORAGE_LOCATION_SECURITY = 0x45ae5065a0bedd1836ba9c199c3e3b4f0
  * @notice Backing storage for the security regulation configuration of an asset.
  * @dev Sole source of truth for regulation and additional security fields on this asset;
  *      mutated only via `SecurityStorageWrapper` against the deterministic ERC-7201 slot.
+ *      `regulationData` and `additionalSecurityData` are inline struct-typed fields, each
+ *      spanning multiple contiguous slots, so they live in the R4 aggregates region.
  * @custom:storage-location erc7201:security.token.standard.storage.Security
  */
 struct SecurityRegulationDataStorage {
-    // ─── R2 Single-slot scalars / aggregates ─────────────────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     RegulationData regulationData;
     AdditionalSecurityData additionalSecurityData;
 

--- a/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
@@ -36,6 +36,8 @@ bytes32 constant STORAGE_LOCATION_SNAPSHOT = 0x2e9cb27cc6da952dbadc3ddf8f7c0573a
  * @custom:storage-location erc7201:security.token.standard.storage.Snapshot
  */
 struct SnapshotStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     /**
      * @dev Unique ID of the current snapshot. Ids increase monotonically, with the first value

--- a/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
@@ -34,6 +34,9 @@ bytes32 constant STORAGE_LOCATION_COUPON = 0x83419e6b8093975a3157050eb9f883164e1
  * @custom:storage-location erc7201:security.token.standard.storage.Coupon
  */
 struct CouponDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     uint256[] couponsOrderedListByIds;
     // ─── APPEND-ONLY ZONE BELOW ───

--- a/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
@@ -29,6 +29,9 @@ struct RoleData {
  * @custom:storage-location erc7201:security.token.standard.storage.AccessControl
  */
 struct RoleDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(bytes32 => RoleData) roles;
     mapping(address => EnumerableSet.Bytes32Set) memberRoles;

--- a/packages/ats/contracts/contracts/domain/core/CapStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CapStorageWrapper.sol
@@ -16,9 +16,11 @@ bytes32 constant STORAGE_LOCATION_CAP = 0xabd29859a2443302b9905d8be07aab508a353c
  * @custom:storage-location erc7201:security.token.standard.storage.Cap
  */
 struct CapDataStorage {
-    // ─── R2 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 maxSupply;
-    // ─── R3 Aggregates (mapping, array, EnumerableSet) ───────
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(bytes32 => uint256) maxSupplyByPartition;
     // ─── APPEND-ONLY ZONE BELOW ───
 }

--- a/packages/ats/contracts/contracts/domain/core/ControlListStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ControlListStorageWrapper.sol
@@ -18,6 +18,8 @@ bytes32 constant STORAGE_LOCATION_CONTROL_LIST = 0x880786188890a6f111c4f0814d49d
 struct ControlListStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool isWhiteList;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     EnumerableSet.AddressSet list;
     // ─── APPEND-ONLY ZONE BELOW ───

--- a/packages/ats/contracts/contracts/domain/core/CorporateActionsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CorporateActionsStorageWrapper.sol
@@ -29,6 +29,9 @@ struct ActionData {
  * @custom:storage-location erc7201:security.token.standard.storage.CorporateAction
  */
 struct CorporateActionDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     EnumerableSet.Bytes32Set actions;
     mapping(bytes32 => ActionData) actionsData;

--- a/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
@@ -15,8 +15,12 @@ bytes32 constant STORAGE_LOCATION_CUSTOM_DATA = 0x92acc34fbd05df4f7a3d758b1a1755
  * @custom:storage-location erc7201:security.token.standard.storage.CustomData
  */
 struct CustomDataDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(bytes32 => bytes[]) customData;
+    // ─── APPEND-ONLY ZONE BELOW ───
 }
 
 /**

--- a/packages/ats/contracts/contracts/domain/core/DeactivateStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/DeactivateStorageWrapper.sol
@@ -17,6 +17,9 @@ bytes32 constant STORAGE_LOCATION_DEACTIVATE = 0x572f1b7cd92e0f948542520f56d2d4e
 struct DeactivateDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool deactivated;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/core/DocumentationStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/DocumentationStorageWrapper.sol
@@ -27,6 +27,9 @@ struct Document {
  * @custom:storage-location erc7201:security.token.standard.storage.Documentation
  */
 struct DocumentationDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(bytes32 => Document) documents;
     mapping(bytes32 => uint256) docIndexes;

--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -35,11 +35,13 @@ bytes32 constant STORAGE_LOCATION_ERC3643 = 0x167d628abbc681171e3e4d784cf450a7f9
  * @custom:storage-location erc7201:security.token.standard.storage.Erc3643
  */
 struct ERC3643Storage {
-    // ─── R1 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     address onchainID;
     address identityRegistry;
     address compliance;
-    // ─── R3 Aggregates (mapping, array, EnumerableSet) ───────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) frozenTokens;
     mapping(address => mapping(bytes32 => uint256)) frozenTokensByPartition;
     mapping(address => bool) addressRecovered;

--- a/packages/ats/contracts/contracts/domain/core/ExternalListManagementStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ExternalListManagementStorageWrapper.sol
@@ -25,13 +25,15 @@ bytes32 constant STORAGE_LOCATION_KYC_MANAGEMENT = 0x44eb866201f22832539d7232090
  *          (STORAGE_LOCATION_PAUSE_MANAGEMENT in PauseStorageWrapper.sol)
  *        - erc7201:security.token.standard.storage.ProceedRecipients
  *          (STORAGE_LOCATION_PROCEED_RECIPIENTS in ProceedRecipientsStorageWrapper.sol)
- *      The annotation below names the first slot for tooling discovery; the other three are
- *      documented via their STORAGE_LOCATION_* constants. No single annotation can capture
- *      the four-slot reuse.
- * @custom:storage-location erc7201:security.token.standard.storage.ControlListManagement
+ *      No single `@custom:storage-location` annotation is present because one line cannot
+ *      capture the four-slot reuse and would mislead tooling into binding the struct to a
+ *      single namespace; each slot is defined by its `STORAGE_LOCATION_*` constant instead.
  */
 struct ExternalListDataStorage {
-    // ─── R3 Aggregates (mapping, array, EnumerableSet) ───────
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     EnumerableSet.AddressSet list;
     // ─── APPEND-ONLY ZONE BELOW ───
 }

--- a/packages/ats/contracts/contracts/domain/core/InitializerStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/InitializerStorageWrapper.sol
@@ -21,6 +21,8 @@ bytes32 constant STORAGE_LOCATION_INITIALIZER = 0x7f2d07b09acba6319339222a47bfb1
  * @custom:storage-location erc7201:security.token.standard.storage.Initializer
  */
 struct InitializerDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     uint256 maxInitializerFacetIndex;
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────

--- a/packages/ats/contracts/contracts/domain/core/KycStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/KycStorageWrapper.sol
@@ -22,6 +22,8 @@ bytes32 constant STORAGE_LOCATION_KYC = 0x88f619eb35d79dd51bdbedb0638479d77479fa
 struct KycStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool internalKycActivated;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => IKyc.KycData) kyc;
     mapping(IKyc.KycStatus => EnumerableSet.AddressSet) kycAddressesByStatus;

--- a/packages/ats/contracts/contracts/domain/core/NonceStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/NonceStorageWrapper.sol
@@ -11,6 +11,9 @@ bytes32 constant STORAGE_LOCATION_NONCE = 0x9752efd73e12c56ed1d4aebb7f98c3d8260f
  * @custom:storage-location erc7201:security.token.standard.storage.Nonce
  */
 struct NonceDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     mapping(address => uint256) nonces;
     // ─── APPEND-ONLY ZONE BELOW ───

--- a/packages/ats/contracts/contracts/domain/core/PauseStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/PauseStorageWrapper.sol
@@ -26,6 +26,9 @@ bytes32 constant STORAGE_LOCATION_PAUSE = 0x3bf57dcdaf5f1e5afff95a10b7216bcff83f
 struct PauseDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool paused;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/core/ProtectedPartitionsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ProtectedPartitionsStorageWrapper.sol
@@ -34,6 +34,9 @@ bytes32 constant STORAGE_LOCATION_PROTECTED_PARTITIONS = 0x5b38507d21e10ec4c8c85
 struct ProtectedPartitionsDataStorage {
     // ─── R1 Lifecycle (bool flags) ───────────────────────────
     bool arePartitionsProtected;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/core/ResolverProxyStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ResolverProxyStorageWrapper.sol
@@ -14,10 +14,13 @@ bytes32 constant STORAGE_LOCATION_RESOLVER_PROXY = 0x688a1184cf65cae3790aef0eb60
  * @custom:storage-location erc7201:security.token.standard.storage.ResolverProxy
  */
 struct ResolverProxyStorage {
-    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     IBusinessLogicResolver resolver;
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     bytes32 resolverProxyConfigurationId;
     uint256 version;
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     // ─── APPEND-ONLY ZONE BELOW ───
 }
 

--- a/packages/ats/contracts/contracts/domain/core/SsiManagementStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/SsiManagementStorageWrapper.sol
@@ -16,8 +16,10 @@ bytes32 constant STORAGE_LOCATION_SSI_MANAGEMENT = 0xce722d9244e395d588d86bfe231
  * @custom:storage-location erc7201:security.token.standard.storage.SsiManagement
  */
 struct SsiManagementStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
     // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
     address revocationRegistry;
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
     // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
     EnumerableSet.AddressSet issuerList;
     // ─── APPEND-ONLY ZONE BELOW ───

--- a/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolverWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolverWrapper.sol
@@ -12,21 +12,34 @@ import { DefaultValueValidation } from "../utils/DefaultValueValidation.sol";
 // solhint-disable-next-line max-line-length
 bytes32 constant STORAGE_LOCATION_BUSINESS_LOGIC_RESOLVER = 0xde52d5af2ee0e84dfa9eb9bcc42ec14eed20a1d286bfef34d73589ea7ee18800;
 
-abstract contract BusinessLogicResolverWrapper is IBusinessLogicResolver {
-    struct BusinessLogicResolverDataStorage {
-        mapping(bytes32 facetId => uint256 lastVersion) latestVersionByFacetId;
-        // list of facetIds
-        bytes32[] activeBusinessLogics;
-        // facetId -> bool
-        mapping(bytes32 => bool) businessLogicActive;
-        // facetId -> pos (one per vesion) -> version + status + address
-        mapping(bytes32 => IBusinessLogicResolver.BusinessLogicVersion[]) businessLogics;
-        // version to status
-        mapping(bytes32 facetIdAndVersion => IBusinessLogicResolver.VersionStatus status) statusByFacetIdAndVersion;
-        bool initialized;
-        mapping(bytes32 => EnumerableSetBytes4.Bytes4Set) selectorBlacklist;
-    }
+/**
+ * @notice Diamond storage backing the business-logic resolver registry.
+ * @dev Records, per facet id, the active version set, status, and selector blacklist that
+ *      determine which logic a resolver-proxy delegates to. Hoisted to file scope per the
+ *      project's ERC-7201 storage convention; new fields must be appended below the
+ *      APPEND-ONLY marker to preserve upgrade safety.
+ * @custom:storage-location erc7201:security.token.standard.storage.BusinessLogicResolver
+ */
+struct BusinessLogicResolverDataStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    bool initialized;
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
+    mapping(bytes32 facetId => uint256 lastVersion) latestVersionByFacetId;
+    // list of facetIds
+    bytes32[] activeBusinessLogics;
+    // facetId -> bool
+    mapping(bytes32 => bool) businessLogicActive;
+    // facetId -> pos (one per vesion) -> version + status + address
+    mapping(bytes32 => IBusinessLogicResolver.BusinessLogicVersion[]) businessLogics;
+    // version to status
+    mapping(bytes32 facetIdAndVersion => IBusinessLogicResolver.VersionStatus status) statusByFacetIdAndVersion;
+    mapping(bytes32 => EnumerableSetBytes4.Bytes4Set) selectorBlacklist;
+    // ─── APPEND-ONLY ZONE BELOW ───
+}
 
+abstract contract BusinessLogicResolverWrapper is IBusinessLogicResolver {
     modifier validVersion(bytes32 _businessLogicKey, uint256 _version) {
         _checkValidVersion(_businessLogicKey, _version);
         _;

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -12,32 +12,45 @@ import { BusinessLogicResolverWrapper } from "./BusinessLogicResolverWrapper.sol
 // solhint-disable-next-line max-line-length
 bytes32 constant STORAGE_LOCATION_DIAMOND_CUT_MANAGER = 0xc9161810d6144bfe5b28041c8a23ceedf202e65acda5c323c5b387259e601000;
 
-abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicResolverWrapper {
-    struct DiamondCutManagerStorage {
-        bytes32[] configurations;
-        mapping(bytes32 => bool) activeConfigurations;
-        mapping(bytes32 => uint256) latestVersion;
-        mapping(bytes32 => uint256) batchVersion;
-        // keccak256(configurationId, version)
-        mapping(bytes32 => bytes32[]) facetIds;
-        // keccak256(configurationId, version)
-        mapping(bytes32 => uint256[]) facetVersions;
-        //keccak256(configurationId, version, facetId)
-        mapping(bytes32 => uint256) facetIdPosition;
-        // keccak256(configurationId, version, selector)
-        mapping(bytes32 => address) facetAddress;
-        // keccak256(configurationId, version, facetId)
-        mapping(bytes32 => address) addr;
-        // keccak256(configurationId, version, facetId)
-        mapping(bytes32 => bytes4[]) selectors;
-        // keccak256(configurationId, version, selector)
-        mapping(bytes32 => bytes32) selectorToFacetId;
-        // keccak256(configurationId, version, facetId)
-        mapping(bytes32 => bytes4[]) interfaceIds;
-        // keccak256(configurationId, version, interfaceId)
-        mapping(bytes32 => bool) supportsInterface;
-    }
+/**
+ * @notice Diamond storage backing the diamond-cut manager configuration registry.
+ * @dev Indexes configurations, their versions, and the per-version facet/selector/interface
+ *      resolution maps used when cutting a resolver-proxy. Hoisted to file scope per the
+ *      project's ERC-7201 storage convention; new fields must be appended below the
+ *      APPEND-ONLY marker to preserve upgrade safety.
+ * @custom:storage-location erc7201:security.token.standard.storage.DiamondCutManager
+ */
+struct DiamondCutManagerStorage {
+    // ─── R1 Lifecycle (bool flags) ───────────────────────────
+    // ─── R2 Packed scalars (uint8, bytes3, address, enum) ────
+    // ─── R3 Single-slot scalars (uint256, bytes32, string) ───
+    // ─── R4 Aggregates (mapping, array, EnumerableSet) ───────
+    bytes32[] configurations;
+    mapping(bytes32 => bool) activeConfigurations;
+    mapping(bytes32 => uint256) latestVersion;
+    mapping(bytes32 => uint256) batchVersion;
+    // keccak256(configurationId, version)
+    mapping(bytes32 => bytes32[]) facetIds;
+    // keccak256(configurationId, version)
+    mapping(bytes32 => uint256[]) facetVersions;
+    //keccak256(configurationId, version, facetId)
+    mapping(bytes32 => uint256) facetIdPosition;
+    // keccak256(configurationId, version, selector)
+    mapping(bytes32 => address) facetAddress;
+    // keccak256(configurationId, version, facetId)
+    mapping(bytes32 => address) addr;
+    // keccak256(configurationId, version, facetId)
+    mapping(bytes32 => bytes4[]) selectors;
+    // keccak256(configurationId, version, selector)
+    mapping(bytes32 => bytes32) selectorToFacetId;
+    // keccak256(configurationId, version, facetId)
+    mapping(bytes32 => bytes4[]) interfaceIds;
+    // keccak256(configurationId, version, interfaceId)
+    mapping(bytes32 => bool) supportsInterface;
+    // ─── APPEND-ONLY ZONE BELOW ───
+}
 
+abstract contract DiamondCutManagerWrapper is IDiamondCutManager, BusinessLogicResolverWrapper {
     modifier validateConfigurationVersion(bytes32 _configurationId, uint256 _version) {
         _checkExplicitVersion(_configurationId, _version);
         _;


### PR DESCRIPTION
## Description

Follow-up to BBND-1767 (the 5-region ERC-7201 storage convention). When the BBND-1688 centralised-initializer work merged into `development` it stripped/renumbered some storage-struct region banners and left behind dead `initialized` fields.

This PR normalises every ERC-7201 storage struct across `domain/asset`, `domain/core`, and `infrastructure/diamond` — 43 structs across 40 `.sol` files — so each carries all four region banners (R1 Lifecycle, R2 Packed scalars, R3 Single-slot scalars, R4 Aggregates) plus the APPEND-ONLY marker, always present and in fixed canonical order even when a region is empty.

Additional work in this PR:

- Corrects off-by-one banner numbering in ERC20, Cap, ERC3643, ExternalList, FixedRate, and LoansPortfolio; fixes the non-canonical combined banner on Security.
- Hoists the two diamond storage structs (`BusinessLogicResolver`, `DiamondCutManager`) to file scope with `@custom:storage-location` annotations.
- Removes dead per-struct `initialized` fields from `NominalValue`, `KpiLinkedRate`, and `InterestRateType` (now owned by the centralised `InitializerStorageWrapper`), while leaving the live guards on Bond, Equity, Loan, and resolver structs untouched.
- Tidies `solhint` disables in Amortization and Clearing.
- Updates the contracts developer guides to reflect the normalised layout.

Empty region banners are greppable, audit-visible scaffolding: they make the correct insertion point for a future field unambiguous and prevent silent renumbering when a region's only field is deleted.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [x] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

Verified locally on Node 24:

- `npm run ats:contracts:build` — success (compile + typechain + registry-regen).
- `npm run ats:contracts:test` — 3718 passing, 5 pending — identical to the pre-change baseline, zero regressions.
- `npm run ats:contracts:lint` — 0 errors (pre-existing warnings only).
- Storage-hash stability: `scripts/domain/atsRoles.generated.ts` unchanged (no role-/slot-hash drift); ERC-7201 base-slot hashes unchanged (region banners are comments — they do not affect slot computation).
- An independent adversarial contract review was run on the diff; all findings were addressed before this PR was opened.

**Breaking change note:** Field offsets shift within several ERC-7201 namespaces where dead `initialized` fields were removed or regions were reordered during normalisation. Existing deployments must be redeployed, not upgraded in place.

### Test Results

3718 passing, 5 pending — zero regressions against baseline.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅