### PR TITLE
feat: STANDARD is the new default rate type, instead of NONE, that was removed

### DIFF
--- a/.changeset/remove-none-rate-type.md
+++ b/.changeset/remove-none-rate-type.md
@@ -1,0 +1,11 @@
+---
+"@hashgraph/asset-tokenization-contracts": major
+---
+
+Remove `NONE` from `IInterestRate.RateType`; `STANDARD` is now the EVM default.
+
+The sentinel variant `NONE` (previously at index `0`) has been removed from the `RateType` enum in `IInterestRate`. The enum now contains only `STANDARD`, `FIXED`, and `KPI_LINKED`, with `STANDARD` at index `0`.
+
+As a result, `STANDARD` is the implicit EVM default for any asset whose interest-rate type was never explicitly set — assets deployed without the `InterestRate` facet, or before `initializeInterestRateType` was called, now read as `STANDARD` rather than `NONE`.
+
+Any on-chain storage that previously held `RateType.FIXED` (`2`) or `RateType.KPI_LINKED` (`3`) on already-deployed assets will be misread after an upgrade; a storage migration or re-initialisation is required for those assets.

--- a/docs/ats/api/contracts/facets/IAsset.md
+++ b/docs/ats/api/contracts/facets/IAsset.md
@@ -10977,21 +10977,6 @@ Emitted by `setOperationalStatus` when every facet of the configuration version 
 | configurationId | bytes32 | Resolver-proxy configuration that became operational. |
 | version         | uint256 | Configuration version that became operational.        |
 
-### OperatorAuthorized
-
-```solidity
-event OperatorAuthorized(address indexed operator, address indexed tokenHolder)
-```
-
-Emitted when an operator is authorized by an account for all partitions of the account
-
-#### Parameters
-
-| Name                  | Type    | Description                               |
-| --------------------- | ------- | ----------------------------------------- |
-| operator `indexed`    | address | The account that changed their delegation |
-| tokenHolder `indexed` | address | The account who authorized the operator   |
-
 ### OperatorByPartitionInitialized
 
 ```solidity
@@ -11060,21 +11045,6 @@ event OperatorInitialized()
 Emitted once when the operator capability is initialised on a token.
 
 _Fires exclusively from `initializeOperator`._
-
-### OperatorRevoked
-
-```solidity
-event OperatorRevoked(address indexed operator, address indexed tokenHolder)
-```
-
-Emitted when an operator is revoked by an account for all partitions of the account
-
-#### Parameters
-
-| Name                  | Type    | Description                               |
-| --------------------- | ------- | ----------------------------------------- |
-| operator `indexed`    | address | The account that changed their delegation |
-| tokenHolder `indexed` | address | The account who revoked the operator      |
 
 ### PartitionTransferredAndLocked
 

--- a/docs/ats/api/contracts/facets/IAsset.md
+++ b/docs/ats/api/contracts/facets/IAsset.md
@@ -2488,9 +2488,9 @@ Returns the stored coupon rate type.
 
 #### Returns
 
-| Name | Type                        | Description                                                |
-| ---- | --------------------------- | ---------------------------------------------------------- |
-| \_0  | enum IInterestRate.RateType | The `RateType` value; defaults to `NONE` (0) if never set. |
+| Name | Type                        | Description           |
+| ---- | --------------------------- | --------------------- |
+| \_0  | enum IInterestRate.RateType | The `RateType` value. |
 
 ### getCouponsFor
 
@@ -5614,7 +5614,7 @@ function initializeInterestRateType(enum IInterestRate.RateType rateType) extern
 
 Initializes the coupon rate type during asset deployment.
 
-_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time._
 
 #### Parameters
 
@@ -7811,7 +7811,7 @@ function setCouponRateType(enum IInterestRate.RateType rateType) external nonpay
 
 Sets the coupon rate type discriminator for this asset.
 
-_Requires `ROLE_INTEREST_RATE_MANAGER`. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Requires `ROLE_INTEREST_RATE_MANAGER`._
 
 #### Parameters
 
@@ -10977,6 +10977,21 @@ Emitted by `setOperationalStatus` when every facet of the configuration version 
 | configurationId | bytes32 | Resolver-proxy configuration that became operational. |
 | version         | uint256 | Configuration version that became operational.        |
 
+### OperatorAuthorized
+
+```solidity
+event OperatorAuthorized(address indexed operator, address indexed tokenHolder)
+```
+
+Emitted when an operator is authorized by an account for all partitions of the account
+
+#### Parameters
+
+| Name                  | Type    | Description                               |
+| --------------------- | ------- | ----------------------------------------- |
+| operator `indexed`    | address | The account that changed their delegation |
+| tokenHolder `indexed` | address | The account who authorized the operator   |
+
 ### OperatorByPartitionInitialized
 
 ```solidity
@@ -11045,6 +11060,21 @@ event OperatorInitialized()
 Emitted once when the operator capability is initialised on a token.
 
 _Fires exclusively from `initializeOperator`._
+
+### OperatorRevoked
+
+```solidity
+event OperatorRevoked(address indexed operator, address indexed tokenHolder)
+```
+
+Emitted when an operator is revoked by an account for all partitions of the account
+
+#### Parameters
+
+| Name                  | Type    | Description                               |
+| --------------------- | ------- | ----------------------------------------- |
+| operator `indexed`    | address | The account that changed their delegation |
+| tokenHolder `indexed` | address | The account who revoked the operator      |
 
 ### PartitionTransferredAndLocked
 
@@ -13230,22 +13260,6 @@ Thrown when an account does not hold or is not associated with the specified par
 | --------- | ------- | --------------------------------------------- |
 | account   | address | Address that was checked.                     |
 | partition | bytes32 | Partition that was not found for the account. |
-
-### InvalidRateType
-
-```solidity
-error InvalidRateType(enum IInterestRate.RateType rateType)
-```
-
-Reverts when `NONE` is passed as a rate type.
-
-_`NONE` is reserved as the uninitialized default; it must never be set explicitly._
-
-#### Parameters
-
-| Name     | Type                        | Description                                   |
-| -------- | --------------------------- | --------------------------------------------- |
-| rateType | enum IInterestRate.RateType | The invalid rate type supplied by the caller. |
 
 ### InvalidSender
 

--- a/docs/ats/api/contracts/facets/interestRate/IInterestRate.md
+++ b/docs/ats/api/contracts/facets/interestRate/IInterestRate.md
@@ -20,9 +20,9 @@ Returns the stored coupon rate type.
 
 #### Returns
 
-| Name | Type                        | Description                                                |
-| ---- | --------------------------- | ---------------------------------------------------------- |
-| \_0  | enum IInterestRate.RateType | The `RateType` value; defaults to `NONE` (0) if never set. |
+| Name | Type                        | Description           |
+| ---- | --------------------------- | --------------------- |
+| \_0  | enum IInterestRate.RateType | The `RateType` value. |
 
 ### initializeInterestRateType
 
@@ -32,7 +32,7 @@ function initializeInterestRateType(enum IInterestRate.RateType rateType) extern
 
 Initializes the coupon rate type during asset deployment.
 
-_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time._
 
 #### Parameters
 
@@ -48,7 +48,7 @@ function setCouponRateType(enum IInterestRate.RateType rateType) external nonpay
 
 Sets the coupon rate type discriminator for this asset.
 
-_Requires `ROLE_INTEREST_RATE_MANAGER`. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Requires `ROLE_INTEREST_RATE_MANAGER`._
 
 #### Parameters
 
@@ -88,21 +88,3 @@ _Fires exclusively from `initializeInterestRateType` after the storage write suc
 | Name     | Type                        | Description                 |
 | -------- | --------------------------- | --------------------------- |
 | rateType | enum IInterestRate.RateType | The rate type that was set. |
-
-## Errors
-
-### InvalidRateType
-
-```solidity
-error InvalidRateType(enum IInterestRate.RateType rateType)
-```
-
-Reverts when `NONE` is passed as a rate type.
-
-_`NONE` is reserved as the uninitialized default; it must never be set explicitly._
-
-#### Parameters
-
-| Name     | Type                        | Description                                   |
-| -------- | --------------------------- | --------------------------------------------- |
-| rateType | enum IInterestRate.RateType | The invalid rate type supplied by the caller. |

--- a/docs/ats/api/contracts/facets/interestRate/InterestRate.md
+++ b/docs/ats/api/contracts/facets/interestRate/InterestRate.md
@@ -20,9 +20,9 @@ Returns the stored coupon rate type.
 
 #### Returns
 
-| Name | Type                        | Description                                                |
-| ---- | --------------------------- | ---------------------------------------------------------- |
-| \_0  | enum IInterestRate.RateType | The `RateType` value; defaults to `NONE` (0) if never set. |
+| Name | Type                        | Description           |
+| ---- | --------------------------- | --------------------- |
+| \_0  | enum IInterestRate.RateType | The `RateType` value. |
 
 ### initializeInterestRateType
 
@@ -32,7 +32,7 @@ function initializeInterestRateType(enum IInterestRate.RateType rateType) extern
 
 Initializes the coupon rate type during asset deployment.
 
-_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time._
 
 #### Parameters
 
@@ -48,7 +48,7 @@ function setCouponRateType(enum IInterestRate.RateType rateType) external nonpay
 
 Sets the coupon rate type discriminator for this asset.
 
-_Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)` and `onlyValidRateType`._
+_Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)`._
 
 #### Parameters
 
@@ -143,22 +143,6 @@ Raised when an initialiser tries to register a facet that already has a non-zero
 | ----------- | ------- | -------------------------------------------------------------- |
 | facetId     | bytes32 | Identifier of the offending facet.                             |
 | lastVersion | uint256 | Last version recorded for that facet at the time of the check. |
-
-### InvalidRateType
-
-```solidity
-error InvalidRateType(enum IInterestRate.RateType rateType)
-```
-
-Reverts when `NONE` is passed as a rate type.
-
-_`NONE` is reserved as the uninitialized default; it must never be set explicitly._
-
-#### Parameters
-
-| Name     | Type                        | Description                                   |
-| -------- | --------------------------- | --------------------------------------------- |
-| rateType | enum IInterestRate.RateType | The invalid rate type supplied by the caller. |
 
 ### WalletRecovered
 

--- a/docs/ats/api/contracts/facets/interestRate/InterestRateFacet.md
+++ b/docs/ats/api/contracts/facets/interestRate/InterestRateFacet.md
@@ -20,9 +20,9 @@ Returns the stored coupon rate type.
 
 #### Returns
 
-| Name | Type                        | Description                                                |
-| ---- | --------------------------- | ---------------------------------------------------------- |
-| \_0  | enum IInterestRate.RateType | The `RateType` value; defaults to `NONE` (0) if never set. |
+| Name | Type                        | Description           |
+| ---- | --------------------------- | --------------------- |
+| \_0  | enum IInterestRate.RateType | The `RateType` value. |
 
 ### getStaticFunctionSelectors
 
@@ -74,7 +74,7 @@ function initializeInterestRateType(enum IInterestRate.RateType rateType) extern
 
 Initializes the coupon rate type during asset deployment.
 
-_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time. Reverts with `InvalidRateType` if `rateType` is `NONE`._
+_Intended to be called by the factory immediately after proxy creation. No role required — the factory is trusted at deploy time._
 
 #### Parameters
 
@@ -90,7 +90,7 @@ function setCouponRateType(enum IInterestRate.RateType rateType) external nonpay
 
 Sets the coupon rate type discriminator for this asset.
 
-_Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)` and `onlyValidRateType`._
+_Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)`._
 
 #### Parameters
 
@@ -185,22 +185,6 @@ Raised when an initialiser tries to register a facet that already has a non-zero
 | ----------- | ------- | -------------------------------------------------------------- |
 | facetId     | bytes32 | Identifier of the offending facet.                             |
 | lastVersion | uint256 | Last version recorded for that facet at the time of the check. |
-
-### InvalidRateType
-
-```solidity
-error InvalidRateType(enum IInterestRate.RateType rateType)
-```
-
-Reverts when `NONE` is passed as a rate type.
-
-_`NONE` is reserved as the uninitialized default; it must never be set explicitly._
-
-#### Parameters
-
-| Name     | Type                        | Description                                   |
-| -------- | --------------------------- | --------------------------------------------- |
-| rateType | enum IInterestRate.RateType | The invalid rate type supplied by the caller. |
 
 ### WalletRecovered
 

--- a/packages/ats/contracts/contracts/domain/asset/InterestRateStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/InterestRateStorageWrapper.sol
@@ -169,7 +169,7 @@ library InterestRateStorageWrapper {
 
     /**
      * @notice Returns the stored coupon rate type.
-     * @return rateType_ The `IInterestRate.RateType` value; defaults to `NONE` (0) if never set.
+     * @return rateType_ The `IInterestRate.RateType` value.
      */
     function getCouponRateType() internal view returns (IInterestRate.RateType rateType_) {
         return interestRateTypeStorage().rateType;
@@ -312,17 +312,6 @@ library InterestRateStorageWrapper {
      */
     function getBaseRate() internal view returns (uint256 baseRate_) {
         baseRate_ = kpiLinkedRateStorage().baseRate;
-    }
-
-    /**
-     * @notice Reverts when `NONE` is supplied as the rate type.
-     * @dev `NONE` is the zero-value default reserved for uninitialised assets; it must never
-     *      be set explicitly.
-     * @param _rateType The rate type to validate.
-     * @custom:revert IInterestRate.InvalidRateType If `_rateType` is `NONE`.
-     */
-    function checkValidRateType(IInterestRate.RateType _rateType) internal pure {
-        if (_rateType == IInterestRate.RateType.NONE) revert IInterestRate.InvalidRateType(_rateType);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/coupon/CouponRateDispatch.sol
+++ b/packages/ats/contracts/contracts/domain/asset/coupon/CouponRateDispatch.sol
@@ -27,8 +27,6 @@ library CouponRateDispatch {
      * @notice Resolves the coupon rate at read or listing-trigger time for variants that
      *         compute the rate lazily.
      * @dev Rate-type dispatch:
-     *      - NONE: rate was forced to (0, 0) at write time — no override needed here.
-     *              Returns shouldOverride_=false.
      *      - STANDARD: user-supplied rate is already SET — no override needed here.
      *              Returns shouldOverride_=false.
      *      - FIXED: rate was stamped at write time — no override needed here.
@@ -50,14 +48,12 @@ library CouponRateDispatch {
                 .calculateKpiLinkedInterestRate(couponID, coupon);
         }
         return resolvedCoupon_;
-        // NONE, STANDARD, FIXED: rate is owned at write time; no action needed at read/trigger time.
+        // STANDARD, FIXED: rate is owned at write time; no action needed at read/trigger time.
     }
 
     /**
      * @notice Validates and stamps the coupon rate at creation (write) time.
      * @dev Rate-type dispatch:
-     *      - NONE: forces rate to (0, 0) with status SET, regardless of user input.
-     *              No coupon payments will ever be owed for this asset.
      *      - FIXED: rejects any non-pending rate triplet, then stamps the rate from storage.
      *              Returns (0, 0) if the fixed-rate facet has not been initialized.
      *      - KPI_LINKED: rejects any non-pending rate triplet; rate stays PENDING and is
@@ -73,13 +69,6 @@ library CouponRateDispatch {
     ) internal view returns (ICouponTypes.Coupon memory resolved_) {
         IInterestRate.RateType rateType = InterestRateStorageWrapper.getCouponRateType();
         resolved_ = newCoupon;
-
-        if (rateType == IInterestRate.RateType.NONE) {
-            resolved_.rate = 0;
-            resolved_.rateDecimals = 0;
-            resolved_.rateStatus = ICouponTypes.RateCalculationStatus.SET;
-            return resolved_;
-        }
 
         if (rateType == IInterestRate.RateType.FIXED) {
             if (!_isPendingRate(resolved_)) revert IFixedRate.InterestRateIsFixed();

--- a/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/coupon/CouponStorageWrapper.sol
@@ -64,7 +64,7 @@ library CouponStorageWrapper {
      * @return couponID_ One-indexed identifier assigned to the new coupon.
      * @return resolved_ The persisted coupon after variant-specific rate stamping (input
      *         struct unchanged for the STANDARD / KPI_LINKED variants; `rate`,
-     *         `rateDecimals`, `rateStatus` overwritten for FIXED and forced to zero for NONE).
+     *         `rateDecimals`, `rateStatus` overwritten for FIXED).
      */
     function setCoupon(
         ICouponTypes.Coupon memory newCoupon
@@ -225,7 +225,7 @@ library CouponStorageWrapper {
      * @dev Returns the coupon's associated corporate-action identifier and
      *      cancellation flag. For STANDARD and KPI_LINKED coupons, or when the
      *      fixing date has not yet occurred, returns the coupon unchanged.
-     *      For FIXED and NONE coupons, or when rate resolution applies,
+     *      For FIXED, or when rate resolution applies,
      *      delegates to `CouponRateDispatch.resolveRate` to compute the
      *      effective rate and optionally update it in-memory.
      * @param couponID One-indexed coupon identifier.

--- a/packages/ats/contracts/contracts/facets/interestRate/IInterestRate.sol
+++ b/packages/ats/contracts/contracts/facets/interestRate/IInterestRate.sol
@@ -16,13 +16,12 @@ bytes32 constant RESOLVER_KEY_INTEREST_RATE = 0xc09a5111a37fc8806e149b4a20c17a33
 interface IInterestRate {
     /**
      * @notice Discriminator that selects which coupon-rate formula is applied.
-     * @dev NONE (0) is the implicit default when no rate type has been set.
+     * @dev STANDARD (0) is the implicit default when no rate type has been set.
      *      It forces the coupon rate to (0, 0) regardless of any facet state.
      *      The admin must call `setCouponRateType` with STANDARD, FIXED, or KPI_LINKED
      *      to enable coupon payments on the asset.
      */
     enum RateType {
-        NONE,
         STANDARD,
         FIXED,
         KPI_LINKED
@@ -43,17 +42,9 @@ interface IInterestRate {
     event CouponRateTypeSet(address indexed operator, RateType rateType);
 
     /**
-     * @notice Reverts when `NONE` is passed as a rate type.
-     * @dev `NONE` is reserved as the uninitialized default; it must never be set explicitly.
-     * @param rateType The invalid rate type supplied by the caller.
-     */
-    error InvalidRateType(RateType rateType);
-
-    /**
      * @notice Initializes the coupon rate type during asset deployment.
      * @dev Intended to be called by the factory immediately after proxy creation.
      *      No role required — the factory is trusted at deploy time.
-     *      Reverts with `InvalidRateType` if `rateType` is `NONE`.
      * @param rateType The `RateType` to persist (STANDARD, FIXED, or KPI_LINKED).
      */
     function initializeInterestRateType(RateType rateType) external;
@@ -61,14 +52,13 @@ interface IInterestRate {
     /**
      * @notice Sets the coupon rate type discriminator for this asset.
      * @dev Requires `ROLE_INTEREST_RATE_MANAGER`.
-     *      Reverts with `InvalidRateType` if `rateType` is `NONE`.
      * @param rateType The `RateType` to persist (STANDARD, FIXED, or KPI_LINKED).
      */
     function setCouponRateType(RateType rateType) external;
 
     /**
      * @notice Returns the stored coupon rate type.
-     * @return The `RateType` value; defaults to `NONE` (0) if never set.
+     * @return The `RateType` value.
      */
     function getCouponRateType() external view returns (RateType);
 }

--- a/packages/ats/contracts/contracts/facets/interestRate/InterestRate.sol
+++ b/packages/ats/contracts/contracts/facets/interestRate/InterestRate.sol
@@ -20,23 +20,17 @@ abstract contract InterestRate is IInterestRate, Modifiers {
     /// @inheritdoc IInterestRate
     function initializeInterestRateType(
         IInterestRate.RateType rateType
-    )
-        external
-        override
-        onlyRole(DEFAULT_ADMIN_ROLE)
-        onlyFacetNotRegistered(RESOLVER_KEY_INTEREST_RATE)
-        onlyValidRateType(rateType)
-    {
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) onlyFacetNotRegistered(RESOLVER_KEY_INTEREST_RATE) {
         InterestRateStorageWrapper.initializeCouponRateType(rateType);
         InitializerStorageWrapper.setFacetToReady(RESOLVER_KEY_INTEREST_RATE);
         emit IInterestRate.InterestRateTypeInitialized(rateType);
     }
 
     /// @inheritdoc IInterestRate
-    /// @dev Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)` and `onlyValidRateType`.
+    /// @dev Protected by `onlyRole(ROLE_INTEREST_RATE_MANAGER)`.
     function setCouponRateType(
         IInterestRate.RateType rateType
-    ) external override onlyOperational onlyActivated onlyRole(ROLE_INTEREST_RATE_MANAGER) onlyValidRateType(rateType) {
+    ) external override onlyOperational onlyActivated onlyRole(ROLE_INTEREST_RATE_MANAGER) {
         // TODO: check if changing the rate type is allowed after existing coupons have been issued
         InterestRateStorageWrapper.setCouponRateType(rateType);
         emit CouponRateTypeSet(EvmAccessors.getMsgSender(), rateType);

--- a/packages/ats/contracts/contracts/services/asset/InterestRateModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/InterestRateModifiers.sol
@@ -32,14 +32,4 @@ abstract contract InterestRateModifiers {
         InterestRateStorageWrapper.requireValidImpactData(_newImpactData);
         _;
     }
-
-    /**
-     * @notice Modifier that reverts when `NONE` is supplied as the rate type.
-     * @dev `NONE` is the zero-value default reserved for uninitialised assets.
-     * @param rateType The rate type to validate.
-     */
-    modifier onlyValidRateType(IInterestRate.RateType rateType) {
-        InterestRateStorageWrapper.checkValidRateType(rateType);
-        _;
-    }
 }

--- a/packages/ats/contracts/test/contracts/integration/interestRate/InterestRateFacet.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/interestRate/InterestRateFacet.test.ts
@@ -10,10 +10,9 @@ import { deployBondFixedRateTokenFixture, deployBondTokenFixture, executeRbac } 
 
 // Must match ICouponTypes.RateType order
 enum RateType {
-  NONE = 0,
-  STANDARD = 1,
-  FIXED = 2,
-  KPI_LINKED = 3,
+  STANDARD = 0,
+  FIXED = 1,
+  KPI_LINKED = 2,
 }
 
 describe("InterestRateFacet Tests", () => {
@@ -70,13 +69,6 @@ describe("InterestRateFacet Tests", () => {
         .withArgs(admin.address, RateType.STANDARD);
 
       expect(await asset.getCouponRateType()).to.equal(RateType.STANDARD);
-    });
-
-    it("GIVEN admin WHEN setCouponRateType(NONE) THEN reverts with InvalidRateType", async () => {
-      await expect(asset.connect(admin).setCouponRateType(RateType.NONE)).to.be.revertedWithCustomError(
-        asset,
-        "InvalidRateType",
-      );
     });
 
     it("GIVEN non-admin WHEN setCouponRateType THEN reverts with AccountHasNoRole", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
@@ -123,7 +123,7 @@ describe("Fixed Rate Tests", () => {
     });
 
     it("GIVEN non-operational asset WHEN setCouponRateType THEN reverts with AssetNotOperational", async () => {
-      await expect(asset.setCouponRateType(2)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
+      await expect(asset.setCouponRateType(1)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
     });
 
     it("GIVEN non-operational asset WHEN setRate THEN reverts with AssetNotOperational", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/fixedRate/fixedRate.test.ts
@@ -10,6 +10,8 @@ import { DEFAULT_BOND_FIXED_RATE_PARAMS, deployBondFixedRateTokenFixture } from 
 import { executeRbac } from "@test";
 
 describe("Fixed Rate Tests", () => {
+  const FIXED_INTEREST_RATE_TYPE = 1;
+
   let diamond: ResolverProxy;
   let signer_A: HardhatEthersSigner;
   let signer_B: HardhatEthersSigner;
@@ -123,7 +125,10 @@ describe("Fixed Rate Tests", () => {
     });
 
     it("GIVEN non-operational asset WHEN setCouponRateType THEN reverts with AssetNotOperational", async () => {
-      await expect(asset.setCouponRateType(1)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
+      await expect(asset.setCouponRateType(FIXED_INTEREST_RATE_TYPE)).to.be.revertedWithCustomError(
+        asset,
+        "AssetNotOperational",
+      );
     });
 
     it("GIVEN non-operational asset WHEN setRate THEN reverts with AssetNotOperational", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -432,7 +432,7 @@ describe("Kpi Linked Rate Tests", () => {
     });
 
     it("GIVEN non-operational asset WHEN setCouponRateType THEN reverts with AssetNotOperational", async () => {
-      await expect(asset.setCouponRateType(3)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
+      await expect(asset.setCouponRateType(2)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
     });
 
     it("GIVEN non-operational asset WHEN setKpiLinkedRateImpactData THEN reverts with AssetNotOperational", async () => {

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -9,6 +9,8 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { DEFAULT_BOND_KPI_LINKED_RATE_PARAMS, deployBondKpiLinkedRateTokenFixture, executeRbac } from "@test";
 
 describe("Kpi Linked Rate Tests", () => {
+  const KPI_INTEREST_RATE_TYPE = 2;
+
   let diamond: ResolverProxy;
   let signer_A: HardhatEthersSigner;
   let signer_B: HardhatEthersSigner;
@@ -432,7 +434,10 @@ describe("Kpi Linked Rate Tests", () => {
     });
 
     it("GIVEN non-operational asset WHEN setCouponRateType THEN reverts with AssetNotOperational", async () => {
-      await expect(asset.setCouponRateType(2)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
+      await expect(asset.setCouponRateType(KPI_INTEREST_RATE_TYPE)).to.be.revertedWithCustomError(
+        asset,
+        "AssetNotOperational",
+      );
     });
 
     it("GIVEN non-operational asset WHEN setKpiLinkedRateImpactData THEN reverts with AssetNotOperational", async () => {


### PR DESCRIPTION
## Description

Remove `NONE` from `IInterestRate.RateType`; `STANDARD` is now the EVM default.

The sentinel variant `NONE` (previously at index `0`) has been removed from the `RateType` enum in `IInterestRate`. The enum now contains only `STANDARD`, `FIXED`, and `KPI_LINKED`, with `STANDARD` at index `0`.

As a result, `STANDARD` is the implicit EVM default for any asset whose interest-rate type was never explicitly set — assets deployed without the `InterestRate` facet, or before `initializeInterestRateType` was called, now read as `STANDARD` rather than `NONE`.

Any on-chain storage that previously held `RateType.FIXED` (`2`) or `RateType.KPI_LINKED` (`3`) on already-deployed assets will be misread after an upgrade; a storage migration or re-initialisation is required for those assets.


## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
