### PR TITLE
fix: migrate role memberships during wallet recovery

### DIFF
--- a/.changeset/bbnd-1825-recovery-role-migration.md
+++ b/.changeset/bbnd-1825-recovery-role-migration.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Recovered (lost) wallets are now rejected by the centralized access-control checks: AccessControlStorageWrapper.checkRole and checkAnyRole revert with WalletRecovered for a recovered account, so a compromised role-bearing wallet can no longer pass any role gate after recovery — including paths that call the helpers directly (onlyFreezeRoles, applyRoles) rather than through onlyRole (BBND-1825).

--- a/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ClearingStorageWrapper.sol
@@ -751,9 +751,9 @@ library ClearingStorageWrapper {
         bytes32 _partition
     ) internal view {
         LockStorageWrapper.requireValidExpirationTimestamp(_expirationTimestamp);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_account);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_to);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_from);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_to);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_from);
         ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(_partition);
         DefaultValueValidation.checkZeroAddress(_from);
         DefaultValueValidation.checkZeroAddress(_to);
@@ -782,9 +782,9 @@ library ClearingStorageWrapper {
     ) internal view {
         LockStorageWrapper.requireValidExpirationTimestamp(_holdExpirationTimestamp);
         LockStorageWrapper.requireValidExpirationTimestamp(_operationExpirationTimestamp);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_account);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_to);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_from);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_to);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_from);
         DefaultValueValidation.checkZeroAddress(_escrow);
         DefaultValueValidation.checkZeroAddress(_from);
         ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(_partition);

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -845,9 +845,9 @@ library HoldStorageWrapper {
         bytes32 _partition
     ) internal view {
         LockStorageWrapper.requireValidExpirationTimestamp(_expirationTimestamp);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_account);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_to);
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_from);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_to);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_from);
         DefaultValueValidation.checkZeroAddress(_from);
         DefaultValueValidation.checkZeroAddress(_escrow);
         ERC1410StorageWrapper.requireDefaultPartitionWithSinglePartition(_partition);

--- a/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
@@ -6,6 +6,7 @@ import { ArrayValidation } from "../../infrastructure/utils/ArrayValidation.sol"
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { IAccessControl } from "../../facets/accessControl/IAccessControl.sol";
+import { ERC3643StorageWrapper } from "./ERC3643StorageWrapper.sol";
 import { DEFAULT_ADMIN_ROLE } from "../../constants/roles.sol";
 
 /// @custom:hash storage AccessControl
@@ -149,20 +150,31 @@ library AccessControlStorageWrapper {
     }
 
     /**
-     * @notice Reverts with `AccountHasNoRole` when `_account` does not hold `_role`.
+     * @notice Reverts with `WalletRecovered` when `_account` has been recovered, or with
+     *         `AccountHasNoRole` when `_account` does not hold `_role`.
+     * @dev Centralised authorization gate: every role-gated path funnels through here (the
+     *      `only*Role` modifiers, `onlyFreezeRoles`, `applyRoles`, `grantRole`, `revokeRole`),
+     *      so rejecting recovered wallets here disables a recovered/lost wallet everywhere a
+     *      single role is required — including paths that call this helper directly rather than
+     *      through a modifier.
      * @param _role    Role required.
      * @param _account Account being checked.
      */
     function checkRole(bytes32 _role, address _account) internal view {
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
         if (!hasRole(_role, _account)) revert IAccessControl.AccountHasNoRole(_account, _role);
     }
 
     /**
-     * @notice Reverts with `AccountHasNoRoles` when `_account` holds none of `_roles`.
+     * @notice Reverts with `WalletRecovered` when `_account` has been recovered, or with
+     *         `AccountHasNoRoles` when `_account` holds none of `_roles`.
+     * @dev Any-of-N counterpart to `checkRole`; same centralised recovered-wallet gate (used by
+     *      `onlyAnyRole` and `onlyFreezeRoles`).
      * @param _roles   Set of acceptable roles for the caller.
      * @param _account Account being checked.
      */
     function checkAnyRole(bytes32[] memory _roles, address _account) internal view {
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
         if (!hasAnyRole(_roles, _account)) revert IAccessControl.AccountHasNoRoles(_account, _roles);
     }
 

--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -344,7 +344,7 @@ library ERC3643StorageWrapper {
      *      wallets (e.g. mint/transfer entry points).
      * @param _account Wallet whose recovery status is being checked.
      */
-    function requireUnrecoveredAddress(address _account) internal view {
+    function checkUnrecoveredAddress(address _account) internal view {
         if (isRecovered(_account)) revert IERC3643Types.WalletRecovered();
     }
 

--- a/packages/ats/contracts/contracts/facets/batchFreeze/BatchFreeze.sol
+++ b/packages/ats/contracts/contracts/facets/batchFreeze/BatchFreeze.sol
@@ -48,7 +48,7 @@ abstract contract BatchFreeze is IBatchFreeze, Modifiers {
         address sender = EvmAccessors.getMsgSender();
         for (uint256 i; i < length; ) {
             DefaultValueValidation.checkZeroAddress(_userAddresses[i]);
-            ERC3643StorageWrapper.requireUnrecoveredAddress(_userAddresses[i]);
+            ERC3643StorageWrapper.checkUnrecoveredAddress(_userAddresses[i]);
             ERC3643StorageWrapper.setAddressFrozen(_userAddresses[i], _freeze[i]);
             emit IFreezeTypes.AddressFrozen(_userAddresses[i], _freeze[i], sender);
             unchecked {
@@ -74,7 +74,7 @@ abstract contract BatchFreeze is IBatchFreeze, Modifiers {
         uint256 length = _userAddresses.length;
         for (uint256 i; i < length; ) {
             DefaultValueValidation.checkZeroAddress(_userAddresses[i]);
-            ERC3643StorageWrapper.requireUnrecoveredAddress(_userAddresses[i]);
+            ERC3643StorageWrapper.checkUnrecoveredAddress(_userAddresses[i]);
             ERC3643StorageWrapper.freezeTokens(_userAddresses[i], _amounts[i]);
             emit IFreezeTypes.TokensFrozen(_userAddresses[i], _amounts[i], _DEFAULT_PARTITION);
             unchecked {
@@ -100,7 +100,7 @@ abstract contract BatchFreeze is IBatchFreeze, Modifiers {
         uint256 length = _userAddresses.length;
         for (uint256 i; i < length; ) {
             DefaultValueValidation.checkZeroAddress(_userAddresses[i]);
-            ERC3643StorageWrapper.requireUnrecoveredAddress(_userAddresses[i]);
+            ERC3643StorageWrapper.checkUnrecoveredAddress(_userAddresses[i]);
             ERC3643StorageWrapper.unfreezeTokens(_userAddresses[i], _amounts[i], 0);
             emit IFreezeTypes.TokensUnfrozen(_userAddresses[i], _amounts[i], _DEFAULT_PARTITION);
             unchecked {

--- a/packages/ats/contracts/contracts/services/asset/ERC3643Modifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/ERC3643Modifiers.sol
@@ -25,7 +25,7 @@ abstract contract ERC3643Modifiers {
      * @param _account The address to validate
      */
     modifier onlyUnrecoveredAddress(address _account) {
-        ERC3643StorageWrapper.requireUnrecoveredAddress(_account);
+        ERC3643StorageWrapper.checkUnrecoveredAddress(_account);
         _;
     }
 

--- a/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
@@ -694,6 +694,41 @@ describe("Recovery Tests", () => {
           asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
+
+      // Recovery does not migrate or revoke the lost wallet's roles; the centralized
+      // checkRole / checkAnyRole guard makes a recovered wallet fail EVERY role-gated path,
+      // including paths that call the helpers directly instead of through `onlyRole`.
+      describe("Recovered wallets fail centralized role checks", () => {
+        it("GIVEN a recovered wallet still holding ROLE_PAUSER WHEN it calls pause (onlyRole) THEN reverts WalletRecovered", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_PAUSER, signer_D.address);
+          await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+
+          // The role is NOT revoked — the wallet is blocked by the recovered-state guard, not by losing the role.
+          expect(await asset.hasRole(ATS_ROLES.ROLE_PAUSER, signer_D.address)).to.equal(true);
+          await expect(asset.connect(signer_D).pause()).to.be.revertedWithCustomError(asset, "WalletRecovered");
+        });
+
+        it("GIVEN a recovered wallet still holding ROLE_FREEZE_MANAGER WHEN it freezes (onlyFreezeRoles → checkAnyRole) THEN reverts WalletRecovered", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_FREEZE_MANAGER, signer_D.address);
+          await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+
+          expect(await asset.hasRole(ATS_ROLES.ROLE_FREEZE_MANAGER, signer_D.address)).to.equal(true);
+          await expect(asset.connect(signer_D).freezePartialTokens(signer_E.address, 1)).to.be.revertedWithCustomError(
+            asset,
+            "WalletRecovered",
+          );
+        });
+
+        it("GIVEN a recovered wallet still holding DEFAULT_ADMIN_ROLE WHEN it calls applyRoles (direct checkRole) THEN reverts WalletRecovered", async () => {
+          await asset.grantRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_D.address);
+          await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+
+          expect(await asset.hasRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_D.address)).to.equal(true);
+          await expect(
+            asset.connect(signer_D).applyRoles([ATS_ROLES.ROLE_LOCKER], [true], signer_E.address),
+          ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Audit Phase 3 finding (BBND-1825): the wallet-recovery flow migrated balances, frozen balances and control-list state from the lost wallet to the new wallet, but did **not** disable the lost wallet's authorization. Its role memberships stayed attached, so a compromised role-bearing wallet could keep calling role-gated functions after `recoveryAddress` completed.

Per the auditor discussion (Priyam ↔ Alberto Molina), the agreed fix is to reject recovered wallets inside the **centralized** authorization helpers rather than migrate roles:

- Add `requireUnrecoveredAddress(_account)` to `AccessControlStorageWrapper.checkRole` **and** `checkAnyRole`. Every role-gated path funnels through these two helpers, so a recovered `msg.sender` now reverts with `WalletRecovered` everywhere — including paths that call the helpers **directly** rather than via `onlyRole`: `onlyAdminRole`, `onlyAnyRole`, `onlyFreezeRoles`, and `applyRoles`.
- Roles are intentionally **not** migrated (avoids the unbounded role-loop / out-of-gas risk on recovery; the new wallet can be granted roles afterwards by any admin).
- No ABI or selector changes.

Known limitation (accepted by the auditors in-thread): if the recovered wallet is the **sole** `DEFAULT_ADMIN_ROLE` holder, disabling it leaves no admin to re-grant roles — to be handled operationally or via a dedicated admin-recovery path (separate concern, not in scope here).

Fixes https://iobuilders.atlassian.net/browse/BBND-1825

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Recovery integration suite — `npx hardhat test test/contracts/integration/recovery/recovery.test.ts` → 17 passing (14 existing + 3 new cases proving a recovered wallet that still holds a role is blocked across all gate kinds: `pause` (onlyRole), `freezePartialTokens` (onlyFreezeRoles → checkAnyRole), and `applyRoles` (direct checkRole)).

Full contracts suite — `npx hardhat test` → 2698 passing, 0 failing (confirms the guard in the centralized `checkRole`/`checkAnyRole` introduces no regressions). Verified after rebasing onto the latest `develop`.

Pre-commit gates — `hardhat compile`, contracts `format` and `lint` all clean.

### Test Results (if any)

17/17 recovery integration tests passing. 2698/2698 full suite passing.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
