### PR TITLE
fix: stop hash-change label false-positive on facet file moves (BBND-1838)

### DIFF
--- a/.github/workflows/105-flow-ats-static-checks.yaml
+++ b/.github/workflows/105-flow-ats-static-checks.yaml
@@ -102,10 +102,16 @@ jobs:
           # declares a hash constant — and ~25% of .sol files do, so an
           # unrelated NatSpec/event edit was triggering the label.
           # `git diff -G <re>` matches files where an added/removed line
-          # hits the regex, which is what we actually want.
+          # hits the regex, which is what we actually want. Diff the whole
+          # range with rename detection (-M) so a pure file move stays a
+          # rename and produces no hit; a new-path-only pathspec would hide
+          # the old path, defeat rename pairing, and flag every moved
+          # hash-bearing line. Filter the hits to the in-scope file set.
           hash_re='@custom:hash|bytes32[[:space:]]+constant[[:space:]]+[A-Z_]+[[:space:]]*=[[:space:]]*0x[0-9a-fA-F]{64}'
+          hash_hits=$(git diff --name-only -M "origin/${{ github.base_ref }}" HEAD -G "${hash_re}" 2>/dev/null \
+            | grep -E '^(packages/ats/contracts/.*\.sol|packages/ats/contracts/scripts/codegen/.*)$' || true)
           if echo "${changed}" | grep -qE 'scripts/codegen/' \
-             || [[ -n "$(git diff --name-only "origin/${{ github.base_ref }}" HEAD -G "${hash_re}" -- ${changed} 2>/dev/null)" ]]; then
+             || [[ -n "${hash_hits}" ]]; then
             echo "Hash-bearing changes detected — applying 'hash-change' label."
             # Use the REST Labels API directly. `gh pr edit --add-label` works
             # but its underlying GraphQL query touches the deprecated


### PR DESCRIPTION
## Description

The \"Label PR if hash-bearing files changed\" step in `105-flow-ats-static-checks.yaml` applied the `hash-change` label to PRs that merely move a hash-bearing `.sol` file.

**Root cause:** The `git diff -G` was scoped with a new-path-only pathspec (`-- ${changed}`), which defeats git rename detection so a moved file reads as all-new and every `@custom:hash` / `bytes32 constant = 0x…` line counts as added.

**Fix:** Diff the whole range with rename detection (`-M`) and post-filter the hits to the in-scope file set, so pure moves stay renames (no hit) while genuine hash-line add/removes still fire.

**Verified against history:** the voting relocation no longer trips it; a real resolver-key change still does.

[BBND-1838](https://iobuilders.atlassian.net/browse/BBND-1838)

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Reproduced both cases locally with the exact CI regex:
- Pure facet move (`e5440a190`) yields no hit under the new logic — old logic flagged `IVoting.sol` incorrectly.
- A genuine hash-bearing commit (`8e612c1e1`) still detected correctly.
- Workflow YAML validated.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅