### PR TITLE
refactor: compose deployment facet lists from typed sets

### DIFF
--- a/.changeset/typed-facet-sets.md
+++ b/.changeset/typed-facet-sets.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Compose the per-domain deployment facet lists from shared, type-checked facet sets backed by a generated `FacetName` union, so unknown or mis-typed facet names become compile errors instead of runtime lookup misses. No on-chain, ABI, or configuration change — every deployment configuration resolves to the same facet set as before.

--- a/docs/ats/developer-guides/contracts/adding-facets.md
+++ b/docs/ats/developer-guides/contracts/adding-facets.md
@@ -419,64 +419,51 @@ abstract contract Common is
 }
 ```
 
-### Step 10: Update Registry
+### Step 10: Add to the Deployment Configurations
 
-Add your facet to the deployment registry.
+Facet lists for each token type are **composed from shared, type-checked tiers**
+in `scripts/domain/facetSets.ts` plus a small per-domain delta in each
+`scripts/domain/<domain>/createConfiguration.ts`. Add your facet name in the
+place that matches its scope:
 
-**File**: `scripts/domain/atsRegistry.ts`
-
-```typescript
-import { RewardsFacet__factory } from "../../typechain-types";
-import { RESOLVER_KEY_REWARDS } from "./constants";
-
-// Add to FACET_FACTORIES
-export const FACET_FACTORIES = {
-  // ... existing facets
-  RewardsFacet: RewardsFacet__factory,
-  // ... more facets
-};
-
-// Add to FACET_REGISTRY (auto-generated after compilation)
-// Run: npm run generate:registry
-```
-
-### Step 11: Add to Configurations
-
-Include your facet in equity/bond configurations as appropriate.
+- **Needed by every token domain** → add it to `COMMON_TOKEN_FACETS` in
+  `scripts/domain/facetSets.ts`.
+- **Needed by every token domain except depositToken** → `EXTENDED_TOKEN_FACETS`.
+- **Shared by the three bond variants** → `BOND_COMMON_FACETS`.
+- **Specific to a single domain** (e.g. only equity) → add it to that domain's
+  delta in `scripts/domain/<domain>/createConfiguration.ts`.
 
 **File**: `scripts/domain/equity/createConfiguration.ts`
 
 ```typescript
-export async function createEquityConfiguration(
-  blr: BusinessLogicResolver,
-  facetAddresses: Map<string, string>,
-  options?: CreateConfigurationOptions,
-): Promise<CreateConfigurationResult> {
-  const facetConfigurations: FacetConfiguration[] = [
-    // ... existing facets
-    {
-      facetName: "RewardsFacet",
-      resolverKey: atsRegistry.getFacetDefinition("RewardsFacet").resolverKey.value,
-      address: facetAddresses.get("RewardsFacet")!,
-    },
-    // ... more facets
-  ];
-
-  // ... rest of configuration creation
-}
+export const EQUITY_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
+  // ... existing equity-specific facets
+  "RewardsFacet",
+];
 ```
+
+Every entry is checked against the generated `FacetName` union, so a typo or an
+unknown facet name is a **compile error**. Adding a facet to a shared tier
+automatically includes it in every domain that composes from that tier — no
+per-domain edits required, and no facet-count bookkeeping in the tests.
+
+### Step 11: Regenerate the Registry
+
+The facet registry is **auto-generated** from the compiled artifacts — you do
+not edit it by hand. Compiling rewrites the (gitignored)
+`scripts/domain/atsRegistry.generated.ts` with the `FACET_REGISTRY` entry for
+your facet (resolver key, factory, methods) and adds `"RewardsFacet"` to the
+generated `FacetName` union that the configuration lists above are typed
+against.
 
 ### Step 12: Compile and Generate Types
 
 ```bash
-# Compile contracts
-npm run compile
-
-# Generate TypeChain types
-npm run typechain
-
-# Update registry
-npm run generate:registry
+# Compiles the contracts, generates the TypeChain types, and regenerates the
+# registry (including the FacetName union) via the post-compile hook.
+npx hardhat compile
 ```
 
 ## Testing Your Facet

--- a/packages/ats/contracts/scripts/domain/atsRegistry.ts
+++ b/packages/ats/contracts/scripts/domain/atsRegistry.ts
@@ -64,6 +64,18 @@ import type {
   INFRASTRUCTURE_CONTRACTS as INFRASTRUCTURE_CONTRACTS_TYPE,
   STORAGE_WRAPPER_REGISTRY as STORAGE_WRAPPER_REGISTRY_TYPE,
 } from "./atsRegistry.generated";
+
+/**
+ * Union of every facet contract name known to the registry.
+ *
+ * @remarks
+ * Auto-generated alongside `FACET_REGISTRY`. Re-exported here so consumers
+ * import it from `@scripts/domain` rather than reaching into the gitignored
+ * generated file. The `export type` is fully erased at runtime — like the
+ * `import type` above, it never resolves `./atsRegistry.generated`, so module
+ * load stays bootstrap-safe.
+ */
+export type { FacetName } from "./atsRegistry.generated";
 import type {
   FacetDefinition,
   ContractDefinition,

--- a/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bond/createConfiguration.ts
@@ -22,145 +22,31 @@ import {
 } from "@scripts/infrastructure";
 import { BOND_CONFIG_ID } from "../constants";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS, BOND_COMMON_FACETS } from "../facetSets";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { BusinessLogicResolver } from "@contract-types";
 
 /**
  * Bond Token Configuration
  *
- * Defines the set of facets for Bond tokens.
- * Includes all common facets plus BondUSAFacet (NOT EquityUSAFacet).
- *
- * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
- * so we only include DiamondFacet to avoid selector collisions.
- *
- * Updated to match origin/develop feature parity (all facets registered).
- *
+ * The common token tiers plus the bond-shared facets (coupons, maturity,
+ * interest rate, principal). The bondFixedRate / bondKpiLinkedRate variants
+ * extend this same composition with their rate-specific facets.
  */
-const BOND_FACETS = [
-  // Core Functionality
-  "AccessControlFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "CorporateActionsFacet",
-  "DiamondFacet", // Combined: includes DiamondCutFacet + DiamondLoupeFacet functionality
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "KycFacet",
-  "PauseFacet",
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-
-  // Core
-  "CoreFacet",
-
-  // Allowance
-  "AllowanceFacet",
-
-  // CoreAdjusted
-  "CoreAdjustedFacet",
-  "InitializerFacet", // Core initializer facet
-
-  //CustomData
-  "CustomDataFacet",
-
-  // ERC Standards
-  "TransferFacet",
-  "MintByPartitionFacet",
-  "ProtectedByPartitionFacet",
-  "OperatorFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "NoncesFacet",
-  "DeactivateFacet",
-  "ERC20VotesFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Clearing & Settlement
-  "ClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
-  "ClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // External Management
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-  "ExternalPauseManagementFacet",
-
-  // Advanced Features
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
-  "CouponFacet",
-  "CouponSecurityHoldersFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "MaturityFacet",
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
-  "ProceedRecipientsFacet",
-  "ProtectedPartitionsFacet",
-  "ScheduledCrossOrderedTasksFacet",
-  "SecurityHoldersFacet",
-  "CouponListingFacet",
-  "SsiManagementFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
-  "InterestRateFacet",
-
-  // Maturity By Partition
-  "MaturityByPartitionFacet",
-
-  // Jurisdiction-Specific
-  "PrincipalFacet",
-] as const;
+export const BOND_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
+  ...BOND_COMMON_FACETS,
+];
 
 /**
  * Create bond token configuration in BusinessLogicResolver.
  *
  * Thin wrapper that calls the generic core operation with bond-specific data:
  * - Configuration ID: BOND_CONFIG_ID
- * - Facet list: BOND_FACETS (43 facets)
+ * - Facet list: BOND_FACETS
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.
@@ -184,7 +70,6 @@ const BOND_FACETS = [
  *     blr,
  *     {
  *         'AccessControlFacet': '0xabc...',
- *         'BondUSAFacet': '0xdef...',
  *         // ... more facets
  *     },
  *     false,

--- a/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondFixedRate/createConfiguration.ts
@@ -20,144 +20,33 @@ import {
   DEFAULT_BATCH_SIZE,
   RetryOptions,
 } from "@scripts/infrastructure";
-import { BOND_FIXED_RATE_CONFIG_ID, atsRegistry, buildFacetList, getMockFacetDefinition } from "@scripts/domain";
+import { BOND_FIXED_RATE_CONFIG_ID } from "../constants";
+import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
+import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS, BOND_COMMON_FACETS } from "../facetSets";
+import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { BusinessLogicResolver } from "@contract-types";
 
 /**
  * Bond Fixed Rate facets list.
  *
- * Uses base facets plus FixedRate-specific facets.
- * Base facets are shared across all bond configurations.
- * FixedRate-specific facets handle interest rate calculations.
- *
+ * The shared bond composition plus `FixedRateFacet` for fixed interest-rate
+ * calculations.
  */
-const BOND_FIXED_RATE_FACETS = [
-  // Core Functionality
-  "AccessControlFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "CorporateActionsFacet",
-  "DiamondFacet",
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "KycFacet",
-  "PauseFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-
-  // Core
-  "CoreFacet",
-
-  // Allowance
-  "AllowanceFacet",
-
-  // CoreAdjusted
-  "CoreAdjustedFacet",
-  "InitializerFacet", // Core initializer facet
-
-  //CustomData
-  "CustomDataFacet",
-
-  // ERC Standards
-  "TransferFacet",
-  "MintByPartitionFacet",
-  "ProtectedByPartitionFacet",
-  "OperatorFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "NoncesFacet",
-  "DeactivateFacet",
-  "ERC20VotesFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Clearing & Settlement
-  "ClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
-  "ClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // External Management
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-  "ExternalPauseManagementFacet",
-
-  // Advanced Features
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "MaturityFacet",
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
-  "ProceedRecipientsFacet",
-  "ProtectedPartitionsFacet",
-  "ScheduledCrossOrderedTasksFacet",
-  "SecurityHoldersFacet",
-  "CouponListingFacet",
-  "SsiManagementFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
-
-  "CouponSecurityHoldersFacet",
-
-  // Interest Rate (rate-specific)
-  "CouponFacet",
+export const BOND_FIXED_RATE_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
+  ...BOND_COMMON_FACETS,
   "FixedRateFacet",
-  "InterestRateFacet",
-
-  // Maturity By Partition
-  "MaturityByPartitionFacet",
-
-  // Jurisdiction-Specific
-  "PrincipalFacet",
-] as const;
+];
 
 /**
  * Create bond token configuration in BusinessLogicResolver.
  *
  * Thin wrapper that calls the generic core operation with bond-specific data:
- * - Configuration ID: BOND_CONFIG_ID
- * - Facet list: BOND_FACETS (43 facets)
+ * - Configuration ID: BOND_FIXED_RATE_CONFIG_ID
+ * - Facet list: BOND_FIXED_RATE_FACETS
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.
@@ -177,11 +66,10 @@ const BOND_FIXED_RATE_FACETS = [
  * const blr = BusinessLogicResolver__factory.connect('0x1234...', signer)
  *
  * // Create bond configuration
- * const result = await createBondConfiguration(
+ * const result = await createBondFixedRateConfiguration(
  *     blr,
  *     {
  *         'AccessControlFacet': '0xabc...',
- *         'BondUSAFacet': '0xdef...',
  *         // ... more facets
  *     },
  *     false,

--- a/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/bondKpiLinkedRate/createConfiguration.ts
@@ -20,140 +20,34 @@ import {
   DEFAULT_BATCH_SIZE,
   RetryOptions,
 } from "@scripts/infrastructure";
-import { BOND_KPI_LINKED_RATE_CONFIG_ID, atsRegistry, buildFacetList, getMockFacetDefinition } from "@scripts/domain";
+import { BOND_KPI_LINKED_RATE_CONFIG_ID } from "../constants";
+import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
+import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS, BOND_COMMON_FACETS } from "../facetSets";
+import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { BusinessLogicResolver } from "@contract-types";
 
 /**
- * Bond-specific facets list (41 facets total).
+ * Bond KPI-Linked Rate facets list.
  *
- * This is an explicit positive list of all facets required for bond tokens.
- * Includes all common facets plus BondUSAFacet (NOT EquityUSAFacet).
- *
- * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
- * so we only include DiamondFacet to avoid selector collisions.
- *
- * Updated to match origin/develop feature parity (all facets registered).
+ * The shared bond composition plus the KPI-linked rate facets
+ * (`KpiLinkedRateFacet`, `KpisFacet`).
  */
-const BOND_KPI_LINKED_RATE_FACETS = [
-  // Core Functionality (10 - DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet)
-  "AccessControlFacet",
-  "AllowanceFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "CorporateActionsFacet",
-  "DiamondFacet", // Combined: includes DiamondCutFacet + DiamondLoupeFacet functionality
-  "CoreFacet",
-  "TransferFacet",
-  "CoreAdjustedFacet",
-  "InitializerFacet", // Core initializer facet
-  "CustomDataFacet",
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "KycFacet",
-  "PauseFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-
-  // ERC Standards
-  "MintByPartitionFacet",
-  "ProtectedByPartitionFacet",
-  "OperatorFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "NoncesFacet",
-  "DeactivateFacet",
-  "ERC20VotesFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Clearing & Settlement
-  "ClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
-  "ClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // External Management
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-  "ExternalPauseManagementFacet",
-
-  // Advanced Features
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "MaturityFacet",
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
-  "ProceedRecipientsFacet", // rate-specific: triggers scheduled tasks
-  "ProtectedPartitionsFacet",
-  "ScheduledCrossOrderedTasksFacet", // rate-specific: _onCouponListed override
-  "SecurityHoldersFacet",
-  "CouponListingFacet",
-  "SsiManagementFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
-
-  "CouponSecurityHoldersFacet",
-
-  // Interest Rate (rate-specific - keep variant names)
-  "CouponFacet",
+export const BOND_KPI_LINKED_RATE_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
+  ...BOND_COMMON_FACETS,
   "KpiLinkedRateFacet",
   "KpisFacet",
-  "InterestRateFacet",
-
-  // Maturity By Partition
-  "MaturityByPartitionFacet",
-
-  // Jurisdiction-Specific (write facet and read facet are both rate-specific)
-  "PrincipalFacet",
-] as const;
+];
 
 /**
  * Create bond token configuration in BusinessLogicResolver.
  *
  * Thin wrapper that calls the generic core operation with bond-specific data:
- * - Configuration ID: BOND_CONFIG_ID
- * - Facet list: BOND_FACETS (43 facets)
+ * - Configuration ID: BOND_KPI_LINKED_RATE_CONFIG_ID
+ * - Facet list: BOND_KPI_LINKED_RATE_FACETS
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.
@@ -173,11 +67,10 @@ const BOND_KPI_LINKED_RATE_FACETS = [
  * const blr = BusinessLogicResolver__factory.connect('0x1234...', signer)
  *
  * // Create bond configuration
- * const result = await createBondConfiguration(
+ * const result = await createBondKpiLinkedRateConfiguration(
  *     blr,
  *     {
  *         'AccessControlFacet': '0xabc...',
- *         'BondUSAFacet': '0xdef...',
  *         // ... more facets
  *     },
  *     false,

--- a/packages/ats/contracts/scripts/domain/depositToken/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/depositToken/createConfiguration.ts
@@ -22,93 +22,20 @@ import {
 import { BusinessLogicResolver } from "@contract-types";
 import { DEPOSIT_TOKEN_CONFIG_ID } from "../constants";
 import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS } from "../facetSets";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 
 /**
- * Deposit Token configuration: 43 facets (42 capability facets + InitializerFacet).
+ * Deposit Token configuration.
  *
- * A deposit token is a minimal cash-style asset, so this list omits the facets for capabilities
- * it does not expose (compliance, KYC, external KYC, external pause, protected partitions,
- * identity, snapshots, lock, coupon, maturity, …). Each facet listed here has a matching
- * initialiser in `Factory._deployDepositToken`.
+ * A deposit token is a minimal cash-style asset, so it uses only the common
+ * token tier (no compliance, KYC, snapshots, locks, coupons, maturity, …) plus
+ * `ClearingHoldByPartitionFacet`. Each facet here has a matching initialiser in
+ * `Factory._deployDepositToken`.
  */
-const DEPOSIT_TOKEN_FACETS = [
-  // Always-on (initializers + diamond infra)
-  "AccessControlFacet",
-  "DiamondFacet",
-  "InitializerFacet", // required by setOperationalStatus / Factory._deployDepositToken
-  "ControlListFacet", // also = Eligibility
-  "CoreFacet", // also = Core
-  "CapFacet", // also = Cap
-
-  // Allowance (includes approve)
-  "AllowanceFacet",
-
-  // Balance Tracker
-  "BalanceTrackerFacet",
-  "BalanceTrackerByPartitionFacet",
-
-  // Transfer
-  "TransferFacet",
-  "TransferByPartitionFacet",
-
-  // Mint
-  "MintFacet",
-  "MintByPartitionFacet",
-
-  // Burn
-  "BurnFacet",
-  "BurnByPartitionFacet",
-
-  // Controller
-  "ControllerFacet",
-  "ControllerByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-
-  // Operator
-  "OperatorFacet",
-  "OperatorByPartitionFacet",
-  "OperatorHoldByPartitionFacet",
-  "OperatorClearingByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-
-  // Partitions
-  "PartitionsFacet",
-
-  // Batch
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "BatchFreezeFacet",
-
-  // Freeze
-  "FreezeFacet",
-
-  // Cap per-partition
-  "CapByPartitionFacet",
-
-  // Clearing
-  "ClearingFacet",
-  "ClearingByPartitionFacet",
-  "ClearingHoldByPartitionFacet",
-
-  // Hold
-  "HoldFacet",
-  "HoldByPartitionFacet",
-
-  // External Eligibility
-  "ExternalControlListManagementFacet",
-
-  // Other YES capabilities
-  "SecurityHoldersFacet",
-  "DeactivateFacet",
-  "DocumentationFacet",
-  "CustomDataFacet",
-  "NominalValueFacet",
-  "PauseFacet",
-] as const;
+export const DEPOSIT_TOKEN_FACETS: readonly FacetName[] = [...COMMON_TOKEN_FACETS, "ClearingHoldByPartitionFacet"];
 
 /**
  * Create the deposit token configuration in BusinessLogicResolver.
@@ -116,7 +43,7 @@ const DEPOSIT_TOKEN_FACETS = [
  * Thin wrapper that calls the generic core operation with deposit-token-specific
  * data:
  * - Configuration ID: DEPOSIT_TOKEN_CONFIG_ID
- * - Facet list: DEPOSIT_TOKEN_FACETS (43 facets)
+ * - Facet list: DEPOSIT_TOKEN_FACETS
  *
  * @param blrContract - BusinessLogicResolver contract instance
  * @param facetAddresses - Map of facet names to their deployed addresses

--- a/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/equity/createConfiguration.ts
@@ -23,130 +23,36 @@ import {
 import { BusinessLogicResolver } from "@contract-types";
 import { EQUITY_CONFIG_ID } from "../constants";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS } from "../facetSets";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 
 /**
  * Equity-specific facets list.
  *
- * This is an explicit positive list of all facets required for equity tokens.
- * Includes all common facets plus VotingFacet, DividendFacet, and DividendSecurityHoldersFacet.
- *
- * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
- * so we only include DiamondFacet to avoid selector collisions.
- *
- * Based on origin/develop configuration where equity uses ALL common facets.
+ * The common token tiers plus the equity-specific facets: dividends, voting,
+ * and the supporting interest-rate / proceed-recipients / clearing-hold facets.
  */
-const EQUITY_FACETS = [
-  // Core Functionality (10 - DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet)
-  "AccessControlFacet",
-  "AllowanceFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "CorporateActionsFacet",
-  "DiamondFacet",
-  "CoreFacet",
-  "TransferFacet",
-  "CoreAdjustedFacet",
-  "InitializerFacet",
-  "CustomDataFacet",
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "KycFacet",
-  "PauseFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-
-  // ERC Standards (13)
-  "MintByPartitionFacet",
-  "ProtectedByPartitionFacet",
-  "OperatorFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "NoncesFacet",
-  "DeactivateFacet",
-  "ERC20VotesFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Clearing & Settlement (7)
-  "ClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
+export const EQUITY_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
   "ClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // External Management (3)
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-  "ExternalPauseManagementFacet",
-
-  // Advanced Features (12)
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
   "DividendFacet",
   "DividendSecurityHoldersFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
-  "ProtectedPartitionsFacet",
-  "ScheduledCrossOrderedTasksFacet",
-  "SecurityHoldersFacet",
-  "SsiManagementFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
+  "InterestRateFacet",
+  "NoncesFacet",
+  "ProceedRecipientsFacet",
   "VotingFacet",
   "VotingSecurityHoldersFacet",
-
-  "InterestRateFacet",
-  "ProceedRecipientsFacet",
-] as const;
+];
 
 /**
  * Create equity token configuration in BusinessLogicResolver.
  *
  * Thin wrapper that calls the generic core operation with equity-specific data:
  * - Configuration ID: EQUITY_CONFIG_ID
- * - Facet list: EQUITY_FACETS (42 facets)
+ * - Facet list: EQUITY_FACETS
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.

--- a/packages/ats/contracts/scripts/domain/facetSets.ts
+++ b/packages/ats/contracts/scripts/domain/facetSets.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared, type-checked facet sets for deployment configurations.
+ *
+ * Each `createConfiguration.ts` composes its facet list from these tiers plus a
+ * small additive delta, instead of hand-maintaining a ~90-entry string array.
+ * Every entry is checked against the generated `FacetName` union, so a typo or
+ * a renamed facet is a compile error rather than a runtime lookup miss.
+ *
+ * Tiers are additive only — a domain that needs fewer facets (e.g. depositToken)
+ * builds up from a smaller tier; no tier is ever subtracted from. This preserves
+ * the project convention of explicit positive facet lists.
+ *
+ * - `COMMON_TOKEN_FACETS` — present in every token domain.
+ * - `EXTENDED_TOKEN_FACETS` — the full-feature set shared by every token domain
+ *   except depositToken (snapshots, compliance/KYC, locks, protected variants,
+ *   scheduled tasks, ...).
+ * - `BOND_COMMON_FACETS` — shared by the three bond variants on top of the two
+ *   token tiers (coupons, maturity, interest rate, principal, ...).
+ *
+ * @module domain/facetSets
+ */
+
+import type { FacetName } from "./atsRegistry";
+
+/**
+ * Facets present in every token domain.
+ */
+export const COMMON_TOKEN_FACETS = [
+  "AccessControlFacet",
+  "AllowanceFacet",
+  "BalanceTrackerByPartitionFacet",
+  "BalanceTrackerFacet",
+  "BatchBurnFacet",
+  "BatchControllerFacet",
+  "BatchFreezeFacet",
+  "BatchMintFacet",
+  "BatchTransferFacet",
+  "BurnByPartitionFacet",
+  "BurnFacet",
+  "CapByPartitionFacet",
+  "CapFacet",
+  "ClearingByPartitionFacet",
+  "ClearingFacet",
+  "ControlListFacet",
+  "ControllerByPartitionFacet",
+  "ControllerFacet",
+  "ControllerHoldByPartitionFacet",
+  "CoreFacet",
+  "CustomDataFacet",
+  "DeactivateFacet",
+  "DiamondFacet",
+  "DocumentationFacet",
+  "ExternalControlListManagementFacet",
+  "FreezeFacet",
+  "HoldByPartitionFacet",
+  "HoldFacet",
+  "InitializerFacet",
+  "MintByPartitionFacet",
+  "MintFacet",
+  "NominalValueFacet",
+  "OperatorByPartitionFacet",
+  "OperatorClearingByPartitionFacet",
+  "OperatorClearingHoldByPartitionFacet",
+  "OperatorFacet",
+  "OperatorHoldByPartitionFacet",
+  "PartitionsFacet",
+  "PauseFacet",
+  "SecurityHoldersFacet",
+  "TransferByPartitionFacet",
+  "TransferFacet",
+] as const satisfies readonly FacetName[];
+
+/**
+ * Full-feature facets shared by every token domain except depositToken.
+ */
+export const EXTENDED_TOKEN_FACETS = [
+  "AdjustBalancesFacet",
+  "BalanceTrackerAdjustedFacet",
+  "BalanceTrackerAtSnapshotByPartitionFacet",
+  "BalanceTrackerAtSnapshotFacet",
+  "ClearingAtSnapshotByPartitionFacet",
+  "ClearingAtSnapshotFacet",
+  "ComplianceByPartitionFacet",
+  "ComplianceFacet",
+  "CoreAdjustedFacet",
+  "CoreAtSnapshotFacet",
+  "CorporateActionsFacet",
+  "EIP712Facet",
+  "ERC20PermitFacet",
+  "ERC20VotesFacet",
+  "ExternalKycListManagementFacet",
+  "ExternalPauseManagementFacet",
+  "FreezeAtSnapshotByPartitionFacet",
+  "FreezeAtSnapshotFacet",
+  "HoldAtSnapshotByPartitionFacet",
+  "HoldAtSnapshotFacet",
+  "IdentityFacet",
+  "KycFacet",
+  "LockAtSnapshotByPartitionFacet",
+  "LockAtSnapshotFacet",
+  "LockByPartitionFacet",
+  "LockFacet",
+  "NominalValueAtSnapshotFacet",
+  "ProtectedByPartitionFacet",
+  "ProtectedClearingByPartitionFacet",
+  "ProtectedClearingHoldByPartitionFacet",
+  "ProtectedHoldByPartitionFacet",
+  "ProtectedPartitionsFacet",
+  "RecoveryFacet",
+  "ScheduledBalanceAdjustmentFacet",
+  "ScheduledCrossOrderedTasksFacet",
+  "SecurityHoldersAtSnapshotFacet",
+  "SnapshotsByPartitionFacet",
+  "SnapshotsFacet",
+  "SsiManagementFacet",
+  "TransferAndLockByPartitionFacet",
+  "TransferAndLockFacet",
+] as const satisfies readonly FacetName[];
+
+/**
+ * Facets shared by the three bond variants on top of the token tiers.
+ */
+export const BOND_COMMON_FACETS = [
+  "ClearingHoldByPartitionFacet",
+  "CouponFacet",
+  "CouponListingFacet",
+  "CouponSecurityHoldersFacet",
+  "InterestRateFacet",
+  "MaturityByPartitionFacet",
+  "MaturityFacet",
+  "NoncesFacet",
+  "PrincipalFacet",
+  "ProceedRecipientsFacet",
+] as const satisfies readonly FacetName[];

--- a/packages/ats/contracts/scripts/domain/factory/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/factory/createConfiguration.ts
@@ -24,6 +24,7 @@ import {
 import { BusinessLogicResolver } from "@contract-types";
 import { FACTORY_CONFIG_ID } from "../constants";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 
 /**
@@ -31,7 +32,7 @@ import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
  *
  * Factory is a single-facet ResolverProxy that handles token deployment.
  */
-const FACTORY_FACETS = ["FactoryFacet"] as const;
+export const FACTORY_FACETS: readonly FacetName[] = ["FactoryFacet"];
 
 /**
  * Create factory token configuration in BusinessLogicResolver.

--- a/packages/ats/contracts/scripts/domain/index.ts
+++ b/packages/ats/contracts/scripts/domain/index.ts
@@ -48,6 +48,9 @@ export * from "./constants";
 // Test-environment facet substitution
 export * from "./facetEnvironment";
 
+// Shared, type-checked facet sets for deployment configurations
+export * from "./facetSets";
+
 // Orchestrator library management
 export * from "./orchestratorLibraries";
 

--- a/packages/ats/contracts/scripts/domain/initializeMock/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/initializeMock/createConfiguration.ts
@@ -17,8 +17,10 @@ import {
 } from "@scripts/infrastructure";
 import { BusinessLogicResolver } from "@contract-types";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 import { INITIALIZE_MOCK_CONFIG_ID } from "../constants";
 import { getMockFacetDefinition } from "./mockFacetsRegistry";
+import type { MockFacetName } from "./mockFacetsRegistry";
 
 // TEST-ONLY: facet set for the InitializeMock domain — the real InitializerFacet
 // followed by `MockDiamondCut` (a mock variant of `DiamondFacet` that exposes
@@ -27,13 +29,13 @@ import { getMockFacetDefinition } from "./mockFacetsRegistry";
 // `InitializerFacet` is resolved from `atsRegistry`; the mocks are resolved
 // from the local mock registry since they are excluded from the auto-generated
 // atsRegistry.
-const INITIALIZE_MOCK_FACETS = [
+export const INITIALIZE_MOCK_FACETS: readonly (FacetName | MockFacetName)[] = [
   "InitializerFacet",
   "MockDiamondCut",
   "MockFacet1",
   "MockFacet2",
   "MockFacet3",
-] as const;
+];
 
 /**
  * TEST-ONLY: create the InitializeMock configuration in BusinessLogicResolver.

--- a/packages/ats/contracts/scripts/domain/initializeMock/mockFacetsRegistry.ts
+++ b/packages/ats/contracts/scripts/domain/initializeMock/mockFacetsRegistry.ts
@@ -28,7 +28,7 @@ const _DIAMOND = "0xd9202bb838fd8d0f2866f13141398cfb9fa74cbbbce7449c9158caffa9c5
 // TEST-ONLY: registry of the mock facets, keyed by the contract name used in
 // `INITIALIZE_MOCK_FACETS`. Shape matches the production `FACET_REGISTRY` so
 // the deploy + configuration code can treat it the same way.
-export const MOCK_FACET_REGISTRY: Record<string, FacetDefinition> = {
+export const MOCK_FACET_REGISTRY = {
   MockDiamondCut: {
     name: "MockDiamondCut",
     description: "TEST-ONLY mock variant of DiamondFacet used by InitializeMock domain",
@@ -62,11 +62,18 @@ export const MOCK_FACET_REGISTRY: Record<string, FacetDefinition> = {
     },
     factory: (signer) => new MockFactoryFacet__factory(signer),
   },
-};
+} satisfies Record<string, FacetDefinition>;
+
+// TEST-ONLY: union of the mock facet contract names. Lets the InitializeMock
+// configuration type its facet list as `FacetName | MockFacetName` so the mock
+// entries (absent from the generated registry) still type-check.
+export type MockFacetName = keyof typeof MOCK_FACET_REGISTRY;
 
 // TEST-ONLY: convenience helper mirroring `atsRegistry.getFacetDefinition` for the mocks.
 export function getMockFacetDefinition(name: string): FacetDefinition | undefined {
-  return MOCK_FACET_REGISTRY[name];
+  // `satisfies` keeps the literal keys for `MockFacetName`, so widen here to
+  // index by an arbitrary runtime string.
+  return (MOCK_FACET_REGISTRY as Record<string, FacetDefinition>)[name];
 }
 
 // TEST-ONLY: returns the three mock FacetDefinitions in declaration order, for

--- a/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loan/createConfiguration.ts
@@ -23,139 +23,35 @@ import {
 import { BusinessLogicResolver } from "@contract-types";
 import { LOAN_CONFIG_ID } from "../constants";
 import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS } from "../facetSets";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 
 /**
- * Loan-specific facets list (46 facets total).
+ * Loan-specific facets list.
  *
- * This is an explicit positive list of all facets required for loan tokens.
- *
- * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
- * so we only include DiamondFacet to avoid selector collisions.
+ * The common token tiers plus the loan-specific facets: the loan lifecycle,
+ * amortization, coupons, and proceed recipients.
  */
-const LOAN_FACETS = [
-  // Loan Functionality
-  "LoanFacet",
-  "CouponFacet",
-  "CouponSecurityHoldersFacet",
-  "CouponListingFacet",
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
+export const LOAN_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
   "AmortizationFacet",
-  "ProceedRecipientsFacet",
-
-  // Core Functionality
-  "AccessControlFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "KycFacet",
-  "SsiManagementFacet",
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "PauseFacet",
-
-  // Core
-  "CoreFacet",
-
-  // Allowance
-  "AllowanceFacet",
-
-  // ERC Standards
-  "TransferFacet",
-  "CoreAdjustedFacet",
-  "InitializerFacet", // Core initializer facet
-  "CustomDataFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "ERC20VotesFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "OperatorFacet",
-  "ProtectedByPartitionFacet",
-  "MintByPartitionFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Hold
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // Clearing & Settlement
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
   "ClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "ClearingByPartitionFacet",
-
-  // Scheduled Tasks
-  "ScheduledCrossOrderedTasksFacet",
-
-  // External Management
-  "ExternalPauseManagementFacet",
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-
-  // Deactivate
-  "DeactivateFacet",
-
-  // Diamond
-  "DiamondFacet",
-
-  // Advanced Features
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "CorporateActionsFacet",
-  "SecurityHoldersFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
-  "ProtectedPartitionsFacet",
-] as const;
+  "CouponFacet",
+  "CouponListingFacet",
+  "CouponSecurityHoldersFacet",
+  "LoanFacet",
+  "ProceedRecipientsFacet",
+];
 
 /**
  * Create loan token configuration in BusinessLogicResolver.
  *
  * Thin wrapper that calls the generic core operation with loan-specific data:
  * - Configuration ID: LOAN_CONFIG_ID
- * - Facet list: LOAN_FACETS (46 facets)
+ * - Facet list: LOAN_FACETS
  *
  * All implementation logic is handled by the generic createConfiguration()
  * operation in core/operations/blrConfigurations.ts.

--- a/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
+++ b/packages/ats/contracts/scripts/domain/loanPortfolio/createConfiguration.ts
@@ -22,126 +22,25 @@ import {
 } from "@scripts/infrastructure";
 import { LOANS_PORTFOLIO_CONFIG_ID } from "../constants";
 import { atsRegistry } from "../atsRegistry";
+import type { FacetName } from "../atsRegistry";
 import { buildFacetList } from "../facetEnvironment";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS } from "../facetSets";
 import { getMockFacetDefinition } from "../initializeMock/mockFacetsRegistry";
 import { BusinessLogicResolver } from "@contract-types";
 
 /**
  * Loan Portfolio Facets
  *
- * This is an explicit positive list of all facets required for loan portfolio tokens.
- * Includes all infrastructure facets EXCEPT:
- * - BondUSAReadFacet
- * - ProceedRecipientsFacet
- * - EquityUSAFacet
- * - CouponFacet
- *
- * Note: DiamondFacet combines DiamondCutFacet + DiamondLoupeFacet functionality,
- * so we only include DiamondFacet to avoid selector collisions.
+ * The common token tiers plus the portfolio-specific facets: the portfolio
+ * facet itself, coupon listing, and nonces.
  */
-const LOANS_PORTFOLIO_FACETS = [
-  "LoansPortfolioFacet",
-  // Core Functionality
-  "AccessControlFacet",
-  "AllowanceFacet",
-  "CapFacet",
-  "CapByPartitionFacet",
-  "ControlListFacet",
-  "CorporateActionsFacet",
-  "DiamondFacet",
-  "CoreFacet",
-  "TransferFacet",
-  "CoreAdjustedFacet",
-  "InitializerFacet", // Core initializer facet
-  "CustomDataFacet",
-  "FreezeFacet",
-  "BatchFreezeFacet",
-  "KycFacet",
-  "PauseFacet",
-  "BalanceTrackerFacet",
-  "BalanceTrackerAdjustedFacet",
-  "SnapshotsFacet",
-  "SnapshotsByPartitionFacet",
-  "SecurityHoldersAtSnapshotFacet",
-  "HoldAtSnapshotFacet",
-  "LockAtSnapshotByPartitionFacet",
-  "FreezeAtSnapshotFacet",
-  "FreezeAtSnapshotByPartitionFacet",
-  "LockAtSnapshotFacet",
-  "CoreAtSnapshotFacet",
-  "SsiManagementFacet",
-  "BalanceTrackerByPartitionFacet",
-  "BalanceTrackerAtSnapshotFacet",
-  "BalanceTrackerAtSnapshotByPartitionFacet",
-  "ClearingAtSnapshotFacet",
-  "ClearingAtSnapshotByPartitionFacet",
-  "HoldAtSnapshotByPartitionFacet",
-
-  // ERC Standards
-  "MintByPartitionFacet",
-  "ProtectedByPartitionFacet",
-  "OperatorFacet",
-  "TransferByPartitionFacet",
-  "PartitionsFacet",
-  "OperatorByPartitionFacet",
-  "BurnByPartitionFacet",
-  "DocumentationFacet",
-  "ControllerFacet",
-  "ERC20PermitFacet",
-  "EIP712Facet",
-  "NoncesFacet",
-  "DeactivateFacet",
-  "ERC20VotesFacet",
-  "BatchControllerFacet",
-  "BatchBurnFacet",
-  "BatchMintFacet",
-  "BatchTransferFacet",
-  "RecoveryFacet",
-  "IdentityFacet",
-  "ComplianceFacet",
-  "ComplianceByPartitionFacet",
-  "MintFacet",
-  "BurnFacet",
-
-  // Nominal Value
-  "NominalValueFacet",
-  "NominalValueAtSnapshotFacet",
-
-  // Hold
-  "HoldFacet",
-  "OperatorHoldByPartitionFacet",
-  "ControllerHoldByPartitionFacet",
-  "ControllerByPartitionFacet",
-  "ProtectedHoldByPartitionFacet",
-  "HoldByPartitionFacet",
-
-  // Clearing & Settlement
-  "OperatorClearingByPartitionFacet",
-  "ProtectedClearingByPartitionFacet",
-  "ProtectedClearingHoldByPartitionFacet",
-  "OperatorClearingHoldByPartitionFacet",
-  "ClearingFacet",
-  "ClearingByPartitionFacet",
-
-  // Scheduled Tasks
-  "ScheduledCrossOrderedTasksFacet",
+export const LOANS_PORTFOLIO_FACETS: readonly FacetName[] = [
+  ...COMMON_TOKEN_FACETS,
+  ...EXTENDED_TOKEN_FACETS,
   "CouponListingFacet",
-
-  // External Management
-  "ExternalPauseManagementFacet",
-  "ExternalControlListManagementFacet",
-  "ExternalKycListManagementFacet",
-
-  // Advanced Features
-  "AdjustBalancesFacet",
-  "ScheduledBalanceAdjustmentFacet",
-  "LockFacet",
-  "LockByPartitionFacet",
-  "ProtectedPartitionsFacet",
-  "SecurityHoldersFacet",
-  "TransferAndLockFacet",
-  "TransferAndLockByPartitionFacet",
-] as const;
+  "LoansPortfolioFacet",
+  "NoncesFacet",
+];
 
 export async function createLoansPortfolioConfiguration(
   blrContract: BusinessLogicResolver,

--- a/packages/ats/contracts/scripts/tools/registry-generator/core/generator.ts
+++ b/packages/ats/contracts/scripts/tools/registry-generator/core/generator.ts
@@ -148,6 +148,7 @@ export function generateRegistry(
     mocks,
   );
   const facetRegistry = generateFacetRegistry(facets);
+  const facetNameUnion = generateFacetNameUnion(facets);
   const contractRegistry = generateContractRegistry(infrastructure);
   const storageWrapperRegistry = storageWrappers ? generateStorageWrapperRegistry(storageWrappers) : "";
   const mockRegistry = mocks && mocks.length > 0 ? generateMockRegistry(mocks) : "";
@@ -160,7 +161,7 @@ export function generateRegistry(
    * roles file remain checked into git while the rest of this file is
    * gitignored and regenerated on `prepare`.
    */
-  const registries = [header, facetRegistry, contractRegistry];
+  const registries = [header, facetRegistry, facetNameUnion, contractRegistry];
   if (storageWrapperRegistry) {
     registries.push(storageWrapperRegistry);
   }
@@ -326,6 +327,38 @@ ${entries.join(",\n\n")}
  * Total number of facets in the registry.
  */
 export const TOTAL_FACETS = ${facets.length} as const`;
+}
+
+/**
+ * Generate the `FacetName` string-literal union type.
+ *
+ * Emits a union of every facet contract name in the registry, sorted
+ * alphabetically for deterministic output. Consumers (e.g. deployment
+ * configuration facet sets) type their lists as `readonly FacetName[]` so an
+ * unknown or mis-typed facet name is a compile error rather than a runtime
+ * lookup miss. `keyof typeof FACET_REGISTRY` cannot serve this purpose because
+ * the registry is typed `Record<string, FacetDefinition>` and widens its keys
+ * to `string`; the explicit literal union preserves the names.
+ *
+ * Emits `never` when there are no facets so the output is always valid
+ * TypeScript (an empty union is a syntax error).
+ *
+ * @param facets - Array of facet metadata
+ * @returns TypeScript code for the FacetName union type
+ */
+function generateFacetNameUnion(facets: ContractMetadata[]): string {
+  const sortedNames = [...facets].map((f) => f.name).sort((a, b) => a.localeCompare(b));
+
+  const body = sortedNames.length > 0 ? sortedNames.map((name) => `    | '${name}'`).join("\n") : "    never";
+
+  return `/**
+ * Union of every facet contract name known to the registry.
+ *
+ * Type the facet-name lists that drive deployment configurations as
+ * \`readonly FacetName[]\` so typos and renames surface as compile errors.
+ */
+export type FacetName =
+${body}`;
 }
 
 /**

--- a/packages/ats/contracts/test/scripts/integration/registryGeneration.test.ts
+++ b/packages/ats/contracts/test/scripts/integration/registryGeneration.test.ts
@@ -136,6 +136,8 @@ describe("Registry Generation Pipeline - Integration Tests", () => {
       expect(result.code).to.include("Record<string,");
       expect(result.code).to.include("FacetDefinition");
       expect(result.code).to.include("ContractDefinition");
+      // FacetName union is emitted alongside FACET_REGISTRY.
+      expect(result.code).to.include("export type FacetName =");
 
       // Should not have syntax errors
       expect(result.code).to.not.include("undefined");

--- a/packages/ats/contracts/test/scripts/unit/domain/facetSets.test.ts
+++ b/packages/ats/contracts/test/scripts/unit/domain/facetSets.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the shared facet sets and the per-domain configuration lists
+ * composed from them.
+ *
+ * @remarks
+ * The `FacetName` type — generated from the registry keys — already guarantees
+ * at compile time that every entry is a real, registered facet, so there is no
+ * value in re-asserting that at runtime. What the type cannot express is that a
+ * `FacetName[]` has no repeats: a facet listed twice (e.g. added to a delta when
+ * it already sits in a tier, or shared between two tiers) type-checks but makes
+ * the chain revert with `DuplicatedFacetInConfiguration` at deploy time. These
+ * tests guard exactly that — duplicates within each list and overlap between the
+ * additive tiers.
+ *
+ * @module test/scripts/unit/domain/facetSets.test
+ */
+
+import { expect } from "chai";
+import { COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS, BOND_COMMON_FACETS } from "@scripts/domain";
+import { BOND_FACETS } from "../../../../scripts/domain/bond/createConfiguration";
+import { BOND_FIXED_RATE_FACETS } from "../../../../scripts/domain/bondFixedRate/createConfiguration";
+import { BOND_KPI_LINKED_RATE_FACETS } from "../../../../scripts/domain/bondKpiLinkedRate/createConfiguration";
+import { EQUITY_FACETS } from "../../../../scripts/domain/equity/createConfiguration";
+import { DEPOSIT_TOKEN_FACETS } from "../../../../scripts/domain/depositToken/createConfiguration";
+import { LOAN_FACETS } from "../../../../scripts/domain/loan/createConfiguration";
+import { LOANS_PORTFOLIO_FACETS } from "../../../../scripts/domain/loanPortfolio/createConfiguration";
+import { FACTORY_FACETS } from "../../../../scripts/domain/factory/createConfiguration";
+import { INITIALIZE_MOCK_FACETS } from "../../../../scripts/domain/initializeMock/createConfiguration";
+
+const hasDuplicates = (list: readonly string[]): boolean => new Set(list).size !== list.length;
+const intersect = (a: readonly string[], b: readonly string[]): string[] => {
+  const setB = new Set(b);
+  return a.filter((x) => setB.has(x));
+};
+
+describe("facetSets", () => {
+  describe("tiers", () => {
+    const tiers = {
+      COMMON_TOKEN_FACETS,
+      EXTENDED_TOKEN_FACETS,
+      BOND_COMMON_FACETS,
+    };
+
+    for (const [name, tier] of Object.entries(tiers)) {
+      it(`${name} has no duplicates`, () => {
+        expect(hasDuplicates(tier)).to.be.false;
+      });
+    }
+
+    it("tiers are mutually disjoint", () => {
+      expect(intersect(COMMON_TOKEN_FACETS, EXTENDED_TOKEN_FACETS)).to.be.empty;
+      expect(intersect(COMMON_TOKEN_FACETS, BOND_COMMON_FACETS)).to.be.empty;
+      expect(intersect(EXTENDED_TOKEN_FACETS, BOND_COMMON_FACETS)).to.be.empty;
+    });
+  });
+
+  describe("composed configuration lists", () => {
+    const configurationLists: Record<string, readonly string[]> = {
+      BOND_FACETS,
+      BOND_FIXED_RATE_FACETS,
+      BOND_KPI_LINKED_RATE_FACETS,
+      EQUITY_FACETS,
+      DEPOSIT_TOKEN_FACETS,
+      LOAN_FACETS,
+      LOANS_PORTFOLIO_FACETS,
+      FACTORY_FACETS,
+      INITIALIZE_MOCK_FACETS,
+    };
+
+    for (const [name, list] of Object.entries(configurationLists)) {
+      it(`${name} has no duplicates`, () => {
+        expect(hasDuplicates(list)).to.be.false;
+      });
+    }
+  });
+});

--- a/packages/ats/contracts/test/scripts/unit/tools/registryGenerator.test.ts
+++ b/packages/ats/contracts/test/scripts/unit/tools/registryGenerator.test.ts
@@ -20,7 +20,7 @@ import type {
 } from "../../../../scripts/tools/registry-generator/types";
 import { extractMetadata } from "../../../../scripts/tools/registry-generator/core/extractor";
 import { generateRegistry } from "../../../../scripts/tools/registry-generator/core/generator";
-import { silenceScriptLogging } from "@test";
+import { silenceScriptLogging, TEST_FACET_NAMES } from "@test";
 import { resetLogger } from "@scripts/infrastructure";
 
 // ---------------------------------------------------------------------------
@@ -234,6 +234,36 @@ describe("Registry Generator - isDeployable", () => {
 
       const entry = entryMatch![0];
       expect(entry).to.not.include("factory:");
+    });
+  });
+
+  // ==========================================================================
+  // generateRegistry - FacetName union type
+  // ==========================================================================
+
+  describe("generateRegistry - FacetName union", () => {
+    it("should emit a sorted FacetName union from the facet names", () => {
+      // Declared out of alphabetical order to prove the generator sorts them
+      // (FACET_A = "FacetA" sorts before FACET_B = "FacetB").
+      const facets = [
+        makeMetadata({ name: TEST_FACET_NAMES.FACET_B, contractName: TEST_FACET_NAMES.FACET_B }),
+        makeMetadata({ name: TEST_FACET_NAMES.FACET_A, contractName: TEST_FACET_NAMES.FACET_A }),
+      ];
+
+      const code = generateRegistry(facets, []);
+
+      expect(code).to.include("export type FacetName =");
+      expect(code).to.include(`| '${TEST_FACET_NAMES.FACET_A}'`);
+      expect(code).to.include(`| '${TEST_FACET_NAMES.FACET_B}'`);
+      expect(code.indexOf(`'${TEST_FACET_NAMES.FACET_A}'`)).to.be.lessThan(
+        code.indexOf(`'${TEST_FACET_NAMES.FACET_B}'`),
+      );
+    });
+
+    it("should emit `never` when there are no facets", () => {
+      const code = generateRegistry([], []);
+
+      expect(code).to.match(/export type FacetName =\s*never/);
     });
   });
 });


### PR DESCRIPTION
## Description

Replaces the hand-maintained raw-string facet lists in the 9 `scripts/domain/*/createConfiguration.ts` modules (86–95 entries each, 60–95% duplicated) with composition from shared, type-checked tiers (`COMMON_TOKEN_FACETS` 42, `EXTENDED_TOKEN_FACETS` 41, `BOND_COMMON_FACETS` 10) plus small additive deltas. The registry generator now emits an `export type FacetName` string-literal union (re-exported type-only from `atsRegistry.ts`, bootstrap-safe), so unknown or mis-typed facet names are compile errors with autocomplete. Behaviour-preserving: no on-chain, ABI, or configuration change. Net −796/+180 lines.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

Set-equivalence proven — all 9 deployment domains resolve to byte-identical facet sets vs develop. Full contracts suite: 3606 passing, 0 failing (baseline develop 3589; +17 new facetSets tests). Build/typecheck green; format + lint clean (0 errors; only pre-existing NatSpec warnings on untouched .sol files). Fresh-bootstrap verified: deleted gitignored `atsRegistry.generated.ts`, `npx hardhat compile` regenerated it cleanly with the FacetName union, no module-load error. Local CI ran on Node v24.12.0.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
