### PR TITLE
chore(scripts): add run-ai-checks.sh and /validate command to repo

### DIFF
--- a/.changeset/ats-style-guide-skill.md
+++ b/.changeset/ats-style-guide-skill.md
@@ -1,0 +1,9 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Add /ats-style-guide Claude Code skill with 35 rule IDs for automated and contextual
+Solidity convention review. Expand adding-facets.md and documenting-contracts.md with
+missing conventions: selector registration pattern, 5-region storage layout, initializer
+modifier requirement, type placement rules, ERC-3643 import boundary, event completeness
+rules, and NatSpec for private/internal callables.

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,0 +1,41 @@
+---
+description: Run ATS contract validation (format, lint, compile, test, coverage)
+argument-hint: [--skip-format] [--skip-lint] [--skip-compile] [--skip-test] [--skip-coverage] [--test-file <path>] [--test-grep <pattern>] [--test-full] [--coverage-min <n>]
+---
+
+Run the unified ATS contracts validation script from the contracts package root.
+
+Execute the following command, forwarding all arguments:
+
+```bash
+cd packages/ats/contracts && bash scripts/run-ai-checks.sh $ARGUMENTS
+```
+
+After the script completes, follow this reading protocol:
+
+**Step 1 — Read the JSON summary** (`packages/ats/contracts/.ai-logs/ai-run.json`):
+Parse and report:
+- Overall status (`ok` / `failed`) and total duration
+- Per-step result: name, exit code, duration
+- Test counts: passing / failing
+- Coverage: lines %, branches %, functions %
+- Lint: errors count, warnings count
+
+**Step 2 — Read the log only when there are failures**
+(`packages/ats/contracts/.ai-logs/ai-run.log`):
+For each failed step, extract the relevant error block from the log
+(error messages, file:line references, stack traces). Do not read the
+full log if all steps passed — the JSON summary is sufficient.
+
+If neither file exists, report the raw script output instead.
+
+## Common invocations
+
+| Command | Effect |
+|---|---|
+| `/validate` | Full run: format + lint + compile + test + coverage |
+| `/validate --skip-test` | Format + lint + compile only |
+| `/validate --skip-format --skip-lint` | Compile + test + coverage |
+| `/validate --test-grep "Cap"` | Only tests matching "Cap" |
+| `/validate --test-file test/unit/cap.test.ts` | Single test file |
+| `/validate --skip-compile --test-grep "Cap"` | Tests without recompiling |

--- a/.claude/skills/ats-style-guide/SKILL.md
+++ b/.claude/skills/ats-style-guide/SKILL.md
@@ -31,23 +31,23 @@ Choose the right command based on user input:
 **Default** (staged + unstaged, no user input):
 
 ```
-{ git -C /home/slimbook/proyects/asset-tokenization-studio diff HEAD --diff-filter=d -- '*.sol'; git -C /home/slimbook/proyects/asset-tokenization-studio diff --cached HEAD --diff-filter=d -- '*.sol'; }
+REPO=$(git rev-parse --show-toplevel); { git -C "$REPO" diff HEAD --diff-filter=d -- '*.sol'; git -C "$REPO" diff --cached HEAD --diff-filter=d -- '*.sol'; }
 ```
 
 **User provides `<branch> <base>`** (fork-point diff):
 
 ```
-git -C /home/slimbook/proyects/asset-tokenization-studio diff --diff-filter=d $(git -C /home/slimbook/proyects/asset-tokenization-studio merge-base <branch> <base>)...<branch> -- '*.sol'
+REPO=$(git rev-parse --show-toplevel); git -C "$REPO" diff --diff-filter=d $(git -C "$REPO" merge-base <branch> <base>)...<branch> -- '*.sol'
 ```
 
 **User provides only a branch** — ask before building the command:
 
-> ¿Desde qué rama parte `<branch>`? (ej. `main`, `develop`, `feat/otra-rama`)
+> What is the base branch for `<branch>`? (e.g. `main`, `develop`, `feat/other-branch`)
 
 **User provides a commit hash**:
 
 ```
-git -C /home/slimbook/proyects/asset-tokenization-studio diff --diff-filter=d <hash>^..<hash> -- '*.sol'
+REPO=$(git rev-parse --show-toplevel); git -C "$REPO" diff --diff-filter=d <hash>^..<hash> -- '*.sol'
 ```
 
 ---
@@ -80,15 +80,15 @@ Then check the line count:
 wc -l < /tmp/ats-style-review.diff
 ```
 
-- If **0 lines**: return exactly: `✅ No hay cambios .sol en packages/ats/contracts/contracts/.`
-- If **> 8000 lines**: return exactly: `⚠️ Diff demasiado grande (N líneas). Estrecha el scope.`
+- If **0 lines**: return exactly: `✅ No .sol changes found in packages/ats/contracts/contracts/.`
+- If **> 8000 lines**: return exactly: `⚠️ Diff too large (N lines). Narrow the scope.`
 - Otherwise: continue to STEP B.
 
 **STEP B — Run solhint on the changed files only.** Extract the file paths from the diff and lint only those:
 
 ```bash
 CHANGED=$(grep '^+++ b/' /tmp/ats-style-review.diff | sed 's|^+++ b/||')
-cd /home/slimbook/proyects/asset-tokenization-studio && npx solhint --config packages/ats/contracts/solhint.config.js $CHANGED 2>&1
+cd $(git rev-parse --show-toplevel) && npx solhint --config packages/ats/contracts/solhint.config.js $CHANGED 2>&1
 ```
 
 - If there are solhint violations, collect them as a `LINTING` section to prepend in the output, format:

--- a/.claude/skills/ats-style-guide/SKILL.md
+++ b/.claude/skills/ats-style-guide/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: ats-style-guide
+description: "Trigger: /ats-style-guide. Review .sol files for ATS coding convention violations. Checks staged/unstaged changes; if none, asks for a commit hash or branch. Reports violations as a fichero:línea | motivo table."
+---
+
+# ATS Style Guide Review
+
+## Orchestrator contract — HARD BOUNDARIES
+
+The orchestrator does **exactly three things**:
+
+1. **Determine the git command string** from user input — text parsing only, no tools.
+2. **Spawn one subagent**, passing that command string + the Rules Reference.
+3. **Render the table** the subagent returns.
+
+The orchestrator **MUST NOT**:
+
+- Call `Bash` for any git or file command
+- Call `Read` on any diff or `.sol` file
+- Inspect, summarise, or relay diff content
+
+All file I/O lives in the subagent. If the orchestrator never calls `Bash` or `Read`,
+it is structurally impossible for diff content to enter its context.
+
+---
+
+## Step 1 — Build the git command string (no tools)
+
+Choose the right command based on user input:
+
+**Default** (staged + unstaged, no user input):
+
+```
+{ git -C /home/slimbook/proyects/asset-tokenization-studio diff HEAD --diff-filter=d -- '*.sol'; git -C /home/slimbook/proyects/asset-tokenization-studio diff --cached HEAD --diff-filter=d -- '*.sol'; }
+```
+
+**User provides `<branch> <base>`** (fork-point diff):
+
+```
+git -C /home/slimbook/proyects/asset-tokenization-studio diff --diff-filter=d $(git -C /home/slimbook/proyects/asset-tokenization-studio merge-base <branch> <base>)...<branch> -- '*.sol'
+```
+
+**User provides only a branch** — ask before building the command:
+
+> ¿Desde qué rama parte `<branch>`? (ej. `main`, `develop`, `feat/otra-rama`)
+
+**User provides a commit hash**:
+
+```
+git -C /home/slimbook/proyects/asset-tokenization-studio diff --diff-filter=d <hash>^..<hash> -- '*.sol'
+```
+
+---
+
+## Step 2 — Spawn ONE subagent
+
+Pass the **git command string** (built in Step 1) and the **Rules Reference** below.
+Do not pass diff content, file paths, or line counts — the subagent determines all of that.
+
+**Subagent instructions** (copy verbatim into the agent prompt, substituting `<GIT_CMD>`):
+
+---
+
+**STEP A — Build the diff.** Run the following command and pipe through the awk filter, saving to `/tmp/ats-style-review.diff`:
+
+```bash
+{ <GIT_CMD>; } | awk '
+/^\+\+\+ b\// {
+  path = substr($0, 7)
+  in_contracts = (path ~ /packages\/ats\/contracts\/contracts\//) &&
+                 (path !~ /\/test\/|\/artifacts\/|\/build\/|\/cache\/|\/typechain-types\//)
+}
+in_contracts { print }
+' > /tmp/ats-style-review.diff
+```
+
+Then check the line count:
+
+```bash
+wc -l < /tmp/ats-style-review.diff
+```
+
+- If **0 lines**: return exactly: `✅ No hay cambios .sol en packages/ats/contracts/contracts/.`
+- If **> 8000 lines**: return exactly: `⚠️ Diff demasiado grande (N líneas). Estrecha el scope.`
+- Otherwise: continue to STEP B.
+
+**STEP B — Run solhint on the changed files only.** Extract the file paths from the diff and lint only those:
+
+```bash
+CHANGED=$(grep '^+++ b/' /tmp/ats-style-review.diff | sed 's|^+++ b/||')
+cd /home/slimbook/proyects/asset-tokenization-studio && npx solhint --config packages/ats/contracts/solhint.config.js $CHANGED 2>&1
+```
+
+- If there are solhint violations, collect them as a `LINTING` section to prepend in the output, format:
+  `contracts/path/File.sol:LINE | SOLHINT — <rule>: <message>`
+- If solhint is clean, continue silently.
+
+**STEP C — Read the diff** and proceed with manual review.
+
+Review the diff for violations **only on added lines** — lines starting with `+`
+(never `+++` file header lines).
+
+Use `@@` hunk headers to track the actual line number on the new-file side
+(the second number in `+M,N`). Count forward from that base for each `+` or
+context line; report the line number of the offending `+` line.
+
+Apply every rule in the Rules Reference below. Report ALL violations found.
+Return ONLY the raw table rows (no headers, no summary, no extra text), one row
+per violation, in the format:
+
+`contracts/path/File.sol:LINE | Rule ID — explanation of the violation`
+
+Use paths relative to `packages/ats/contracts/` (starting with `contracts/`).
+
+---
+
+## Step 3 — Render output
+
+If the subagent returned a `LINTING` section, render it first:
+
+```
+### Solhint
+| Fichero:Línea | Motivo |
+|---|---|
+<LINTING rows>
+```
+
+Then render the manual review rows:
+
+```
+### Manual review
+| Fichero:Línea | Motivo |
+|---|---|
+<manual rows>
+```
+
+If the subagent returns the ✅ or ⚠️ sentinel, relay it directly.
+If both sections are empty, output:
+
+> ✅ No se encontraron violaciones en los ficheros revisados.
+
+---
+
+## Rules Reference
+
+### AUTOMATED — detectable by reading the source text
+
+**ATS-EVM-001** `msg.sender` used directly.
+
+- Pattern: `msg.sender` in any expression that is NOT inside `EvmAccessors.sol`
+  itself and NOT in a NatSpec comment.
+- Fix: replace with `EvmAccessors.getMsgSender()`.
+
+**ATS-EVM-002** `block.timestamp` used directly.
+
+- Pattern: `block.timestamp` outside of NatSpec comments and outside
+  `TimeTravelStorageWrapper.sol` itself.
+- Fix: replace with `TimeTravelStorageWrapper.getBlockTimestamp()`.
+
+**ATS-ERR-001** `require()` with a string message.
+
+- Pattern: `require(` followed by a string literal argument.
+- Fix: replace with a custom error and `revert`.
+
+**ATS-IMP-001** Bare import (no named symbols).
+
+- Pattern: `import "` or `import '` without `{`.
+- Fix: use named imports: `import { X } from "..."`.
+
+**ATS-GAS-001** Post-increment `i++` in a loop counter context.
+
+- Pattern: `i++` or `j++` (any single-letter counter) inside a `for` or
+  `while` body where the return value of the expression is discarded.
+- Fix: use `++i` inside an `unchecked {}` block at the end of the loop body.
+
+**ATS-GAS-002** Loop without `unchecked` counter increment.
+
+- Pattern: a `for` loop whose increment is `++i` or `i++` and is NOT wrapped
+  in `unchecked {}`.
+- Fix: move the counter increment to `unchecked { ++i; }` at the end of the
+  body and remove it from the `for` header.
+
+**ATS-FUNC-001** `memory` used for a reference-type parameter in an `external`
+function (when `calldata` is possible).
+
+- Pattern: `external` function with a parameter declared as `[] memory` or
+  `struct … memory` (not a return variable).
+- Fix: change to `calldata`.
+
+**ATS-PRIV-001** StorageWrapper accessor not `private`.
+
+- Pattern: in a `library …StorageWrapper`, a function whose name matches
+  `*Storage()` and whose visibility is `internal` instead of `private`.
+- Fix: change to `private`.
+
+**ATS-NAME-001** Function parameter missing `_` prefix.
+
+- Pattern: `external`, `public`, or `internal` function with a parameter name
+  that does NOT start with `_` (excluding `this`, unnamed params `uint256`,
+  and overridden OpenZeppelin functions that must match parent signatures).
+- Fix: add `_` prefix to the parameter name.
+
+**ATS-NAME-002** Named return variable missing `_` suffix.
+
+- Pattern: `returns (type name)` where `name` does NOT end with `_`.
+- Fix: add `_` suffix.
+
+**ATS-NAME-003** `internal` library function with `_` prefix.
+
+- Pattern: inside a `library` body, a `function` with `internal` visibility
+  whose name starts with `_`, unless the entire library consistently uses `_`
+  on all its `internal` functions as an explicit bytecode-vs-DELEGATECALL signal.
+- Rationale: library `internal` functions are inlined into the caller's bytecode
+  and form the library's composable API — `_` implies hidden implementation detail,
+  which they are not. Exception: a library mixing `internal` (inlined) and
+  `external` (DELEGATECALL) functions may adopt `_` on all its `internal` functions
+  to make the call-type distinction explicit. Must be applied consistently — never mixed.
+- Fix: remove the `_` prefix from all `internal` function names and update call sites,
+  or adopt it consistently across all `internal` functions in the library.
+
+**ATS-SUFFIX-001** `XxxFacet` contract does not inherit `IStaticFunctionSelectors`.
+
+- Pattern: `contract …Facet` declaration whose `is` list does not include
+  `IStaticFunctionSelectors`.
+- Fix: add `IStaticFunctionSelectors` to the inheritance list.
+
+**ATS-IFACE-001** Interface declared without `I` prefix.
+
+- Pattern: `interface` keyword followed by a name that does NOT start with `I`
+  (e.g. `interface Cap`, `interface AccessControl`).
+- Fix: rename to `IXxx` and update all references.
+
+**ATS-STORAGE-001** Storage struct missing `@custom:storage-location erc7201:` annotation.
+
+- Pattern: a `struct` whose name ends in `DataStorage` (or `Storage` in legacy
+  files) declared in a `…StorageWrapper.sol` that is NOT immediately preceded
+  by a NatSpec block containing `@custom:storage-location erc7201:`.
+- Fix: add the annotation above the struct declaration.
+
+**ATS-EVENT-001** Numeric amount indexed in an event.
+
+- Pattern: an `event` declaration that contains `uint256 indexed` (or any
+  `uintN indexed` / `int256 indexed`) for a parameter that represents a
+  quantity or amount rather than an identifier.
+- Rationale: indexing amounts wastes bloom-filter slots and is almost never
+  used for filtering; only addresses and natural keys (e.g. `bytes32 role`)
+  should be indexed.
+- Fix: remove `indexed` from the numeric parameter.
+
+**ATS-EVENT-002** Event parameter has `_` prefix.
+
+- Pattern: an `event` declaration with a parameter name that starts with `_`
+  (e.g. `event Paused(address indexed _operator)`).
+- Rationale: event parameters use clean names without leading `_`. The ABI/topic
+  hash depends on types only — not names — so this rename is non-breaking.
+  Follows OpenZeppelin convention (`Transfer(address indexed from, ...)`).
+- Fix: remove the `_` prefix from the event parameter name and its `@param` tag.
+
+**ATS-FACET-001** State variable declared inside a Facet or business-logic abstract.
+
+- Pattern: a non-`constant` / non-`immutable` state variable declaration in a
+  file whose contract name ends in `Facet`, or in an abstract contract that
+  sits in `facets/<name>/` and is not a `…Modifiers` or `…Base` file.
+- Rationale: all state must live in storage structs accessed via
+  `StorageWrapper` libraries — this is the core MAF invariant.
+- Fix: move the state to the appropriate `XxxDataStorage` struct and access it
+  through the StorageWrapper.
+
+**ATS-LINT-001** `solhint-disable` comment added.
+
+- Severity: WARNING — always flag, never block.
+- Pattern: any line containing `// solhint-disable` (inline or block form).
+- Review guidance: there are very few legitimate uses in this codebase.
+  Known acceptable cases:
+  - `// solhint-disable-next-line no-inline-assembly` immediately before the
+    `assembly { s_.slot := position }` block inside a StorageWrapper accessor.
+    Outside these known cases, the disable comment is a smell — ask: _Is there
+    a refactor that removes the need for it?_
+- When reporting, include the exact disable directive and the surrounding
+  context (what rule is being suppressed and why).
+
+**ATS-SEL-001** Ascending selector registration in `getStaticFunctionSelectors`.
+
+- Pattern: inside a `getStaticFunctionSelectors` function body, an ascending counter
+  such as `selectors[i++]`, `selectors[selectorIndex++]`, or any `i++`/`++i`
+  in the `for` header rather than the descending `unchecked { r[--i] = ...; }` pattern.
+- Fix: rewrite using the descending pattern:
+  `uint256 i = N; r = new bytes4[](i); unchecked { r[--i] = this.fn.selector; ... }`
+
+**ATS-BOUND-001** Forbidden import from `factory/ERC3643/`.
+
+- Pattern: an `import` statement in any file whose path contains
+  `contracts/constants/`, `contracts/domain/`, `contracts/facets/layer_1-2/`,
+  or whose filename is `Factory.sol`, that references `factory/ERC3643/`.
+- Fix: place shared types at a neutral location; the T-REX side re-exports or keeps its own copy.
+
+### CONTEXTUAL — require reading and understanding the code
+
+**ATS-ARCH-001** Thin wrapper function.
+
+- A function whose entire body is a single call to another function with the
+  same arguments and no additional logic, guard, or event.
+- Fix: delete the wrapper; callers invoke the underlying function directly.
+
+**ATS-ARCH-002** `initializeXxx` wrapper in a StorageWrapper.
+
+- A `library …StorageWrapper` that contains a function named `initializeXxx`
+  whose body only assigns values to the storage struct — a setter already
+  exists (or should exist) for this purpose.
+- Fix: expose only the setter; have the external facet initializer call the
+  setter directly.
+
+**ATS-ARCH-003** Event emitted inside a StorageWrapper or Ops library.
+
+- An `emit` statement inside a `library` body.
+- Fix: move the emit to the outermost business-logic layer (the abstract
+  contract of the facet), unless the library function is called from multiple
+  callers with no shared outer layer.
+
+**ATS-STYLE-001** Storage struct named `XxxStorage` instead of `XxxDataStorage`.
+
+- A `struct` whose name ends with `Storage` but not `DataStorage`, declared
+  inside a `…StorageWrapper` file.
+- Severity: WARNING (deuda técnica — do not auto-fix, flag only).
+
+**ATS-STYLE-002** Business-logic layer is `contract` instead of `abstract contract`.
+
+- A file in `facets/<name>/` (not `…Facet.sol`) that declares `contract`
+  instead of `abstract contract`.
+- Severity: WARNING (deuda técnica).
+
+**ATS-ARCH-004** `using X for Y` declared in a concrete facet or business-logic abstract.
+
+- A `using` statement inside a `contract` (not abstract) or an abstract in
+  `facets/<name>/` that is not a `…Modifiers` file and not an infrastructure
+  proxy contract.
+- `using` is permitted only in: `library …StorageWrapper`, `abstract contract
+…Modifiers`, and infrastructure proxy contracts under `infrastructure/`.
+- Fix: move the `using` declaration to the appropriate StorageWrapper library
+  or Modifiers abstract; have the facet layer call the library function
+  directly.
+
+**ATS-INIT-001** External `initializeXxx` function missing `InitializerStorageWrapper.setFacetToReady` call.
+
+- An `external` function whose name starts with `initialize` that does NOT
+  contain a call to `InitializerStorageWrapper.setFacetToReady(RESOLVER_KEY_…)`.
+- Rationale: every facet initializer must mark itself as ready in the
+  InitializerStorageWrapper so the Diamond resolver can track registration.
+- Fix: add `InitializerStorageWrapper.setFacetToReady(RESOLVER_KEY_XXX);`
+  after the setter calls and before the emitted event.
+
+**ATS-STORAGE-002** Storage struct missing 5-region layout.
+
+- A `struct` in a `*StorageWrapper.sol` that does not follow the 5-region layout with
+  all region banner comments present (even when a region is empty):
+  R1 Lifecycle bools, R2 Packed scalars, R3 Single-slot scalars, R4 Aggregates, APPEND-ONLY ZONE.
+- Fix: reorganise fields into the 5 regions and add all five banner comments.
+
+**ATS-INIT-002** Initializer uses inline guard instead of `onlyNot<Feature>Initialized` modifier.
+
+- An `external` function whose name starts with `initialize` that calls
+  `_checkNotInitialized(...)` or any equivalent inline guard expression, instead of
+  applying an `onlyNot<Feature>Initialized` modifier at the function signature.
+- Fix: extract the guard into a dedicated `onlyNot<Feature>Initialized` modifier and apply it.
+
+**ATS-EVENT-003** State-changing external function emits no event.
+
+- An `external` non-`view`/non-`pure` function that writes to storage and contains
+  no `emit` statement anywhere in its execution path.
+- Fix: declare and emit a dedicated event for the state change on the writer interface.
+
+**ATS-EVENT-004** Event declared on a shared types interface.
+
+- An `event` declaration inside an `I*Types.sol` file.
+- Fix: move the event to the writer interface (`I<Feature>.sol`) of the facet that emits it.
+
+**ATS-EVENT-005** Initializer does not emit a `<Feature>Initialized` event.
+
+- An `external` `initializeXxx` function that does not emit an event whose name ends
+  in `Initialized` and carries the initialised field values.
+- Fix: declare `event <Feature>Initialized(...)` on the writer interface and emit it.
+
+**ATS-TYPE-001** Type placement violation.
+
+- A `struct` or `enum` used by exactly one facet declared in a shared `I*Types.sol`
+  (should be inline on that facet's interface); or a type used by 2+ facets declared
+  inline on a single facet interface (should be in a shared `I*Types.sol`).
+- Fix: move to the correct location based on usage count.
+
+**ATS-TYPE-002** Custom error outside the reverting facet's interface.
+
+- A custom `error` declared in a file that is not the interface of the facet that
+  reverts with it, and not `ICommonErrors` (for cross-domain errors).
+- Fix: move the error to the writer interface of the facet that uses it, or to `ICommonErrors`.
+
+**ATS-NATSPEC-001** Missing NatSpec on `private` or `internal` callable.
+
+- A `private` or `internal` function, modifier, or constructor with no NatSpec block
+  (neither `/** */` block nor `///` line tags). Solhint `use-natspec` only warns on
+  `external`/`public` — this rule covers the unreported gap.
+- Fix: add at minimum a `@notice` line describing intent and a `@dev` line covering
+  preconditions or implementation constraints.

--- a/.claude/skills/ats-style-guide/references/style-guide.md
+++ b/.claude/skills/ats-style-guide/references/style-guide.md
@@ -1,0 +1,31 @@
+# References
+
+## Source of truth
+
+- **ATS Solidity Style Guide** — `.claude/solidity-style-guide.md`
+  Human-readable conventions. Each rule ID in this skill maps to a section there.
+
+  | Rule IDs                                               | Style guide section                                      |
+  | ------------------------------------------------------ | -------------------------------------------------------- |
+  | ATS-EVM-001, ATS-EVM-002                               | §9 Diamond / MAF Patterns — EVM context accessors        |
+  | ATS-ERR-001                                            | §11 Custom Errors & Reverts                              |
+  | ATS-IMP-001                                            | §3 Imports                                               |
+  | ATS-GAS-001, ATS-GAS-002                               | §13 Gas Patterns                                         |
+  | ATS-FUNC-001                                           | §7 Function Visibility & Prefix Rules — calldata         |
+  | ATS-PRIV-001                                           | §9 Diamond / MAF Patterns — StorageWrapper accessor      |
+  | ATS-NAME-001, ATS-NAME-002, ATS-NAME-003               | §6 Naming Conventions                                    |
+  | ATS-SUFFIX-001                                         | §9 Diamond / MAF Patterns — IStaticFunctionSelectors     |
+  | ATS-IFACE-001                                          | §4 Artifact Types & Name Suffixes — Interface            |
+  | ATS-STORAGE-001                                        | §8 Storage Struct Layout — storage-location annotation   |
+  | ATS-EVENT-001, ATS-EVENT-002                           | §12 Events — Indexed parameters, Parameter names         |
+  | ATS-FACET-001                                          | §9 Diamond / MAF Patterns — No state variables in facets |
+  | ATS-ARCH-001, ATS-ARCH-002, ATS-ARCH-003, ATS-ARCH-004 | §14 Prohibited Patterns                                  |
+  | ATS-STYLE-001, ATS-STYLE-002                           | §8 Storage Struct Layout, §4 Artifact Types              |
+  | ATS-INIT-001, ATS-INIT-002                             | §9 Diamond / MAF Patterns — Initializer pattern          |
+  | ATS-LINT-001                                           | §14 Prohibited Patterns — solhint-disable comments       |
+  | ATS-SEL-001                                            | §9 Diamond / MAF Patterns — getStaticFunctionSelectors   |
+  | ATS-BOUND-001                                          | §5 Architecture — Where Does Logic Live?                 |
+  | ATS-STORAGE-002                                        | §8 Storage Struct Layout — 5-region layout               |
+  | ATS-EVENT-003, ATS-EVENT-004, ATS-EVENT-005            | §12 Events — Emission location, Parameter names          |
+  | ATS-TYPE-001, ATS-TYPE-002                             | §4 Artifact Types & Name Suffixes — IXxxTypes.sol        |
+  | ATS-NATSPEC-001                                        | §10 NatSpec — External and public functions              |

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ asset-tokenization-studio.iml
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/solidity-natspec/
+!.claude/skills/ats-style-guide/
 .opencode/
 CLAUDE.md
 AGENTS.md

--- a/docs/ats/developer-guides/contracts/adding-facets.md
+++ b/docs/ats/developer-guides/contracts/adding-facets.md
@@ -125,6 +125,18 @@ interface IRewards {
 }
 ```
 
+#### Type placement
+
+| Usage                                   | Where to declare                                           |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `struct` / `enum` used by **1 facet**   | Inline on that facet's interface (`IFeature.sol`)          |
+| `struct` / `enum` used by **2+ facets** | Shared `I<Domain>Types.sol`                                |
+| `event`                                 | Writer interface (`IFeature.sol`) — never on `I*Types.sol` |
+| `error` (single facet)                  | Writer interface of the facet that reverts with it         |
+| `error` (cross-domain)                  | `ICommonErrors.sol`                                        |
+
+A facet interface inherits a types interface **only if it uses at least one symbol from it**.
+
 ### Step 2: Create Storage Wrapper (if needed)
 
 If your facet requires custom storage, create a storage wrapper under
@@ -135,10 +147,29 @@ If your facet requires custom storage, create a storage wrapper under
 → **R3 Single-slot scalars (uint256, bytes32, string)** → **R4 Aggregates
 (mapping, array, EnumerableSet, checkpoint arrays)** → **APPEND-ONLY ZONE**.
 New fields go below the marker — the boundary is greppable and audit-visible.
-All four region banners are **always present, in canonical order, even when a region has no
+All five region banners are **always present, in canonical order, even when a region has no
 fields** — the empty banners are scaffolding that fixes each field's insertion point and the
 region numbering. Never renumber a region when its only field is removed; leave the empty
 banner in place.
+
+Every storage struct must follow the 5-region layout. All five region banner comments are **always present**, even when a region has no fields:
+
+```solidity
+struct CapDataStorage {
+  // ─── R1 Lifecycle ──────────────────────────────────────────
+  bool isInitialized;
+  // ─── R2 Packed scalars ─────────────────────────────────────
+
+  // ─── R3 Single-slot scalars ────────────────────────────────
+  uint256 maxSupply;
+
+  // ─── R4 Aggregates ─────────────────────────────────────────
+
+  // ─── APPEND-ONLY ZONE ──────────────────────────────────────
+  // New fields must be added below this line.
+  // Reordering fields above this marker requires a major version bump and clean redeploy.
+}
+```
 
 **File**: `contracts/domain/asset/rewards/RewardsStorageWrapper.sol`
 
@@ -402,6 +433,31 @@ contract RewardsFacet is Rewards, IStaticFunctionSelectors {
 }
 ```
 
+#### `getStaticFunctionSelectors` — descending `unchecked` pattern
+
+**Use the descending `unchecked` pattern — the ascending form is prohibited.**
+
+```solidity
+// ✅ descending — mandatory for new/modified facets
+function getStaticFunctionSelectors() external pure override returns (bytes4[] memory r) {
+    uint256 i = 3;
+    r = new bytes4[](i);
+    unchecked {
+        r[--i] = this.getRewards.selector;
+        r[--i] = this.distributeReward.selector;
+        r[--i] = this.initialize_Rewards.selector;
+    }
+}
+
+// ❌ ascending — forbidden
+function getStaticFunctionSelectors() external pure override returns (bytes4[] memory) {
+    bytes4[] memory selectors = new bytes4[](3);
+    uint256 i = 0;
+    selectors[i++] = this.initialize_Rewards.selector;
+    ...
+}
+```
+
 ### Step 9: Update Common Contract (if needed)
 
 If your facet requires storage access across all facets, update the `Common` contract inheritance chain.
@@ -628,6 +684,13 @@ const tx = await factory.createEquityToken(
 
 ## Best Practices
 
+### ERC-3643 import boundary
+
+**Hard rule.** Files under `contracts/constants/`, `contracts/domain/`, `contracts/facets/layer_1-2/`,
+and `contracts/factory/Factory.sol` must **never** import from `contracts/factory/ERC3643/`.
+When types need to be shared, the canonical definition lives at the neutral location;
+the T-REX side re-exports or keeps an isolated copy.
+
 ### Naming Conventions
 
 | Element                 | Convention                      | Example                    |
@@ -641,6 +704,13 @@ const tx = await factory.createEquityToken(
 | Storage position        | STORAGE_LOCATION_FEATURE        | `STORAGE_LOCATION_REWARDS` |
 | Role                    | ROLE_NAME                       | `ROLE_REWARDS_DISTRIBUTOR` |
 | Initialization          | initializeFeatureName           | `initializeRewards`        |
+
+#### Library `internal` functions — `_` prefix convention
+
+**Library `internal` functions — no `_` prefix by default.**
+These functions are inlined into the calling contract's bytecode at compile time and form the library's composable API, always called as `LibraryName.fn()`. Using `_` would imply they are hidden implementation details when they are not.
+
+**Optional exception — explicit call-type annotation:** In libraries that mix `internal` (inlined, bytecode-composed) and `external` (DELEGATECALL) functions, a team may adopt `_` on all `internal` functions as a visual signal distinguishing bytecode composition from DELEGATECALL dispatch. If adopted, apply it consistently across the entire library — never mixed.
 
 ### Storage Management
 
@@ -656,6 +726,28 @@ const tx = await factory.createEquityToken(
 3. **Validate addresses**: `validateAddress(_tokenHolder)`
 4. **Check KYC status**: Verify compliance for sensitive operations
 
+#### Initializer modifier — `onlyNot<Feature>Initialized`
+
+Every initializer MUST apply an `onlyNot<Feature>Initialized` modifier — never an inline `_checkNotInitialized(...)` call buried in the function body:
+
+```solidity
+// ✅
+function initializeCap(uint256 _maxSupply)
+    external
+    override
+    onlyRole(DEFAULT_ADMIN_ROLE)
+    onlyFacetNotRegistered(RESOLVER_KEY_CAP)
+    onlyNotCapInitialized
+    onlyValidMaxSupply(_maxSupply)
+{ ... }
+
+// ❌
+function initializeCap(uint256 _maxSupply) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    _checkNotInitialized(RESOLVER_KEY_CAP);
+    ...
+}
+```
+
 ### Gas Optimization
 
 1. **Separate read/write operations**: Consider split facets (like Bond/BondRead)
@@ -669,11 +761,45 @@ const tx = await factory.createEquityToken(
 2. **Descriptive error names**: `RewardAmountIsZero` vs `InvalidAmount`
 3. **Document error conditions**: Add NatSpec comments
 
+### No `solhint-disable` comments
+
+`// solhint-disable` comments (inline or block form) must not be introduced without justification. The only known acceptable use is the `no-inline-assembly` suppression immediately before the `assembly { s_.slot := position }` block inside a StorageWrapper accessor:
+
+```solidity
+// solhint-disable-next-line no-inline-assembly
+assembly {
+    s_.slot := position
+}
+```
+
+Every other occurrence is a signal to refactor — ask: _Is there a change to the code that removes the need for this suppression?_
+
 ### Event Emission
 
 1. **Emit events for state changes**: Required for off-chain tracking
 2. **Include indexed parameters**: For efficient filtering
 3. **Use descriptive event names**: `RewardDistributed` vs `Distributed`
+
+#### Event parameter names — no `_` prefix
+
+Event parameters use clean names — **no `_` prefix**.
+
+```solidity
+event Paused(address indexed operator); // ✅
+event Paused(address indexed _operator); // ❌
+```
+
+This applies to the `event` declaration and its `@param` NatSpec tags. The ABI/topic hash depends on event name and parameter types only — never on parameter names — so renaming is non-breaking. Follows the same convention as OpenZeppelin (`Transfer(address indexed from, ...)`), even where the source EIP uses underscores.
+
+**Out of scope:** function parameters keep the project convention — `_input` for inputs, `output_` for named returns.
+
+#### Emission location — exceptions
+
+Events should be emitted at the outermost business-logic layer. **Exceptions — the emit may stay in the domain layer when:**
+
+- The emit lives in a low-level helper reached from several callers, the orchestrator (`*Ops`), or another wrapper — moving it would duplicate or drop the event.
+- The emit is conditional on internal state the facet does not have.
+- The event reconstructs internal storage state, or is a **synthetic** ledger event (e.g. a `Transfer` / `TransferByPartition` to/from `address(0)` mirroring a hold or lock). These are bookkeeping details of the domain representation and belong with it.
 
 ## Examples
 

--- a/docs/ats/developer-guides/contracts/documenting-contracts.md
+++ b/docs/ats/developer-guides/contracts/documenting-contracts.md
@@ -96,6 +96,25 @@ function _calculateCouponAmount(
 }
 ```
 
+### Private and internal callables require NatSpec too
+
+Solhint's `use-natspec` warning only fires on `external` and `public` elements.
+Every `private` and `internal` function, modifier, and constructor also requires
+a NatSpec block — at minimum `@notice` (intent) and `@dev` (preconditions or
+implementation constraints):
+
+```solidity
+/**
+ * @notice Validates that the corporate action id is non-zero.
+ * @dev Reverts with InvalidCorporateActionId if actionId is bytes32(0).
+ */
+function _checkValidCorporateActionId(bytes32 _actionId) internal view { ... }
+```
+
+> **Rationale:** private/internal logic is where subtle invariants live.
+> Auditors read it; without NatSpec they rely solely on variable names,
+> which is insufficient for non-obvious preconditions.
+
 ### Events Documentation
 
 Document all events with clear descriptions of when they're emitted:

--- a/packages/ats/contracts/.gitignore
+++ b/packages/ats/contracts/.gitignore
@@ -88,3 +88,10 @@ deployments/**/.checkpoints/
 
 # Auto-generated MCP server context (added automatically)
 .mcp-server-context.md
+
+# run-ai-checks.sh output — never commit these
+ai-run.log
+ai-run.json
+*.ai-run.log
+*.ai-run.json
+.ai-logs/

--- a/packages/ats/contracts/package.json
+++ b/packages/ats/contracts/package.json
@@ -65,6 +65,7 @@
     "lint:sol:fix": "solhint --config solhint.config.js 'contracts/**/*.sol' --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "ai-checks": "bash scripts/run-ai-checks.sh",
     "generate:registry": "npx tsx scripts/tools/registry-generator/index.ts",
     "generate:registry:cached": "npx tsx scripts/tools/registry-generator/index.ts --use-cache",
     "hashes:generate": "npx tsx scripts/codegen/applyHashGen.ts --write",

--- a/packages/ats/contracts/scripts/DEVELOPER_GUIDE.md
+++ b/packages/ats/contracts/scripts/DEVELOPER_GUIDE.md
@@ -4,19 +4,71 @@ This guide provides practical, step-by-step instructions for the most common dev
 
 ## Table of Contents
 
-1. [Architecture Overview](#architecture-overview)
-2. [Quick Start - Using the CLI](#quick-start---using-the-cli)
-3. [Scenario 1: Add/Remove Facet from Existing Asset](#scenario-1-addremove-facet-from-existing-asset)
-4. [Scenario 2: Create New Asset Type (Configuration ID)](#scenario-2-create-new-asset-type-configuration-id)
-5. [Scenario 3: Upgrading Facet Implementations](#scenario-3-upgrading-facet-implementations)
-6. [Scenario 4: Selective Configuration Upgrades](#scenario-4-selective-configuration-upgrades)
-7. [Scenario 5: Multi-Environment Rollout](#scenario-5-multi-environment-rollout)
-8. [Scenario 6: Upgrading TUP Proxy Implementations (BLR/Factory)](#scenario-6-upgrading-tup-proxy-implementations-blrfactory)
-9. [Scenario 7: Recovering from Failed Deployment](#scenario-7-recovering-from-failed-deployment)
-10. [Complete Deployment Workflows](#complete-deployment-workflows)
-11. [Registry System](#registry-system)
-12. [Advanced Topics](#advanced-topics)
-13. [Troubleshooting](#troubleshooting)
+1. [Validation & AI Tools](#validation--ai-tools)
+2. [Architecture Overview](#architecture-overview)
+3. [Quick Start - Using the CLI](#quick-start---using-the-cli)
+4. [Scenario 1: Add/Remove Facet from Existing Asset](#scenario-1-addremove-facet-from-existing-asset)
+5. [Scenario 2: Create New Asset Type (Configuration ID)](#scenario-2-create-new-asset-type-configuration-id)
+6. [Scenario 3: Upgrading Facet Implementations](#scenario-3-upgrading-facet-implementations)
+7. [Scenario 4: Selective Configuration Upgrades](#scenario-4-selective-configuration-upgrades)
+8. [Scenario 5: Multi-Environment Rollout](#scenario-5-multi-environment-rollout)
+9. [Scenario 6: Upgrading TUP Proxy Implementations (BLR/Factory)](#scenario-6-upgrading-tup-proxy-implementations-blrfactory)
+10. [Scenario 7: Recovering from Failed Deployment](#scenario-7-recovering-from-failed-deployment)
+11. [Complete Deployment Workflows](#complete-deployment-workflows)
+12. [Registry System](#registry-system)
+13. [Advanced Topics](#advanced-topics)
+14. [Troubleshooting](#troubleshooting)
+
+---
+
+## Validation & AI Tools
+
+### `run-ai-checks.sh` — unified validation script
+
+The script at `scripts/run-ai-checks.sh` runs the full validation pipeline (format → lint → compile → test → coverage) and produces a structured log optimised for AI-assisted diagnosis.
+
+**Available from the repo — no installation required:**
+
+```bash
+# Full run
+npm run ai-checks
+
+# With flags
+bash scripts/run-ai-checks.sh --skip-test
+bash scripts/run-ai-checks.sh --test-grep "Cap"
+bash scripts/run-ai-checks.sh --skip-format --skip-lint
+bash scripts/run-ai-checks.sh --test-file test/unit/cap.test.ts
+```
+
+**Common flags:**
+
+| Flag                    | Effect                               |
+| ----------------------- | ------------------------------------ |
+| `--skip-format`         | Skip Prettier                        |
+| `--skip-lint`           | Skip solhint + ESLint                |
+| `--skip-compile`        | Skip Hardhat compile                 |
+| `--skip-test`           | Skip tests and coverage              |
+| `--skip-coverage`       | Run tests but skip coverage          |
+| `--test-grep <pattern>` | Run only tests matching pattern      |
+| `--test-file <path>`    | Run a single test file               |
+| `--test-full`           | Show full test output (not filtered) |
+| `--coverage-min <n>`    | Fail if statement coverage < n%      |
+
+The script writes output to `.ai-logs/ai-run.log`. All logs, archives, metrics and baselines
+live under `.ai-logs/` — nothing is written to the package root. Read `.ai-logs/ai-run.log`
+to diagnose failures; do not re-run individual `npm` commands before checking it.
+
+### `/validate` — Claude Code command
+
+If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), the `/validate` command wraps the script directly from the chat interface:
+
+```
+/validate
+/validate --skip-test
+/validate --test-grep "Cap"
+```
+
+Claude will run the script, read `ai-run.log`, and report errors, warnings, test results, and coverage in a structured summary.
 
 ---
 

--- a/packages/ats/contracts/scripts/coverage-report.js
+++ b/packages/ats/contracts/scripts/coverage-report.js
@@ -15,9 +15,11 @@
  *   Defaults to ./coverage.json in the current working directory.
  */
 
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
+/* eslint-enable @typescript-eslint/no-require-imports */
 
 // ── ANSI ─────────────────────────────────────────────────────────────────────
 const R = "\x1b[0m";
@@ -177,7 +179,7 @@ try {
     .map((line) => path.resolve(gitRoot, line.slice(3).trim()));
 
   pendingEntries = allEntries.filter((e) => pendingPaths.includes(e.fullPath));
-} catch (_) {
+} catch {
   // not a git repo or git unavailable
 }
 

--- a/packages/ats/contracts/scripts/coverage-report.js
+++ b/packages/ats/contracts/scripts/coverage-report.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * coverage-report.js
+ *
+ * Reads coverage.json (Istanbul/solidity-coverage format) and prints:
+ *   • Overall line / branch / function / statement totals with progress bars
+ *   • Top 10 files with worst combined (line + branch) coverage
+ *   • Pending git changes — coverage for every modified .sol file
+ *
+ * Usage:
+ *   coverage-report.js [path/to/coverage.json]
+ *
+ *   Defaults to ./coverage.json in the current working directory.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// ── ANSI ─────────────────────────────────────────────────────────────────────
+const R = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RED = "\x1b[31m";
+const YLW = "\x1b[33m";
+const GRN = "\x1b[32m";
+const CYN = "\x1b[36m";
+const MAG = "\x1b[35m";
+
+function colorFor(p) {
+  if (p === null) return DIM;
+  if (p < 50) return RED;
+  if (p < 80) return YLW;
+  return GRN;
+}
+
+/** Fixed-width (6 visible chars) coloured percentage string. */
+function fmtPct(p) {
+  if (p === null) return `${DIM}   N/A${R}`;
+  return `${colorFor(p)}${`${p.toFixed(1)}%`.padStart(6)}${R}`;
+}
+
+/** Mini progress bar — width is in visible chars. */
+function bar(p, w = 14) {
+  if (p === null) return `${DIM}${"─".repeat(w)}${R}`;
+  const f = Math.round((p / 100) * w);
+  return `${colorFor(p)}${"█".repeat(f)}${DIM}${"░".repeat(w - f)}${R}`;
+}
+
+// ── Coverage calculation ──────────────────────────────────────────────────────
+function calcCov(data) {
+  const l = data.l || {};
+  const b = data.b || {};
+  const f = data.f || {};
+  const s = data.s || {};
+
+  const totalL = Object.keys(l).length;
+  const covL = Object.values(l).filter((v) => v > 0).length;
+
+  let totalB = 0,
+    covB = 0;
+  for (const arr of Object.values(b)) {
+    for (const hit of arr) {
+      totalB++;
+      if (hit > 0) covB++;
+    }
+  }
+
+  const totalF = Object.keys(f).length;
+  const covF = Object.values(f).filter((v) => v > 0).length;
+
+  const totalS = Object.keys(s).length;
+  const covS = Object.values(s).filter((v) => v > 0).length;
+
+  const linePct = totalL > 0 ? (covL / totalL) * 100 : null;
+  const branchPct = totalB > 0 ? (covB / totalB) * 100 : null;
+  const funcPct = totalF > 0 ? (covF / totalF) * 100 : null;
+  const stmtPct = totalS > 0 ? (covS / totalS) * 100 : null;
+
+  // Score = average of the dimensions that are present
+  const dims = [linePct, branchPct].filter((v) => v !== null);
+  const score = dims.length > 0 ? dims.reduce((a, v) => a + v, 0) / dims.length : 100;
+
+  return { covL, totalL, linePct, covB, totalB, branchPct, covF, totalF, funcPct, covS, totalS, stmtPct, score };
+}
+
+function sumCov(entries) {
+  return entries.reduce(
+    (a, e) => {
+      a.covL += e.cov.covL;
+      a.totalL += e.cov.totalL;
+      a.covB += e.cov.covB;
+      a.totalB += e.cov.totalB;
+      a.covF += e.cov.covF;
+      a.totalF += e.cov.totalF;
+      a.covS += e.cov.covS;
+      a.totalS += e.cov.totalS;
+      return a;
+    },
+    { covL: 0, totalL: 0, covB: 0, totalB: 0, covF: 0, totalF: 0, covS: 0, totalS: 0 },
+  );
+}
+
+/** Truncate or pad a string to exactly n visible chars. */
+function fit(str, n) {
+  if (str.length > n) return "…" + str.slice(-(n - 1));
+  return str.padEnd(n);
+}
+
+// ── Table ─────────────────────────────────────────────────────────────────────
+const NAME_W = 50;
+
+function printTable(entries) {
+  console.log(`  ${fit("File", NAME_W)}  ${"Lines".padStart(6)}  ${"Branches".padStart(8)}  ${"Score".padStart(6)}`);
+  console.log(`  ${DIM}${"─".repeat(NAME_W)}  ${"─".repeat(6)}  ${"─".repeat(8)}  ${"─".repeat(6)}${R}`);
+  for (const e of entries) {
+    const { cov } = e;
+    // fmtPct returns 6 visible chars + ANSI; right columns need no extra padding
+    console.log(
+      `  ${fit(e.name, NAME_W)}  ${fmtPct(cov.linePct)}  ${fmtPct(cov.branchPct).padStart(8 + 9)}  ${fmtPct(cov.score)}`,
+    );
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+const coveragePath = process.argv[2] || path.join(process.cwd(), "coverage.json");
+
+if (!fs.existsSync(coveragePath)) {
+  console.error(`\n${RED}✗ coverage.json not found: ${coveragePath}${R}`);
+  console.error(`  Run: npx hardhat coverage   (or pass the file path as argument)\n`);
+  process.exit(1);
+}
+
+const raw = JSON.parse(fs.readFileSync(coveragePath, "utf8"));
+const baseDir = path.dirname(path.resolve(coveragePath));
+
+const allEntries = Object.entries(raw).map(([key, data]) => {
+  const fullPath = data.path ? path.resolve(data.path) : path.resolve(baseDir, key);
+  const rel = path.relative(baseDir, fullPath);
+  const name = rel.startsWith("..") ? fullPath : rel;
+  return { key, name, fullPath, cov: calcCov(data) };
+});
+
+// Overall totals
+const T = sumCov(allEntries);
+const oL = T.totalL > 0 ? (T.covL / T.totalL) * 100 : null;
+const oB = T.totalB > 0 ? (T.covB / T.totalB) * 100 : null;
+const oF = T.totalF > 0 ? (T.covF / T.totalF) * 100 : null;
+const oS = T.totalS > 0 ? (T.covS / T.totalS) * 100 : null;
+
+// Worst 10 (skip files with no trackable lines/branches)
+const worst10 = allEntries
+  .filter((e) => e.cov.totalL > 0 || e.cov.totalB > 0)
+  .sort((a, b) => a.cov.score - b.cov.score)
+  .slice(0, 10);
+
+// Pending Solidity changes
+let pendingEntries = [];
+let pendingPaths = [];
+
+try {
+  const gitRoot = execSync("git rev-parse --show-toplevel", {
+    cwd: baseDir,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+
+  pendingPaths = execSync("git status --porcelain", {
+    cwd: gitRoot,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+    .split("\n")
+    .filter((line) => line.length > 2 && line.slice(3).trim().endsWith(".sol"))
+    .map((line) => path.resolve(gitRoot, line.slice(3).trim()));
+
+  pendingEntries = allEntries.filter((e) => pendingPaths.includes(e.fullPath));
+} catch (_) {
+  // not a git repo or git unavailable
+}
+
+// ── Output ────────────────────────────────────────────────────────────────────
+console.log(`\n${BOLD}${CYN}  ◆ SOLIDITY COVERAGE REPORT${R}\n`);
+
+// Overall
+console.log(`${BOLD}  Overall  ${DIM}(${allEntries.length} files)${R}`);
+for (const [label, p, cov, total] of [
+  ["Lines", oL, T.covL, T.totalL],
+  ["Branches", oB, T.covB, T.totalB],
+  ["Functions", oF, T.covF, T.totalF],
+  ["Statements", oS, T.covS, T.totalS],
+]) {
+  console.log(`    ${label.padEnd(12)} ${bar(p)}  ${fmtPct(p)}  ${DIM}(${cov}/${total})${R}`);
+}
+console.log();
+
+const THRESHOLD = 80;
+const ok = (oL === null || oL >= THRESHOLD) && (oB === null || oB >= THRESHOLD);
+console.log(
+  ok
+    ? `  ${GRN}✓  Overall coverage meets the ${THRESHOLD}% threshold${R}`
+    : `  ${YLW}⚠  Overall coverage is below the ${THRESHOLD}% threshold${R}`,
+);
+console.log();
+
+// Top 10 worst
+console.log(`${BOLD}  Top 10 Worst Coverage${R}  ${DIM}(score = avg line + branch)${R}`);
+printTable(worst10);
+console.log();
+
+// Pending changes
+if (pendingEntries.length > 0) {
+  const n = pendingEntries.length;
+  console.log(
+    `${BOLD}${MAG}  Pending Changes  ${DIM}(${n} modified .sol file${n > 1 ? "s" : ""} with coverage data)${R}`,
+  );
+  printTable(pendingEntries);
+  console.log();
+} else if (pendingPaths.length > 0) {
+  console.log(
+    `${BOLD}${MAG}  Pending Changes${R}  ${YLW}⚠  ${pendingPaths.length} modified .sol file(s) not in coverage.json${R}`,
+  );
+  console.log(`  ${DIM}Re-run: npx hardhat coverage${R}`);
+  console.log();
+}

--- a/packages/ats/contracts/scripts/run-ai-checks.sh
+++ b/packages/ats/contracts/scripts/run-ai-checks.sh
@@ -1,0 +1,1247 @@
+#!/usr/bin/env bash
+# ============================================================================
+# run-ai-checks.sh — Unified validation for ATS contracts
+#
+# Usage:
+#   run-ai-checks.sh [logfile]                     ← full run (default: ai-run.log)
+#   run-ai-checks.sh --skip-format                  ← without prettier
+#   run-ai-checks.sh --skip-lint                    ← without lint (sol + js)
+#   run-ai-checks.sh --skip-compile                 ← without compilation
+#   run-ai-checks.sh --skip-test                    ← without tests (also skips typecheck and lint:js)
+#   run-ai-checks.sh --skip-format --skip-lint      ← compile + test only
+#   run-ai-checks.sh --test-file <path>             ← a single test file
+#   run-ai-checks.sh --test-grep <pattern>          ← tests by name
+#   run-ai-checks.sh --test-full                    ← full test and coverage output in the log
+#   run-ai-checks.sh --test-filter <text>           ← filter test and coverage output by text
+#   run-ai-checks.sh --skip-compile --test-file X   ← without compiling, specific test
+#   run-ai-checks.sh --skip-format --skip-lint --skip-compile --skip-test ← dry-run
+#   run-ai-checks.sh --skip-coverage                ← without coverage
+#   run-ai-checks.sh --skip-typecheck               ← without tsc --noEmit (typecheck of test files)
+#   run-ai-checks.sh --coverage-min 70              ← minimum statements threshold (%)
+#   run-ai-checks.sh --help                         ← this help text
+#
+# Output: LOG_FILE (default: ai-run.log) containing:
+#   - Execution context
+#   - Filtered output + exit code for each step
+#   - Structured summary (timings, diff, failures)
+#
+# Test output modes (and coverage):
+#   (default)                 ← failing tests only (filter_test_relevant)
+#   --test-full               ← full output without filtering
+#   --test-filter <text>      ← only lines containing <text>
+# ============================================================================
+
+set -u
+set -o pipefail
+
+SCRIPT_VERSION="2.3.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- Default flags ---------------------------------------------------
+SKIP_FORMAT=false
+SKIP_LINT=false
+LINT_CHANGED=false
+SKIP_COMPILE=false
+SKIP_TEST=false
+SKIP_TYPECHECK=false
+SKIP_COVERAGE=false
+COVERAGE_CHANGED=false
+COVERAGE_MIN=""
+TEST_FILE=""
+TEST_GREP=""
+TEST_OUTPUT="errors"   # errors | filter | full
+TEST_FILTER_TEXT=""
+LOG_RETENTION_DAYS=15  # number of days logs are retained in .ai-logs/archive/
+
+# ---- Argument parsing ------------------------------------------------
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-format) SKIP_FORMAT=true; shift ;;
+    --skip-lint)    SKIP_LINT=true;    shift ;;
+    --lint-changed) LINT_CHANGED=true; shift ;;
+    --skip-compile) SKIP_COMPILE=true; shift ;;
+    --skip-test)     SKIP_TEST=true;      shift ;;
+    --skip-typecheck) SKIP_TYPECHECK=true; shift ;;
+    --skip-coverage)    SKIP_COVERAGE=true;    shift ;;
+    --coverage-changed) COVERAGE_CHANGED=true; shift ;;
+    --coverage-min)     COVERAGE_MIN="$2";     shift 2 ;;
+    --test-file)     TEST_FILE="$2";       shift 2 ;;
+    --test-grep)     TEST_GREP="$2";       shift 2 ;;
+    --test-full)       TEST_OUTPUT="full";   shift ;;
+    --test-filter)     TEST_OUTPUT="filter"; TEST_FILTER_TEXT="$2"; shift 2 ;;
+    --log-retention)   LOG_RETENTION_DAYS="${2%d}"; shift 2 ;;
+    --help|-h)
+      head -35 "$0" | grep -E '^#|^$' | sed 's/^# //;s/^#$//'
+      exit 0
+      ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+# ---- Log directory (.ai-logs/) ----------------------------------------
+# Structure:
+#   .ai-logs/archive/   ← previous runs, auto-purged according to LOG_RETENTION_DAYS
+#   .ai-logs/baselines/ ← per-branch baselines (formerly .ai-baselines/)
+#   .ai-logs/metrics.ndjson ← NDJSON metrics history (formerly *.log.history)
+AI_LOGS_DIR=".ai-logs"
+mkdir -p "${AI_LOGS_DIR}/archive" "${AI_LOGS_DIR}/baselines" 2>/dev/null || true
+
+# First positional argument = log name (default inside .ai-logs/)
+_log_arg="${POSITIONAL[0]:-}"
+if [[ -n "$_log_arg" && "$_log_arg" != */* ]]; then
+  LOG_FILE="${AI_LOGS_DIR}/${_log_arg}"
+else
+  LOG_FILE="${_log_arg:-${AI_LOGS_DIR}/ai-run.log}"
+fi
+
+# Archive the previous log before overwriting
+if [[ -f "$LOG_FILE" ]]; then
+    _arch_ts=$(date +%Y%m%d_%H%M%S)
+    cp "$LOG_FILE" "${AI_LOGS_DIR}/archive/${_arch_ts}_$(basename "$LOG_FILE")" 2>/dev/null || true
+    _json_prev="${LOG_FILE%.log}.json"
+    [[ -f "$_json_prev" ]] && \
+        cp "$_json_prev" "${AI_LOGS_DIR}/archive/${_arch_ts}_$(basename "$_json_prev")" 2>/dev/null || true
+fi
+
+# Purge files older than LOG_RETENTION_DAYS
+if [[ "${LOG_RETENTION_DAYS:-0}" -gt 0 ]]; then
+    find "${AI_LOGS_DIR}/archive" -maxdepth 1 \
+        \( -name "*.log" -o -name "*.json" \) \
+        -mtime +"$LOG_RETENTION_DAYS" -delete 2>/dev/null || true
+fi
+
+# ---- Temporary setup and cleanup ------------------------------------------------
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; [[ -n "${_ats_wrapper:-}" ]] && rm -f "$_ats_wrapper"; }
+trap cleanup EXIT
+
+: > "$LOG_FILE"
+
+# ---- Helper functions -----------------------------------------------------------
+
+log() {
+  echo "$*" >> "$LOG_FILE"
+}
+
+log_header() {
+  local title="$1"
+  log ""
+  log "============================================================"
+  log "  $title"
+  log "  $(date -Iseconds)"
+  log "============================================================"
+}
+
+# Filter for lines relevant to AI diagnosis — balance between
+# capturing errors and avoiding noise saturation.
+# Includes the tsc format: "file.ts(line,col): error TSxxxx: ..."
+filter_relevant() {
+  grep -Ei \
+    'error|errors|warning|warnings|failed|failure|failures|failing|fatal|passed|passing|test suites|tests:|✓|✗|×|snapshots:|time:|jest|eslint|solhint|hardhat|compile|compilation|type error|syntaxerror|referenceerror|assertionerror|exception|revert|panic|stack|trace|at .*:[0-9]+:[0-9]+|\.ts:[0-9]+|\.ts\([0-9]+,[0-9]+\)|\.sol:[0-9]+|npm err|exit code|exitcode|code |expected|received|actual|reason|caused by|cannot find|module not found|not found|undefined|null|timeout|gas remaining|coverage|summary|found [0-9]+ error|^✖|^×|^✓' \
+    | grep -Eiv \
+    'npm notice|npm fund|npm audit|added [0-9]+ packages|changed [0-9]+ packages|up to date|audited [0-9]+ packages|found 0 vulnerabilities|deprecated \([0-9]+|download|progress|cache|verbose|sill|timing'
+}
+
+# Variant for the test step: collapses the describe/it hierarchy of each
+# Mocha failure block into a single compact line "  N) Suite.nested.test:"
+filter_test_relevant() {
+  awk '
+    BEGIN { in_block = 0; path = ""; prefix = "" }
+
+    # Entry to numbered block — extracts the prefix "  N) " and the first segment
+    /^[[:space:]]+[0-9]+\) / {
+      in_block = 1
+      match($0, /^[[:space:]]+[0-9]+\) /)
+      prefix = substr($0, 1, RLENGTH)
+      path   = substr($0, RLENGTH + 1)
+      sub(/[[:space:]]+$/, "", path)
+      next
+    }
+
+    # Inside the block: path lines (≥6 spaces, not stack/error lines)
+    in_block && /^[[:space:]]{6}/ &&
+    !/^[[:space:]]*(at [^[:space:]]|AssertionError|[A-Z][a-zA-Z]*Error:|VM Exception|panic|revert)/ {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      path = path "." line
+      next
+    }
+
+    # End of block: emits the compact line and falls through to the base filter
+    in_block {
+      in_block = 0
+      print prefix path
+    }
+
+    # Mocha summary ("N passing (Xs)" / "N failing") — always show
+    /^[[:space:]]*[0-9]+ (passing|failing)/ { print; next }
+
+    # Base filter — no ✓ or generic "passing/passed" so as not to show passing tests
+    /[Ee]rror|[Ww]arning|[Ff]ail(ed|ure|ures|ing)?|[Ff]atal|✗|×|[Ee]xception|revert|panic|timeout|assert|expected|received|actual|reason|caused by|cannot find|not found|undefined|null|gas remaining|coverage|summary|\.ts:[0-9]+|\.sol:[0-9]+|at .*:[0-9]+:[0-9]+|exit code/ &&
+    !/npm (notice|fund|audit)|added [0-9]+ packages|up to date|audited|found 0 vulnerabilities|deprecated \(|download|progress|cache|verbose|sill|timing/ {
+      print
+    }
+  '
+}
+
+# No filter: pass everything through (--test-full mode)
+filter_none() { cat; }
+
+# Free-text filter (--test-filter <text> mode)
+filter_by_text() {
+  grep -i "$TEST_FILTER_TEXT" || true
+}
+
+# Formats milliseconds as "Xh Xm Xs", omitting zero-value units.
+# Examples: 22000 → "22s"  |  90500 → "1m 30s"  |  3661000 → "1h 1m 1s"
+format_duration() {
+  local ms=$1
+  local s=$(( ms / 1000 ))
+  local frac=$(( ms % 1000 ))
+  local h=$(( s / 3600 ))
+  local m=$(( (s % 3600) / 60 ))
+  local sec=$(( s % 60 ))
+  local sec_str
+  sec_str="${sec}.$(printf '%03d' $frac)s"
+  if   [[ $h -gt 0 ]]; then echo "${h}h ${m}m ${sec_str}"
+  elif [[ $m -gt 0 ]]; then echo "${m}m ${sec_str}"
+  else                       echo "${sec_str}"
+  fi
+}
+
+run_step() {
+  # Usage: run_step [--filter <fn>] [--errors-only] <name> <cmd...>
+  #
+  # --errors-only: considers the step successful if there are no error lines,
+  # even if the command exits with a non-zero exit code (e.g. solhint with warnings only).
+  local filter_fn="filter_relevant"
+  local fail_on_errors_only=false
+
+  while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+      --filter)       filter_fn="$2"; shift 2 ;;
+      --errors-only)  fail_on_errors_only=true; shift ;;
+      *)              break ;;
+    esac
+  done
+
+  local name="$1"
+  shift
+
+  local step_start
+  step_start=$(date +%s%N)
+  local raw_file="$TMP_DIR/${name// /_}.raw.log"
+  local exit_code=0
+
+  log_header "STEP: $name"
+  log "\$ $*"
+  log ""
+
+  "$@" > "$raw_file" 2>&1 || exit_code=$?
+
+  # --errors-only: if the command failed due to warnings (not errors), treat as OK
+  if $fail_on_errors_only && [[ "$exit_code" -ne 0 ]]; then
+    local _err_count
+    _err_count=$(grep -cE $'^\s+[0-9]+:[0-9]+\s+error' "$raw_file" 2>/dev/null || true)
+    [[ "${_err_count:-0}" -eq 0 ]] && exit_code=0
+  fi
+
+  local step_end
+  step_end=$(date +%s%N)
+  local step_ms=$(( (step_end - step_start) / 1000000 ))
+  local step_dur
+  step_dur=$(format_duration "$step_ms")
+
+  {
+    echo "----- Relevant output -----"
+    "$filter_fn" < "$raw_file" || true
+    echo ""
+    echo "----- End of step '$name' -----"
+    echo "  Command: $*"
+    echo "  Exit code: $exit_code"
+    echo "  Duration: $step_dur"
+    echo ""
+  } >> "$LOG_FILE"
+
+  echo "$name|$exit_code|$step_dur" >> "$TMP_DIR/steps.log"
+
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "❌ Failed: $name (exit $exit_code, $step_dur)"
+    echo "   Log: $LOG_FILE"
+    return "$exit_code"
+  fi
+
+  echo "✅ OK: $name ($step_dur)"
+  return 0
+}
+
+# ---- FINAL SUMMARY --------------------------------------------------------
+generate_summary() {
+  log ""
+  log "============================================================"
+  log "  VALIDATION SUMMARY"
+  log "  $(date -Iseconds)"
+  log "============================================================"
+
+  local total_sec=0
+  local all_ok=true
+
+  if [[ -f "$TMP_DIR/steps.log" ]]; then
+    while IFS='|' read -r step_name step_code step_dur; do
+      local code_num
+      code_num=$(echo "$step_code" | xargs)
+      local status
+      if [[ "$code_num" -eq 0 ]]; then
+        status="✅"
+      else
+        status="❌"
+        all_ok=false
+      fi
+      log "  $status  $step_name  →  exit $step_code  (${step_dur})"
+    done < "$TMP_DIR/steps.log"
+  else
+    log "  (no steps were executed — all skipped)"
+  fi
+
+  log ""
+
+  # Git diff stats
+  if git rev-parse --is-inside-work-tree &>/dev/null; then
+    local branch
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+    local commit
+    commit=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
+    log "  Git branch: $branch  commit: $commit"
+    log ""
+    log "  Uncommitted changes:"
+    git diff --stat 2>/dev/null >> "$LOG_FILE" || true
+    git diff --stat --cached 2>/dev/null >> "$LOG_FILE" || true
+  fi
+
+  log ""
+
+  # Initialise cross-run comparison variables
+  parent_baseline=""; pname=""
+  parent_branch=$(detect_parent_branch 2>/dev/null || true)
+  if [[ -n "$parent_branch" ]]; then
+    pname="${parent_branch#origin/}"
+    parent_baseline=$(read_baseline "$pname" 2>/dev/null || true)
+  fi
+
+  # Get current branch for history lookup
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+
+  # Coverage if available
+  if [[ -f "$TMP_DIR/metrics.env" ]]; then
+    # shellcheck disable=SC1090
+    source "$TMP_DIR/metrics.env"
+    if [[ -n "${cov_pct:-}" ]]; then
+      local line_l="  📊 Lines:     ${cov_pct}%  (${lh_total:-?}/${lf_total:-?})"
+      local line_b="  📊 Branches:  ${branch_pct:-0}%  (${brh_total:-?}/${brf_total:-?})"
+      local line_f="  📊 Functions: ${func_pct:-0}%  (${fnh_total:-?}/${fnf_total:-?})"
+      log "$line_l"; echo "$line_l"
+      log "$line_b"; echo "$line_b"
+      log "$line_f"; echo "$line_f"
+
+      # Find baseline: same branch > parent branch > none
+      prev_cov=""; prev_br=""; cov_source=""
+      if [[ -f "$HISTORY_FILE" ]]; then
+        local same_branch
+        same_branch=$(grep "\"branch\":\"$current_branch\"" "$HISTORY_FILE" 2>/dev/null | tail -1)
+        if [[ -n "$same_branch" ]]; then
+          prev_cov=$(echo "$same_branch" | grep -oP '"cov":\K[0-9.]+')
+          prev_br=$(echo "$same_branch" | grep -oP '"br":\K[0-9.]+')
+          cov_source="same branch"
+        fi
+      fi
+      if [[ -z "$prev_cov" && -n "$parent_baseline" ]]; then
+        prev_cov=$(get_baseline_field "$parent_baseline" "cov")
+        prev_br=$(get_baseline_field "$parent_baseline" "br")
+        cov_source="origin/$pname"
+      fi
+
+      if [[ -n "$prev_cov" ]]; then
+        diff=$(( cov_pct - prev_cov ))
+        if [[ "$diff" -gt 0 ]]; then
+          local line="  📈 Lines +${diff}pp vs $cov_source (${prev_cov}%)"
+          log "$line"; echo "$line"
+        elif [[ "$diff" -lt 0 ]]; then
+          local line="  📉 Lines ${diff}pp vs $cov_source (${prev_cov}%)"
+          log "$line"; echo "$line"
+        else
+          local line="  ➖ Lines unchanged vs $cov_source (${prev_cov}%)"
+          log "$line"; echo "$line"
+        fi
+        if [[ -n "$prev_br" && -n "${branch_pct:-}" ]]; then
+          bdiff=$(( branch_pct - prev_br ))
+          if [[ "$bdiff" -gt 0 ]]; then
+            local line="  📈 Branches +${bdiff}pp vs $cov_source (${prev_br}%)"
+            log "$line"; echo "$line"
+          elif [[ "$bdiff" -lt 0 ]]; then
+            local line="  📉 Branches ${bdiff}pp vs $cov_source (${prev_br}%)"
+            log "$line"; echo "$line"
+          else
+            local line="  ➖ Branches unchanged vs $cov_source (${prev_br}%)"
+            log "$line"; echo "$line"
+          fi
+        fi
+      fi
+    fi
+    if [[ -n "${lint_warnings:-}" ]]; then
+      local line_lint="  ⚠️  Lint: ${lint_warnings} warnings, ${lint_errors} errors"
+      log "$line_lint"; echo "$line_lint"
+      if [[ -f "$TMP_DIR/lint_top3.txt" && -s "$TMP_DIR/lint_top3.txt" ]]; then
+        local top_hdr="  Top 3 solhint violations:"
+        log "$top_hdr"; echo "$top_hdr"
+        while read -r count rule; do
+          local top_line="    $(printf '%5d' "$count")×  $rule"
+          log "$top_line"; echo "$top_line"
+        done < "$TMP_DIR/lint_top3.txt"
+      fi
+      prev_lint_w=""; lint_source=""
+      if [[ -f "$HISTORY_FILE" ]]; then
+        local same_branch
+        same_branch=$(grep "\"branch\":\"$current_branch\"" "$HISTORY_FILE" 2>/dev/null | tail -1)
+        if [[ -n "$same_branch" ]]; then
+          prev_lint_w=$(echo "$same_branch" | grep -oP '"lint_w":\K[0-9]+')
+          lint_source="same branch"
+        fi
+      fi
+      if [[ -z "$prev_lint_w" && -n "$parent_baseline" ]]; then
+        prev_lint_w=$(get_baseline_field "$parent_baseline" "lint_w")
+        lint_source="origin/$pname"
+      fi
+      if [[ -n "$prev_lint_w" ]]; then
+        wdiff=$(( lint_warnings - prev_lint_w ))
+        if [[ "$wdiff" -gt 0 ]]; then
+          local line="  ⚠️  +${wdiff} warnings vs $lint_source (${prev_lint_w})"
+          log "$line"; echo "$line"
+        elif [[ "$wdiff" -lt 0 ]]; then
+          local line="  ✅ ${wdiff} warnings vs $lint_source (${prev_lint_w})"
+          log "$line"; echo "$line"
+        else
+          local line="  ➖ Warnings unchanged vs $lint_source (${prev_lint_w})"
+          log "$line"; echo "$line"
+        fi
+      fi
+    fi
+    log ""
+  fi
+
+  if $all_ok; then
+    local v="  VERDICT: ✅ All steps passed."
+    log "$v"; echo "$v"
+  else
+    local v="  VERDICT: ❌ At least one step failed. Check the log."
+    log "$v"; echo "$v"
+  fi
+  echo ""
+
+  write_history 2>/dev/null || true
+  _finalize_log 2>/dev/null || true
+}
+
+# ---- INLINE LINT SUMMARY -----------------------------------------------
+# Emits a File|Line:Col|Level|Description|Rule table to the log and console.
+# Arguments:
+#   $1  step name (default: "lint")
+#   $2  optional context/label ("stash", "changed", …)
+# Respects LINT_CHANGED_FILES when defined (restricts to the indicated scope).
+print_lint_summary() {
+  local step_name="${1:-lint}"
+  local context="${2:-}"
+  local raw_file="$TMP_DIR/${step_name// /_}.raw.log"
+  [[ -f "$raw_file" ]] || return 0
+
+  local total_w total_e
+  total_w=$(grep -cE $'^\s+[0-9]+:[0-9]+\s+warning' "$raw_file" 2>/dev/null || true)
+  total_e=$(grep -cE $'^\s+[0-9]+:[0-9]+\s+error'   "$raw_file" 2>/dev/null || true)
+  total_w=${total_w:-0}; total_e=${total_e:-0}
+  [[ "$((total_w + total_e))" -eq 0 ]] && return 0
+
+  local work_file="$raw_file"
+  if [[ -n "${LINT_CHANGED_FILES:-}" ]]; then
+    local filtered_file="$TMP_DIR/lint_filtered_${context:-main}.log"
+    awk -v changed="$LINT_CHANGED_FILES" '
+      BEGIN { split(changed, arr, "\n"); for (i in arr) keep[arr[i]] = 1 }
+      !/^[[:space:]]/ && /\.(sol|ts)/ { cur = $0; in_file = (cur in keep) }
+      in_file { print }
+    ' "$raw_file" > "$filtered_file"
+    work_file="$filtered_file"
+    total_w=$(grep -cE $'^\s+[0-9]+:[0-9]+\s+warning' "$work_file" 2>/dev/null || true)
+    total_e=$(grep -cE $'^\s+[0-9]+:[0-9]+\s+error'   "$work_file" 2>/dev/null || true)
+    total_w=${total_w:-0}; total_e=${total_e:-0}
+    if [[ "$((total_w + total_e))" -eq 0 ]]; then
+      local ok_msg="  ✅ No violations${context:+" [${context}]"} in in-scope files"
+      echo "$ok_msg"; echo "$ok_msg" >> "$LOG_FILE"
+      return 0
+    fi
+  fi
+
+  # Summary header
+  local scope="${context:+"[${context}] "}(${step_name})"
+  local hdr="  ⚠️  Lint ${scope}: ${total_e} errors, ${total_w} warnings"
+  echo "$hdr"; echo "$hdr" >> "$LOG_FILE"
+
+  # Calculate File column width based on the longest name
+  local _col_w
+  _col_w=$(awk '
+    !/^[[:space:]]/ && /\.(sol|ts)/ {
+      f = $0
+      sub(/.*\/contracts\//, "", f)
+      sub(/.*test\/contracts\/integration\//, "", f)
+      if (length(f) > max) max = length(f)
+    }
+    END { print (max+0 > 8 ? max : 8) }
+  ' "$work_file")
+  _col_w=${_col_w:-40}
+
+  # Table: File(_col_w) | Line:Col(9) | Level(7) | Description(42) | Rule
+  local table_rows
+  table_rows=$(awk -v cw="$_col_w" '
+    !/^[[:space:]]/ && /\.(sol|ts)/ {
+      f = $0
+      sub(/.*\/contracts\//, "", f)
+      sub(/.*test\/contracts\/integration\//, "", f)
+      cur = f; next
+    }
+    /^[[:space:]]+[0-9]+:[0-9]+[[:space:]]+(warning|error)/ {
+      lc = $1; lvl = $2; rule = $NF
+      desc = ""; for (i = 3; i < NF; i++) desc = desc (i==3?"": " ") $i
+      if (length(desc) > 42) desc = substr(desc, 1, 39) "..."
+      sf = length(cur) > cw ? "..." substr(cur, length(cur)-(cw-4)) : cur
+      lns[++n] = sprintf("  %-*s | %-9s | %-7s | %-42s | %s", cw, sf, lc, lvl, desc, rule)
+      is_err[n] = (lvl == "error")
+    }
+    END {
+      p = 0
+      for (i = 1; i <= n && p < 200; i++) if (is_err[i])  { print lns[i]; p++ }
+      for (i = 1; i <= n && p < 200; i++) if (!is_err[i]) { print lns[i]; p++ }
+      if (n > 200) print "  ... (" (n - 200) " more)"
+    }
+  ' "$work_file")
+
+  local _sep_f _d2 _d3 _d4 _d5
+  printf -v _sep_f "%-${_col_w}s" ""; _sep_f="${_sep_f// /-}"
+  printf -v _d2 '%09d' 0; _d2="${_d2//0/-}"
+  printf -v _d3 '%07d' 0; _d3="${_d3//0/-}"
+  printf -v _d4 '%042d' 0; _d4="${_d4//0/-}"
+  printf -v _d5 '%018d' 0; _d5="${_d5//0/-}"
+  local tbl_hdr tbl_sep
+  printf -v tbl_hdr "  %-${_col_w}s | %-9s | %-7s | %-42s | %s" \
+      'File' 'Line:Col' 'Level' 'Description' 'Rule'
+  tbl_sep="  ${_sep_f}-+-${_d2}-+-${_d3}-+-${_d4}-+-${_d5}"
+
+  # Table → log and console
+  local tbl_out
+  tbl_out=$(printf '%s\n%s\n%s\n' "$tbl_hdr" "$tbl_sep" "$table_rows" \
+    | sed 's/\x1b\[[0-9;]*[mGKHF]//g')
+  echo "$tbl_out" >> "$LOG_FILE"
+  echo "$tbl_out"
+}
+
+# ---- MAIN EXECUTION ------------------------------------------------
+
+log_header "EXECUTION CONTEXT (v$SCRIPT_VERSION)"
+{
+  echo "  Directory: $(pwd)"
+  echo "  Node: $(node --version 2>/dev/null || echo 'not available')"
+  echo "  npm: $(npm --version 2>/dev/null || echo 'not available')"
+  echo "  Git branch: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'not available')"
+  echo "  Git commit: $(git rev-parse --short HEAD 2>/dev/null || echo 'not available')"
+  echo ""
+  echo "  Flags:"
+  echo "    Skip format:  $SKIP_FORMAT"
+  echo "    Skip lint:    $SKIP_LINT"
+  echo "    Skip compile: $SKIP_COMPILE"
+  echo "    Skip test:      $SKIP_TEST"
+  echo "    Skip typecheck: $SKIP_TYPECHECK"
+  echo "    Skip coverage:  $SKIP_COVERAGE"
+  echo "    Coverage min:   ${COVERAGE_MIN:-"(none)"}"
+  echo "    Test file:      ${TEST_FILE:-"(all)"}"
+  echo "    Test grep:      ${TEST_GREP:-"(none)"}"
+  echo "    Test output:    ${TEST_OUTPUT}${TEST_FILTER_TEXT:+" (\"$TEST_FILTER_TEXT\")"}"
+  echo ""
+} >> "$LOG_FILE"
+
+# ---- Detection of files in stash -----------------------------------------
+# If a stash exists, any .sol files it contains are automatically included in the
+# lint and coverage diff, even without --lint-changed or --coverage-changed.
+_stash_sol=""
+if git stash list 2>/dev/null | grep -q .; then
+  _repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  _cwd=$(pwd)
+  if [[ -n "$_repo_root" ]]; then
+    _stash_sol=$(
+      git stash show --name-only 2>/dev/null | while IFS= read -r _sf; do
+        [[ -z "$_sf" ]] && continue
+        _abs="${_repo_root}/${_sf}"
+        _rel="${_abs#${_cwd}/}"
+        [[ "$_rel" != "$_abs" ]] && echo "$_rel"
+      done | grep '\.sol$' | sort -u || true
+    )
+    if [[ -n "$_stash_sol" ]]; then
+      _stash_count=$(echo "$_stash_sol" | wc -l | tr -d ' ')
+      echo "  📦 Stash detected: ${_stash_count} .sol file(s) — included in lint and coverage diff"
+    fi
+  fi
+fi
+
+ALL_OK=true
+
+# ---- ATS project detection (enables ATS_TEST_MODE) ---------------------
+_ats_project=false
+if [[ "$(pwd)" == *"asset-tokenization-studio"* ]] || \
+   { [[ -f "package.json" ]] && grep -q '"asset-tokenization' package.json 2>/dev/null; }; then
+  _ats_project=true
+  export ATS_TEST_MODE=true
+fi
+
+# ---- Step 0: forced clean build --------------------------------------------
+run_step "clean:build" npm run clean:build || ALL_OK=false
+
+if ! $SKIP_FORMAT; then
+  run_step "format" npm run format || ALL_OK=false
+fi
+
+# ---- lint:sol — Solidity linting -------------------------------------------
+# Fails only on real errors; warnings (use-natspec, etc.) do not block.
+if ! $SKIP_LINT; then
+  if $LINT_CHANGED; then
+    _lc_parent=""
+    for _c in origin/development origin/main origin/master; do
+      if git rev-parse --verify "$_c" &>/dev/null 2>&1; then _lc_parent="$_c"; break; fi
+    done
+    _lc_parent="${_lc_parent:-HEAD~1}"
+
+    _lc_all=$(
+      git diff --name-only --relative "${_lc_parent}..HEAD" 2>/dev/null
+      git diff --name-only --relative HEAD 2>/dev/null
+      git diff --name-only --relative --cached HEAD 2>/dev/null
+      # Include stash files when a stash exists
+      [[ -n "${_stash_sol:-}" ]] && echo "$_stash_sol"
+    )
+    _lc_count=$(echo "$_lc_all" | grep -cE '\.sol$' 2>/dev/null || echo 0)
+
+    if [[ "$_lc_count" -eq 0 ]]; then
+      echo "  ℹ️  --lint-changed: no .sol changes vs ${_lc_parent}"
+    else
+      LINT_CHANGED_FILES=$(echo "$_lc_all" | grep -E '\.sol$' | sort -u)
+      export LINT_CHANGED_FILES
+      echo "  🔍 --lint-changed: ${_lc_count} .sol files vs ${_lc_parent}${_stash_sol:+" (includes stash)"}"
+      run_step --errors-only "lint:sol" npm run lint:sol || ALL_OK=false
+      print_lint_summary "lint:sol"
+    fi
+  else
+    run_step --errors-only "lint:sol" npm run lint:sol || ALL_OK=false
+    print_lint_summary "lint:sol"
+    # Auto-stash: show warning diff for stash files even without --lint-changed
+    if [[ -n "${_stash_sol:-}" ]]; then
+      LINT_CHANGED_FILES="$_stash_sol" print_lint_summary "lint:sol" "stash"
+    fi
+  fi
+fi
+
+if ! $SKIP_COMPILE; then
+  run_step "compile" npm run compile --force || ALL_OK=false
+fi
+
+# ---- Contract sizes ---------------------------------------------------
+# Scans artifacts/contracts/ after compilation.
+# Log: top 10 by deployed size.  Terminal: top 2.
+# If any non-test contract exceeds 24 KiB (24576 bytes), the script halts.
+ARTIFACTS_DIR="./artifacts/contracts"
+if [[ -d "$ARTIFACTS_DIR" ]]; then
+  _size_script="$TMP_DIR/contract_sizes.js"
+  cat > "$_size_script" << 'NODEEOF'
+'use strict';
+const fs   = require('fs');
+const path = require('path');
+const base = process.env.ARTIFACTS_DIR;
+const LIMIT = 24576;
+
+function walk(dir) {
+  const res = [];
+  for (const f of fs.readdirSync(dir)) {
+    const full = path.join(dir, f);
+    if (fs.statSync(full).isDirectory()) { res.push(...walk(full)); continue; }
+    if (f.endsWith('.json') && !f.endsWith('.dbg.json')) res.push(full);
+  }
+  return res;
+}
+
+const contracts = [];
+for (const f of walk(base)) {
+  let a;
+  try { a = JSON.parse(fs.readFileSync(f, 'utf8')); } catch { continue; }
+  if (!a.deployedBytecode || a.deployedBytecode === '0x') continue;
+  const size = (a.deployedBytecode.length - 2) / 2;
+  if (size === 0) continue;
+  contracts.push({ name: a.contractName, size, isTest: f.includes('/test/') });
+}
+contracts.sort((a, b) => b.size - a.size);
+
+const KIB = n => (n / 1024).toFixed(2) + ' KiB';
+
+// Top 10 → stdout (consumed by shell for log)
+console.log('TOP10');
+contracts.slice(0, 10).forEach(c =>
+  console.log(`  ${String(c.size).padStart(6)}  ${c.isTest ? '[test]  ' : '        '}  ${c.name}  (${KIB(c.size)})`)
+);
+
+// Top 2 → labelled for terminal summary
+console.log('TOP2');
+contracts.slice(0, 2).forEach(c =>
+  console.log(`  ${c.name}: ${KIB(c.size)}${c.isTest ? ' [test]' : ''}`)
+);
+
+// Violations → any non-test contract over limit
+const violations = contracts.filter(c => !c.isTest && c.size > LIMIT);
+if (violations.length > 0) {
+  console.log('VIOLATIONS');
+  violations.forEach(c =>
+    console.log(`  ${c.name}: ${c.size} bytes (${KIB(c.size)}) — exceeds 24 KiB EIP-170 limit`)
+  );
+}
+process.exit(violations.length > 0 ? 1 : 0);
+NODEEOF
+
+  _size_out=$(ARTIFACTS_DIR="$ARTIFACTS_DIR" node "$_size_script" 2>&1)
+  _size_exit=$?
+
+  # Parse sections from output
+  _top10=$(echo "$_size_out" | awk '/^TOP10/{f=1;next}/^TOP2|^VIOLATIONS/{f=0} f{print}')
+  _top2=$(echo "$_size_out"  | awk '/^TOP2/{f=1;next}/^VIOLATIONS/{f=0} f{print}')
+  _viols=$(echo "$_size_out" | awk '/^VIOLATIONS/{f=1;next} f{print}')
+
+  log ""
+  log "----- Contract Sizes (top 10 by deployed bytecode) -----"
+  log "$_top10"
+  log ""
+
+  # Terminal: top 2
+  echo "  📦 Contract sizes (top 2):"
+  echo "$_top2"
+
+  if [[ "$_size_exit" -ne 0 && -n "$_viols" ]]; then
+    echo ""
+    echo "❌ Non-test contracts above the EIP-170 limit (24 KiB):"
+    echo "$_viols"
+    log ""
+    log "❌ EIP-170 VIOLATION — deployed bytecode over 24 KiB:"
+    log "$_viols"
+    ALL_OK=false
+    generate_summary
+    echo "⚠️  There were failures. Check: $LOG_FILE"
+    exit 1
+  fi
+fi
+
+if ! $SKIP_TEST && ! $SKIP_TYPECHECK; then
+  # tsc --noEmit type-checks all files in tsconfig include (scripts + test/**/*).
+  # Runs BEFORE hardhat test so TS syntax/type errors fail fast with clean diagnostics:
+  #   test/foo.test.ts(42,13): error TS1005: ',' expected.
+  # --pretty false → no ANSI colours in the log file.
+  run_step "typecheck" npx tsc --noEmit --pretty false || ALL_OK=false
+fi
+
+# ---- lint:js — TypeScript/ESLint linting -----------------------------------
+# Runs after typecheck. If it fails, the script halts immediately.
+if ! $SKIP_LINT && ! $SKIP_TEST; then
+  if ! run_step "lint:js" npm run lint:js; then
+    ALL_OK=false
+    generate_summary
+    echo "⚠️  There were failures. Check: $LOG_FILE"
+    exit 1
+  fi
+fi
+
+if ! $SKIP_TEST; then
+  # Build test command according to flags
+  _ats_wrapper=""
+  if [[ -n "$TEST_FILE" ]]; then
+    # If the file exports a function without self-invocation, generate a temporary wrapper
+    _func=$(grep -oP '^export function \K\w+Tests' "$TEST_FILE" 2>/dev/null | head -1)
+    if [[ -n "$_func" ]]; then
+      _rel=$(realpath --relative-to=test/contracts/integration "$TEST_FILE" 2>/dev/null || python3 -c "import os; print(os.path.relpath('$TEST_FILE', 'test/contracts/integration'))")
+      _ats_wrapper="test/contracts/integration/_ats_runner.test.ts"
+      printf 'import { %s } from "./%s";\n%s();\n' "$_func" "${_rel%.ts}" "$_func" > "$_ats_wrapper"
+      TEST_CMD=(npx hardhat test --no-compile "$_ats_wrapper")
+    else
+      TEST_CMD=(npx hardhat test --no-compile "$TEST_FILE")
+    fi
+  else
+    # shellcheck disable=SC2207
+    TEST_FILES=()
+    while IFS= read -r -d '' f; do
+      TEST_FILES+=("$f")
+    done < <(find test/contracts/integration test/scripts -name '*.test.ts' -type f -print0 2>/dev/null)
+    if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+      echo "⚠️  No test files found in test/contracts/integration or test/scripts"
+      TEST_CMD=(npx hardhat test --no-compile)
+    else
+      TEST_CMD=(npx hardhat test --no-compile "${TEST_FILES[@]}")
+    fi
+  fi
+
+  if [[ -n "$TEST_GREP" ]]; then
+    TEST_CMD+=(--grep "$TEST_GREP")
+  fi
+
+  # Select output filter based on mode
+  case "$TEST_OUTPUT" in
+    full)   _test_filter="filter_none" ;;
+    filter) _test_filter="filter_by_text" ;;
+    *)      _test_filter="filter_test_relevant" ;;
+  esac
+
+  run_step --filter "$_test_filter" "test" "${TEST_CMD[@]}" || ALL_OK=false
+fi
+
+# ---- Coverage (post-test) ---------------------------------------------------
+if ! $SKIP_COVERAGE && $ALL_OK; then
+  # Select output filter based on mode (same logic as tests).
+  # In errors mode: if we reach coverage, tests passed — same filter as tests.
+  case "$TEST_OUTPUT" in
+    full)   _cov_filter="filter_none" ;;
+    filter) _cov_filter="filter_by_text" ;;
+    *)      _cov_filter="filter_test_relevant" ;;
+  esac
+
+  # Build the coverage command respecting --test-file and --test-grep.
+  # --testfiles filters files; TEST_GREP is passed via env var (read by hardhat.config.ts).
+  COVERAGE_CMD=(npx hardhat coverage)
+  if [[ -n "$_ats_wrapper" ]]; then
+    COVERAGE_CMD+=(--testfiles "$_ats_wrapper")
+  elif [[ -n "$TEST_FILE" ]]; then
+    COVERAGE_CMD+=(--testfiles "$TEST_FILE")
+  fi
+  export TEST_GREP
+  run_step --filter "$_cov_filter" "coverage" "${COVERAGE_CMD[@]}" || ALL_OK=false
+
+  # Parse coverage from lcov.info (lines + branches + functions)
+  LCOV_FILE="./coverage/lcov.info"
+  if [[ -f "$LCOV_FILE" ]]; then
+    lf_total=0; lh_total=0; brf_total=0; brh_total=0; fnf_total=0; fnh_total=0
+    lf_val=""; lh_val=""; brf_val=""; brh_val=""; fnf_val=""; fnh_val=""
+    while IFS= read -r line; do
+      case "$line" in
+        LF:*) lf_val="${line#LF:}"; lf_total=$((lf_total + lf_val)) ;;
+        LH:*) lh_val="${line#LH:}"; lh_total=$((lh_total + lh_val)) ;;
+        BRF:*) brf_val="${line#BRF:}"; brf_total=$((brf_total + brf_val)) ;;
+        BRH:*) brh_val="${line#BRH:}"; brh_total=$((brh_total + brh_val)) ;;
+        FNF:*) fnf_val="${line#FNF:}"; fnf_total=$((fnf_total + fnf_val)) ;;
+        FNH:*) fnh_val="${line#FNH:}"; fnh_total=$((fnh_total + fnh_val)) ;;
+      esac
+    done < <(grep -E '^(LF|LH|BRF|BRH|FNF|FNH):' "$LCOV_FILE")
+
+    cov_pct=0; branch_pct=0; func_pct=0
+    if [[ "$lf_total" -gt 0 ]]; then
+      cov_pct=$((lh_total * 100 / lf_total))
+    fi
+    if [[ "$brf_total" -gt 0 ]]; then
+      branch_pct=$((brh_total * 100 / brf_total))
+    fi
+    if [[ "$fnf_total" -gt 0 ]]; then
+      func_pct=$((fnh_total * 100 / fnf_total))
+    fi
+
+    log ""
+    log "----- Coverage Summary -----"
+    log "  Lines:     $lh_total / $lf_total  (${cov_pct}%)"
+    log "  Branches:  $brh_total / $brf_total  (${branch_pct}%)"
+    log "  Functions: $fnh_total / $fnf_total  (${func_pct}%)"
+
+    if [[ -n "$COVERAGE_MIN" ]]; then
+      if [[ "$cov_pct" -lt "$COVERAGE_MIN" ]]; then
+        log "  ❌ Lines ${cov_pct}% below threshold ${COVERAGE_MIN}%"
+        echo "❌ Lines ${cov_pct}% < ${COVERAGE_MIN}% (threshold)"
+        ALL_OK=false
+      else
+        log "  ✅ Lines ${cov_pct}% meets threshold ${COVERAGE_MIN}%"
+      fi
+    fi
+    echo "  📊 Lines: ${cov_pct}%  Branches: ${branch_pct}%  Functions: ${func_pct}%"
+    echo "cov_pct=$cov_pct" > "$TMP_DIR/metrics.env"
+    echo "lh_total=$lh_total" >> "$TMP_DIR/metrics.env"
+    echo "lf_total=$lf_total" >> "$TMP_DIR/metrics.env"
+    echo "branch_pct=$branch_pct" >> "$TMP_DIR/metrics.env"
+    echo "brh_total=$brh_total" >> "$TMP_DIR/metrics.env"
+    echo "brf_total=$brf_total" >> "$TMP_DIR/metrics.env"
+    echo "func_pct=$func_pct" >> "$TMP_DIR/metrics.env"
+    echo "fnh_total=$fnh_total" >> "$TMP_DIR/metrics.env"
+    echo "fnf_total=$fnf_total" >> "$TMP_DIR/metrics.env"
+  else
+    log "  ⚠️  lcov.info not found at $LCOV_FILE — cannot parse coverage"
+  fi
+
+  # Per-file breakdown: top 10 worst + pending changes
+  COVERAGE_JSON="./coverage.json"
+  COVERAGE_REPORT_BIN="${SCRIPT_DIR}/coverage-report.js"
+  if [[ -f "$COVERAGE_JSON" && -f "$COVERAGE_REPORT_BIN" ]]; then
+    echo ""
+    echo "📋 Coverage breakdown (top 10 worst + pending changes):"
+    report_out=$(node "$COVERAGE_REPORT_BIN" "$COVERAGE_JSON" 2>&1)
+    echo "$report_out"
+    echo ""
+    log ""
+    log "----- Coverage Breakdown -----"
+    echo "$report_out" | sed 's/\x1b\[[0-9;]*[mGKHF]//g' >> "$LOG_FILE"
+    log ""
+  fi
+
+  # --coverage-changed: threshold check restricted to files modified in this branch
+  if $COVERAGE_CHANGED && [[ -f "$COVERAGE_JSON" ]]; then
+    _ccv_threshold="${COVERAGE_MIN:-80}"
+    _ccv_parent=""
+    for _c in origin/development origin/main origin/master; do
+      if git rev-parse --verify "$_c" &>/dev/null 2>&1; then _ccv_parent="$_c"; break; fi
+    done
+    _ccv_parent="${_ccv_parent:-HEAD~1}"
+
+    _ccv_all=$(
+      git diff --name-only --relative "${_ccv_parent}..HEAD" 2>/dev/null
+      git diff --name-only --relative HEAD 2>/dev/null
+      git diff --name-only --relative --cached HEAD 2>/dev/null
+      # Include stash files when a stash exists
+      [[ -n "${_stash_sol:-}" ]] && echo "$_stash_sol"
+    )
+    _ccv_changed=$(echo "$_ccv_all" | grep '\.sol$' | sort -u)
+
+    if [[ -z "$_ccv_changed" ]]; then
+      echo "  ℹ️  --coverage-changed: no .sol changes vs ${_ccv_parent}"
+    else
+      echo "  🔍 --coverage-changed: threshold ${_ccv_threshold}% on modified files vs ${_ccv_parent}${_stash_sol:+" (includes stash)"}"
+      _ccv_script="$TMP_DIR/coverage_changed.js"
+      cat > "$_ccv_script" << 'NODEEOF'
+'use strict';
+const fs   = require('fs');
+const path = require('path');
+const cov  = JSON.parse(fs.readFileSync(process.env.COV_FILE, 'utf8'));
+const changed   = process.env.CC_FILES.split('\n').filter(Boolean);
+const threshold = parseInt(process.env.CC_THRESHOLD, 10);
+const cwd = process.cwd();
+let failed = false, checked = 0;
+const results = [];
+for (const [, data] of Object.entries(cov)) {
+  const fullPath = data.path ? path.resolve(data.path) : null;
+  if (!fullPath) continue;
+  const rel = path.relative(cwd, fullPath).replace(/\\/g, '/');
+  if (!changed.some(f => rel === f || rel.endsWith('/' + f) || f.endsWith('/' + rel))) continue;
+  const lines = Object.keys(data.l || {}).length;
+  if (lines === 0) { console.log('  SKIP  ' + rel + '  (no trackable lines)'); continue; }
+  const covered = Object.values(data.l || {}).filter(v => v > 0).length;
+  const pct = Math.round(covered * 100 / lines);
+  const ok  = pct >= threshold;
+  results.push({ ok, pct, rel });
+  if (!ok) failed = true;
+  checked++;
+}
+if (checked === 0) console.log('  ⚠️  No modified files found in coverage.json');
+const failures = results.filter(r => !r.ok);
+const oks = results.filter(r => r.ok);
+failures.forEach(r => console.log('  ❌  ' + String(r.pct).padStart(3) + '%  ' + r.rel));
+oks.slice(0, 5).forEach(r => console.log('  ✅  ' + String(r.pct).padStart(3) + '%  ' + r.rel));
+if (oks.length > 5) console.log('    ... (' + (oks.length - 5) + ' more OK)');
+process.exit(failed ? 1 : 0);
+NODEEOF
+      _ccv_out=$(COV_FILE="$COVERAGE_JSON" CC_FILES="$_ccv_changed" CC_THRESHOLD="$_ccv_threshold" \
+        node "$_ccv_script" 2>&1)
+      _ccv_exit=$?
+      echo "$_ccv_out"
+      log "----- Coverage Changed -----"
+      echo "$_ccv_out" >> "$LOG_FILE"
+      log ""
+      if [[ "$_ccv_exit" -ne 0 ]]; then
+        echo "❌ --coverage-changed: one or more modified files below the ${_ccv_threshold}% threshold"
+        ALL_OK=false
+      fi
+    fi
+  fi
+
+  # Auto-stash: coverage for stash files when --coverage-changed was not used
+  if [[ -n "${_stash_sol:-}" ]] && ! $COVERAGE_CHANGED && [[ -f "$COVERAGE_JSON" ]]; then
+    _astash_threshold="${COVERAGE_MIN:-80}"
+    echo "  📦 Coverage (stash, threshold ${_astash_threshold}%):"
+    _astash_script="$TMP_DIR/coverage_changed.js"
+    # Reuse the Node.js script if already written, or write it now
+    if [[ ! -f "$_astash_script" ]]; then
+      cat > "$_astash_script" << 'NODEEOF'
+'use strict';
+const fs   = require('fs');
+const path = require('path');
+const cov  = JSON.parse(fs.readFileSync(process.env.COV_FILE, 'utf8'));
+const changed   = process.env.CC_FILES.split('\n').filter(Boolean);
+const threshold = parseInt(process.env.CC_THRESHOLD, 10);
+const cwd = process.cwd();
+let failed = false, checked = 0;
+const results = [];
+for (const [, data] of Object.entries(cov)) {
+  const fullPath = data.path ? path.resolve(data.path) : null;
+  if (!fullPath) continue;
+  const rel = path.relative(cwd, fullPath).replace(/\\/g, '/');
+  if (!changed.some(f => rel === f || rel.endsWith('/' + f) || f.endsWith('/' + rel))) continue;
+  const lines = Object.keys(data.l || {}).length;
+  if (lines === 0) { console.log('  SKIP  ' + rel + '  (no trackable lines)'); continue; }
+  const covered = Object.values(data.l || {}).filter(v => v > 0).length;
+  const pct = Math.round(covered * 100 / lines);
+  const ok  = pct >= threshold;
+  results.push({ ok, pct, rel });
+  if (!ok) failed = true;
+  checked++;
+}
+if (checked === 0) console.log('  ⚠️  No stash files found in coverage.json');
+const failures = results.filter(r => !r.ok);
+const oks = results.filter(r => r.ok);
+failures.forEach(r => console.log('  ❌  ' + String(r.pct).padStart(3) + '%  ' + r.rel));
+oks.slice(0, 5).forEach(r => console.log('  ✅  ' + String(r.pct).padStart(3) + '%  ' + r.rel));
+if (oks.length > 5) console.log('    ... (' + (oks.length - 5) + ' more OK)');
+process.exit(failed ? 1 : 0);
+NODEEOF
+    fi
+    _astash_out=$(COV_FILE="$COVERAGE_JSON" CC_FILES="$_stash_sol" CC_THRESHOLD="$_astash_threshold" \
+        node "$_astash_script" 2>&1)
+    echo "$_astash_out"
+    log "----- Coverage Stash -----"
+    echo "$_astash_out" >> "$LOG_FILE"
+    log ""
+  fi
+fi
+
+# ---- Parse lint metrics ------------------------------------------------
+# Combines lint:sol and lint:js for the summary and history.
+lint_warnings=0; lint_errors=0
+for _lint_step in "lint:sol" "lint:js"; do
+  _lint_raw="$TMP_DIR/${_lint_step// /_}.raw.log"
+  [[ -f "$_lint_raw" ]] || continue
+  _lint_summary=$(grep -Eo '[0-9]+ problems? \([0-9]+ errors?, [0-9]+ warnings?' "$_lint_raw" | tail -1)
+  if [[ -n "$_lint_summary" ]]; then
+    _e=$(echo "$_lint_summary" | grep -Eo '[0-9]+' | sed -n '2p')
+    _w=$(echo "$_lint_summary" | grep -Eo '[0-9]+' | sed -n '3p')
+    lint_errors=$(( lint_errors + ${_e:-0} ))
+    lint_warnings=$(( lint_warnings + ${_w:-0} ))
+  fi
+done
+
+if [[ "$((lint_warnings + lint_errors))" -gt 0 ]]; then
+  # Write to metrics.env (may not exist if coverage was skipped)
+  {
+    echo "lint_warnings=$lint_warnings"
+    echo "lint_errors=$lint_errors"
+  } >> "$TMP_DIR/metrics.env"
+
+  # Top 3 combined rules from both steps
+  {
+    [[ -f "$TMP_DIR/lint:sol.raw.log" ]] && cat "$TMP_DIR/lint:sol.raw.log"
+    [[ -f "$TMP_DIR/lint:js.raw.log"  ]] && cat "$TMP_DIR/lint:js.raw.log"
+  } | grep -E $'^\s+[0-9]+:[0-9]+\s+(warning|error)' \
+    | awk '{print $NF}' \
+    | sort | uniq -c | sort -rn | head -3 \
+    > "$TMP_DIR/lint_top3.txt" 2>/dev/null || true
+fi
+
+# ---- Per-branch baselines + NDJSON history --------------------------------
+HISTORY_FILE="${AI_LOGS_DIR}/metrics.ndjson"
+BASELINE_DIR="${AI_LOGS_DIR}/baselines"
+# baselines dir already created at startup; metrics.ndjson is created on first write
+
+detect_parent_branch() {
+  for candidate in origin/development origin/main origin/master; do
+    if git rev-parse --verify "$candidate" &>/dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+read_baseline() {
+  local branch_name="$1"
+  local bfile="$BASELINE_DIR/${branch_name//\//_}.json"
+  if [[ -f "$bfile" ]]; then
+    cat "$bfile"
+  fi
+}
+
+write_baseline() {
+  local branch_name="$2" val="$1"
+  local bfile="$BASELINE_DIR/${branch_name//\//_}.json"
+  echo "$val" > "$bfile"
+}
+
+get_baseline_field() {
+  local json="$1" field="$2"
+  echo "$json" | grep -oP "\"$field\":\K[0-9.]+" | head -1
+}
+
+write_history() {
+  if [[ -f "$TMP_DIR/metrics.env" ]]; then
+    # shellcheck disable=SC1090
+    source "$TMP_DIR/metrics.env"
+  fi
+  local branch commit
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+  commit=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
+  local format_dur="" lint_dur="" compile_dur="" test_dur="" coverage_dur="" clean_dur=""
+  while IFS='|' read -r sn sc sd; do
+    case "$sn" in
+      clean:build) clean_dur="$sd" ;;
+      format)      format_dur="$sd" ;;
+      lint:sol)    lint_dur="$sd" ;;
+      compile)     compile_dur="$sd" ;;
+      test)        test_dur="$sd" ;;
+      coverage)    coverage_dur="$sd" ;;
+    esac
+  done < "$TMP_DIR/steps.log" 2>/dev/null || true
+
+  local entry
+  entry=$(cat <<-ENTRY
+{"ts":"$(date -Iseconds)","branch":"$branch","commit":"$commit","cov":${cov_pct:-null},"br":${branch_pct:-null},"fn":${func_pct:-null},"lh":${lh_total:-null},"lf":${lf_total:-null},"brh":${brh_total:-null},"brf":${brf_total:-null},"fnh":${fnh_total:-null},"fnf":${fnf_total:-null},"lint_w":${lint_warnings:-null},"lint_e":${lint_errors:-null},"dur_format":"$format_dur","dur_lint":"$lint_dur","dur_compile":"$compile_dur","dur_test":"$test_dur","dur_coverage":"$coverage_dur"}
+ENTRY
+)
+
+  echo "$entry" >> "$HISTORY_FILE"
+  write_baseline "$entry" "$branch"
+}
+
+# ---- FAST-READ + JSON SIDECAR ------------------------------------------------
+# _finalize_log: called at the end of generate_summary.
+#   1. Prepends a compact FAST-READ block to the log (AI can read just that).
+#   2. If there are test failures, also prepends a consolidated FAILURES section.
+#   3. Writes a structured JSON sidecar (${LOG_FILE%.log}.json).
+_finalize_log() {
+  # Count tests from the raw log
+  local _tp=0 _tf=0
+  local _test_raw="$TMP_DIR/test.raw.log"
+  if [[ -f "$_test_raw" ]]; then
+    _tp=$(grep -oE '^[[:space:]]*[0-9]+ passing' "$_test_raw" 2>/dev/null \
+          | grep -oE '[0-9]+' | tail -1 || true); _tp=${_tp:-0}
+    _tf=$(grep -oE '^[[:space:]]*[0-9]+ failing'  "$_test_raw" 2>/dev/null \
+          | grep -oE '[0-9]+' | tail -1 || true); _tf=${_tf:-0}
+  fi
+
+  # Read metrics
+  local _cl="" _cb="" _cf="" _le=0 _lw=0
+  if [[ -f "$TMP_DIR/metrics.env" ]]; then
+    _cl=$(grep '^cov_pct='        "$TMP_DIR/metrics.env" | cut -d= -f2 || true)
+    _cb=$(grep '^branch_pct='    "$TMP_DIR/metrics.env" | cut -d= -f2 || true)
+    _cf=$(grep '^func_pct='      "$TMP_DIR/metrics.env" | cut -d= -f2 || true)
+    _le=$(grep '^lint_errors='   "$TMP_DIR/metrics.env" | cut -d= -f2 || echo 0)
+    _lw=$(grep '^lint_warnings=' "$TMP_DIR/metrics.env" | cut -d= -f2 || echo 0)
+  fi
+
+  # ── FAST-READ block ──────────────────────────────────────────────────────────
+  local _ok_str; $ALL_OK && _ok_str="✅ PASS" || _ok_str="❌ FAIL"
+  local _fr=""
+  _fr+="============================================================"$'\n'
+  _fr+="  FAST-READ (v${SCRIPT_VERSION})  —  ${LOG_FILE%.log}.json para acceso estructurado"$'\n'
+  _fr+="  $(date -Iseconds)"$'\n'
+  _fr+="============================================================"$'\n'
+  _fr+="  STATUS: ${_ok_str}"$'\n'$'\n'
+  _fr+="  Steps:"$'\n'
+  if [[ -f "$TMP_DIR/steps.log" ]]; then
+    while IFS='|' read -r _sn _sc _sd; do
+      local _ico; [[ "$_sc" -eq 0 ]] && _ico="✅" || _ico="❌"
+      _fr+="    ${_ico}  $(printf '%-14s' "$_sn")  ${_sd}"$'\n'
+    done < "$TMP_DIR/steps.log"
+  fi
+  [[ $(( _tp + _tf )) -gt 0 ]] && _fr+=$'\n'"  Tests:    ${_tp} passing  ${_tf} failing"$'\n'
+  [[ -n "$_cl" ]] && _fr+="  Coverage: lines ${_cl}%  branches ${_cb:-?}%  functions ${_cf:-?}%"$'\n'
+  [[ "${_lw:-0}" != "0" ]] && _fr+="  Lint:     ${_le:-0} errors  ${_lw} warnings"$'\n'
+  _fr+="============================================================"$'\n'
+
+  # ── FAILURES block (only when there are test failures) ───────────────────────────
+  local _fb=""
+  if [[ -f "$_test_raw" && "${_tf:-0}" -gt 0 ]]; then
+    local _fc
+    _fc=$(filter_test_relevant < "$_test_raw" 2>/dev/null || true)
+    _fb+="============================================================"$'\n'
+    _fb+="  TEST FAILURES (${_tf})"$'\n'
+    _fb+="============================================================"$'\n'
+    _fb+="${_fc}"$'\n'
+    _fb+="============================================================"$'\n'
+  fi
+
+  # ── Prepend to log ────────────────────────────────────────────────────────
+  {
+    printf '%s' "$_fr"
+    [[ -n "$_fb" ]] && printf '%s' "$_fb"
+    printf '\n'
+    cat "$LOG_FILE"
+  } > "$TMP_DIR/final_log.tmp" && mv "$TMP_DIR/final_log.tmp" "$LOG_FILE"
+
+  # ── Sidecar JSON ──────────────────────────────────────────────────────────
+  _write_json_sidecar "$_tp" "$_tf" "${_cl:-null}" "${_cb:-null}" "${_cf:-null}" "${_le:-0}" "${_lw:-0}"
+}
+
+_write_json_sidecar() {
+  local _tp="$1" _tf="$2" _cl="$3" _cb="$4" _cf="$5" _le="$6" _lw="$7"
+  local _json="${LOG_FILE%.log}.json"
+  local _ts _branch _commit _status
+  _ts=$(date -Iseconds)
+  _branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+  _commit=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
+  $ALL_OK && _status="PASS" || _status="FAIL"
+
+  # Steps object
+  local _steps_json="{" _sfirst=true
+  if [[ -f "$TMP_DIR/steps.log" ]]; then
+    while IFS='|' read -r _sn _sc _sd; do
+      local _ok; [[ "$_sc" -eq 0 ]] && _ok="true" || _ok="false"
+      $_sfirst || _steps_json+=","
+      _steps_json+="\"${_sn}\":{\"ok\":${_ok},\"exit\":${_sc},\"dur\":\"${_sd}\"}"
+      _sfirst=false
+    done < "$TMP_DIR/steps.log"
+  fi
+  _steps_json+="}"
+
+  # Failures array (collapsed names of failing tests)
+  local _failures_json="[]"
+  if [[ -f "$TMP_DIR/test.raw.log" && "${_tf:-0}" -gt 0 ]]; then
+    _failures_json=$(awk '
+      BEGIN { in_block=0; path=""; n=0 }
+      /^[[:space:]]+[0-9]+\) / {
+        in_block=1
+        match($0,/^[[:space:]]+[0-9]+\) /)
+        path=substr($0,RLENGTH+1); sub(/[[:space:]]+$/,"",path); next
+      }
+      in_block && /^[[:space:]]{6}/ &&
+      !/^[[:space:]]*(at [^[:space:]]|AssertionError|[A-Z][a-zA-Z]*Error:|VM Exception|panic|revert)/ {
+        line=$0; sub(/^[[:space:]]+/,"",line); sub(/[[:space:]]+$/,"",line)
+        path=path "." line; next
+      }
+      in_block { in_block=0; n++; gsub(/"/, "\\\"", path); arr[n]=path; path="" }
+      END {
+        printf "["; for (i=1;i<=n;i++) printf "%s\"%s\"", (i>1?",":""), arr[i]; printf "]"
+      }
+    ' "$TMP_DIR/test.raw.log")
+  fi
+
+  cat > "$_json" << JSONEOF
+{
+  "version": "${SCRIPT_VERSION}",
+  "timestamp": "${_ts}",
+  "branch": "${_branch}",
+  "commit": "${_commit}",
+  "status": "${_status}",
+  "steps": ${_steps_json},
+  "tests": { "passing": ${_tp}, "failing": ${_tf} },
+  "coverage": { "lines": ${_cl}, "branches": ${_cb}, "functions": ${_cf} },
+  "lint": { "errors": ${_le}, "warnings": ${_lw} },
+  "failures": ${_failures_json}
+}
+JSONEOF
+  echo "  📄 JSON: ${_json}"
+}
+
+generate_summary
+
+if $ALL_OK; then
+  echo "🎉 All checks passed. Log: $LOG_FILE"
+else
+  echo "⚠️  There were failures. Check: $LOG_FILE"
+fi

--- a/packages/ats/contracts/scripts/run-ai-checks.sh
+++ b/packages/ats/contracts/scripts/run-ai-checks.sh
@@ -815,7 +815,7 @@ if ! $SKIP_COVERAGE && $ALL_OK; then
   # Build the coverage command respecting --test-file and --test-grep.
   # --testfiles filters files; TEST_GREP is passed via env var (read by hardhat.config.ts).
   COVERAGE_CMD=(npx hardhat coverage)
-  if [[ -n "$_ats_wrapper" ]]; then
+  if [[ -n "${_ats_wrapper:-}" ]]; then
     COVERAGE_CMD+=(--testfiles "$_ats_wrapper")
   elif [[ -n "$TEST_FILE" ]]; then
     COVERAGE_CMD+=(--testfiles "$TEST_FILE")


### PR DESCRIPTION
  - add scripts/run-ai-checks.sh: unified validation pipeline (format, lint, compile, test, coverage) with structured AI-readable log output; all comments and user-facing strings in British English
  - add scripts/coverage-report.js: Istanbul/solidity-coverage report renderer, previously a personal install at $HOME/.local/bin/
  - redirect all script output to .ai-logs/ (logs, archive, metrics, baselines) so the package root stays clean; bare filename args resolved to .ai-logs/<name>
  - update run-ai-checks.sh to resolve coverage-report.js via SCRIPT_DIR
  - add npm run ai-checks wrapper in package.json
  - add .claude/commands/validate.md: /validate slash command for Claude Code; agents read ai-run.json first, log only on failures
  - gitignore ai-run.log, ai-run.json and .ai-logs/ in contracts package
  - document tooling in scripts/DEVELOPER_GUIDE.md under "Validation & AI Tools"

## Description

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
