### PR TITLE
chore: changeset changelog formatter, body lint, and split CI gate

### DIFF
--- a/.changeset/changelog.cjs
+++ b/.changeset/changelog.cjs
@@ -1,0 +1,64 @@
+// Custom Changesets changelog formatter. Two responsibilities:
+//
+//  1. getDependencyReleaseLine — collapse the per-changeset
+//     `- Updated dependencies [<hash>]` wall into a single resolved line per
+//     release. The ATS packages share a fixed-version group, so those per-hash
+//     lines are noise that duplicates the upstream package's own changelog.
+//
+//  2. getReleaseLine — sanitise each changeset body before it is written, so a
+//     messy changeset (markdown headers, bold-as-heading, fenced blocks, blank
+//     runs) still yields a clean CHANGELOG.md entry. The CI lint
+//     (.changeset/lint-changesets.mjs) rejects these at PR time; this is the
+//     belt-and-braces backstop at generation time. House style lives in
+//     .claude/rules/40-package/versioning.md.
+//
+// Reuses @changesets/changelog-git (the implementation behind the default
+// `@changesets/cli/changelog`) for the actual line rendering.
+
+const git = require("@changesets/changelog-git").default;
+
+function sanitiseSummary(summary) {
+  const out = [];
+  let inFence = false;
+  for (let line of summary.split("\n")) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence; // drop the fence markers, keep any inner lines as prose
+      continue;
+    }
+    if (!inFence) {
+      if (/^\s*\|[\s:|-]+\|\s*$/.test(line)) continue; // drop table separator rows
+      if (/^\s*\|.*\|\s*$/.test(line)) {
+        // turn a table row into a "-" bullet of em-dash-joined cells
+        const cells = line
+          .trim()
+          .replace(/^\||\|$/g, "")
+          .split("|")
+          .map((cell) => cell.trim())
+          .filter(Boolean);
+        line = `- ${cells.join(" — ")}`;
+      } else {
+        line = line.replace(/^(\s*)#{1,6}\s+/, "$1"); // demote headers to plain text
+        line = line.replace(
+          /^(\s*)\*\*(.+?)\*\*\s*$/,
+          (_m, indent, text) => `${indent}${text.replace(/\s*:?\s*$/, "")}:`,
+        ); // un-bold a standalone heading line into a plain "Label:" prefix
+      }
+    }
+    out.push(line);
+  }
+  return out
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+module.exports = {
+  getReleaseLine: (changeset, type, options) =>
+    git.getReleaseLine({ ...changeset, summary: sanitiseSummary(changeset.summary) }, type, options),
+
+  getDependencyReleaseLine: async (_changesets, dependenciesUpdated) => {
+    if (dependenciesUpdated.length === 0) return "";
+    const lines = dependenciesUpdated.map((dependency) => `  - ${dependency.name}@${dependency.newVersion}`);
+    return ["- Updated dependencies:", ...lines].join("\n");
+  },
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./changelog.cjs",
   "commit": false,
   "fixed": [
     [

--- a/.changeset/lint-changesets.mjs
+++ b/.changeset/lint-changesets.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Lints changeset bodies for changelog-hostile formatting before they are merged.
+// House style: plain prose + "-" bullets only — see
+// .claude/rules/40-package/versioning.md. Exits non-zero on any violation so the
+// changeset-check CI gate can block the PR before a messy entry reaches a
+// generated CHANGELOG.md. Pure Node (no dependencies); pass changeset file paths
+// as arguments.
+
+import { readFileSync } from "node:fs";
+
+const MAX_BODY_LINES = 12; // a changeset is one changelog line-item, not a design doc
+
+const files = process.argv.slice(2).filter(Boolean);
+if (files.length === 0) {
+  console.log("No changeset files to lint.");
+  process.exit(0);
+}
+
+let totalViolations = 0;
+
+for (const file of files) {
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    continue; // file was removed in a later commit of the PR; nothing to lint
+  }
+
+  const lines = raw.split("\n");
+  // Body = everything after the second front-matter delimiter.
+  const delims = [];
+  lines.forEach((line, i) => {
+    if (line.trim() === "---") delims.push(i);
+  });
+  const bodyStart = delims.length >= 2 ? delims[1] + 1 : 0;
+  const body = lines.slice(bodyStart);
+
+  const violations = [];
+  let inFence = false;
+  body.forEach((line, idx) => {
+    const lineNo = bodyStart + idx + 1; // 1-based line number within the file
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      violations.push([lineNo, "fenced code block (```) — use inline `code` or prose"]);
+      return;
+    }
+    if (inFence) return;
+    if (/^\s*#{1,6}\s/.test(line))
+      violations.push([lineNo, "markdown header (#/##/###) — inverts the changelog outline; use plain prose"]);
+    if (/^\s*\|.*\|/.test(line)) violations.push([lineNo, "table row (| … |) — use a '-' bullet list"]);
+    if (/^\s*\*\*[^*]+\*\*:?\s*$/.test(line))
+      violations.push([lineNo, "bold-as-heading (**Label**) — fold into prose, e.g. 'Label: …'"]);
+  });
+
+  const nonEmpty = body.filter((line) => line.trim() !== "");
+  if (nonEmpty.length > MAX_BODY_LINES)
+    violations.push([
+      null,
+      `body has ${nonEmpty.length} non-empty lines (max ${MAX_BODY_LINES}) — condense to a headline plus a few bullets; detail belongs in the PR/commit`,
+    ]);
+
+  if (violations.length) {
+    totalViolations += violations.length;
+    console.error(`\n✖ ${file}`);
+    for (const [lineNo, message] of violations) console.error(`  ${lineNo ? `line ${lineNo}: ` : ""}${message}`);
+  } else {
+    console.log(`✓ ${file}`);
+  }
+}
+
+if (totalViolations) {
+  console.error(`\n❌ ${totalViolations} changeset formatting violation(s).`);
+  console.error(
+    "House style: plain prose + '-' bullets only — no headers, tables, fenced blocks, or bold-as-heading; keep it short.",
+  );
+  console.error("See .claude/rules/40-package/versioning.md.");
+  process.exit(1);
+}
+
+console.log("\n✅ Changeset formatting OK.");

--- a/.github/workflows/000-flow-changeset-check.yaml
+++ b/.github/workflows/000-flow-changeset-check.yaml
@@ -74,31 +74,32 @@ jobs:
             echo "🔍 No bypass labels found. Changeset check required."
           fi
 
-      - name: Install dependencies
-        if: ${{ steps.bypass.outputs.bypass == 'false' }}
-        run: npm ci
-
-      - name: Check changeset status
-        if: ${{ steps.bypass.outputs.bypass == 'false' }}
+      - name: Detect changesets in this PR
+        id: detect
         env:
           BASE_BRANCH: ${{ github.base_ref }}
         run: |
-          echo "🔍 Checking for NEW changesets in this PR..."
-          echo "Comparing HEAD against base branch: ${BASE_BRANCH}"
+          # New or modified changeset files introduced by this PR (the author's own).
+          NEW_CHANGESETS=$(git diff "${BASE_BRANCH}...HEAD" --name-only --diff-filter=AM \
+            | { grep -E "^\.changeset/.*\.md$" || true; } | { grep -v "README.md" || true; })
+          NEW_COUNT=$(printf '%s\n' "${NEW_CHANGESETS}" | { grep -c "\.md$" || true; })
 
-          NEW_CHANGESETS=$(git diff "${BASE_BRANCH}...HEAD" --name-only --diff-filter=A | grep "^\.changeset/.*\.md$" | grep -v "README.md" || true)
-          NEW_CHANGESET_COUNT=$(echo "${NEW_CHANGESETS}" | grep -c "\.md$" || true)
+          # Any pending changeset files present in the tree (excluding README).
+          PENDING_COUNT=$(ls .changeset/*.md 2>/dev/null | { grep -v "README.md" || true; } | { grep -c "\.md$" || true; })
 
-          echo "Files changed in PR:"
-          git diff "${BASE_BRANCH}...HEAD" --name-only --diff-filter=A | head -10
-          echo ""
-          echo "NEW changeset files in this PR: ${NEW_CHANGESET_COUNT}"
+          echo "new_count=${NEW_COUNT}" >> "${GITHUB_OUTPUT}"
+          echo "pending_count=${PENDING_COUNT}" >> "${GITHUB_OUTPUT}"
+
+          echo "New/modified changesets in this PR: ${NEW_COUNT}"
           if [[ -n "${NEW_CHANGESETS}" ]]; then
-            echo "Found NEW changesets:"
             echo "${NEW_CHANGESETS}"
           fi
+          echo "Pending changeset files in tree: ${PENDING_COUNT}"
 
-          if [[ "${NEW_CHANGESET_COUNT}" -gt 0 ]]; then
+      - name: Require a changeset (waived by bypass labels)
+        if: ${{ steps.bypass.outputs.bypass == 'false' }}
+        run: |
+          if [[ "${{ steps.detect.outputs.new_count }}" -gt 0 ]]; then
             echo "✅ Changeset validation passed - found NEW changeset files in PR"
           else
             echo ""
@@ -121,12 +122,21 @@ jobs:
             echo "- chore: For build system or dependency updates"
             echo "- hotfix: For emergency fixes"
             echo ""
+            echo "Note: bypass labels waive the *requirement* to add a changeset, but any"
+            echo "changeset you DO include is still validated and lint-checked below."
+            echo ""
             echo "More info: https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md"
             exit 1
           fi
 
-      - name: Validate changeset contents
-        if: ${{ steps.bypass.outputs.bypass == 'false' }}
+      - name: Install dependencies
+        # Needed for `changeset status`; runs whenever changesets exist, even under a bypass label.
+        if: ${{ steps.detect.outputs.pending_count != '0' }}
+        run: npm ci
+
+      - name: Validate changeset package names
+        # Runs whenever changesets exist (bypass or not) so a labelled PR cannot slip an invalid changeset through.
+        if: ${{ steps.detect.outputs.pending_count != '0' }}
         run: |
           echo "🔍 Validating that all pending changesets reference known workspace packages..."
           if ! npx changeset status; then
@@ -144,6 +154,17 @@ jobs:
             exit 1
           fi
           echo "✅ All pending changesets reference valid workspace packages"
+
+      - name: Lint changeset body formatting
+        # Runs whenever this PR adds/edits changesets (bypass or not) to keep generated changelogs clean.
+        if: ${{ steps.detect.outputs.new_count != '0' }}
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          mapfile -t FILES < <(git diff "${BASE_BRANCH}...HEAD" --name-only --diff-filter=AM \
+            | { grep -E "^\.changeset/.*\.md$" || true; } | { grep -v "README.md" || true; })
+          echo "Linting ${#FILES[@]} changeset file(s)..."
+          node .changeset/lint-changesets.mjs "${FILES[@]}"
 
       - name: Success summary
         if: ${{ always() }}


### PR DESCRIPTION
## Description

Follow-up hardening to the v8.0.0 changelog cleanup (PR #1292) to stop changelog bloat recurring. Adds a custom @changesets changelog formatter (`.changeset/changelog.cjs`) that (a) collapses the per-hash "Updated dependencies" wall to one resolved line per release, and (b) sanitises changeset bodies at generation time (demotes stray headers, un-bolds heading lines, strips fenced blocks and tables, collapses blank runs). Adds a zero-dependency body lint (`.changeset/lint-changesets.mjs`) and wires it into `000-flow-changeset-check.yaml`, splitting the gate so bypass labels waive only the *requirement* to add a changeset, while any changeset that IS present is still package-name-validated and body-lint-checked — closing the gap where a bypass label previously skipped all checks.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

- Body-lint dry-run: fails a deliberately messy changeset (8 violations — markdown header, bold-as-heading, table rows, fenced block, >12 lines) and passes a clean one (no false positives).
- Formatter dry-run: sanitises the same messy body (headers→prose, bold→plain label, table→bullets, fence stripped) and collapses dependency lines to a single resolved line; a normal one-line entry is unchanged.
- Workflow YAML validated (parses; step order verified) and `prettier --check` clean on the new tooling files. No product/runtime code touched.

### Test Results (if any)

All dry-run checks passed. No product or runtime code was modified.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅