### PR TITLE
docs: fix SECURITY.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,4 +343,4 @@ to [oss@hedera.com](mailto:oss@hedera.com).
 
 ## Security
 
-Please do not file a public ticket mentioning the vulnerability. Refer to the security policy defined in the [SECURITY.md](https://github.com/hashgraph/assettokenization-studio/blob/main/SECURITY.md).
+Please do not file a public ticket mentioning the vulnerability. Refer to the security policy defined in the [SECURITY.md](https://github.com/hashgraph/asset-tokenization-studio/blob/main/SECURITY.md).


### PR DESCRIPTION
Small fix: the repo slug in the SECURITY.md link was missing the hyphen ('assettokenization-studio' → 'asset-tokenization-studio').