### PR TITLE
ci: add solhint warning ratchet for ATS contracts

### DIFF
--- a/.github/workflows/103-flow-ats-lint.yaml
+++ b/.github/workflows/103-flow-ats-lint.yaml
@@ -1,4 +1,4 @@
-name: "103: [FLOW] ATS Lint and Format"
+name: "103: [FLOW] ATS Format and Lint"
 
 on:
   pull_request:
@@ -11,6 +11,10 @@ on:
       - ".github/workflows/800-call-lint-format.yaml"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 permissions:
   contents: read
 
@@ -19,8 +23,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-and-format:
-    name: lint-and-format
+  format-and-lint:
+    name: format-and-lint
     uses: ./.github/workflows/800-call-lint-format.yaml
     with:
       module: ats
+
+  # Solhint warning ratchet for packages/ats/contracts: the warning count may only
+  # stay equal or decrease, never increase. Two read-only checks (no push-back):
+  #   1. `betterer ci` — the committed .betterer.results matches the actual code.
+  #   2. check-ratchet-vs-base.ts — per-rule counts are not worse than the base
+  #      branch's (blocks an upward re-baseline that check 1 alone would accept).
+  # The baseline is maintained locally by the contracts `lint`/`lint:fix` scripts.
+  lint-ratchet:
+    name: lint-ratchet
+    runs-on: token-studio-linux-medium
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Need the base branch ref reachable so the base comparison can read
+          # its committed .betterer.results via `git show`.
+          fetch-depth: 0
+
+      - name: Setup NodeJS Environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # betterer runs solhint, whose accessor generator imports @contract-types
+      # (TypeChain). npm ci does not build it (ignore-scripts skips prepare), so
+      # compile first to emit typechain-types/ before the ratchet check.
+      - name: Build TypeChain types
+        run: npm run compile --workspace=packages/ats/contracts
+
+      - name: Check baseline is honest (betterer ci)
+        run: npm run lint:ratchet --workspace=packages/ats/contracts
+
+      - name: Check baseline is not worse than base branch
+        run: npx tsx packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts "${{ github.base_ref }}"

--- a/.github/workflows/104-flow-mp-lint.yaml
+++ b/.github/workflows/104-flow-mp-lint.yaml
@@ -1,4 +1,4 @@
-name: "104: [FLOW] MP Lint and Format"
+name: "104: [FLOW] MP Format and Lint"
 
 on:
   pull_request:
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-and-format:
-    name: lint-and-format
+  format-and-lint:
+    name: format-and-lint
     uses: ./.github/workflows/800-call-lint-format.yaml
     with:
       module: mass-payout

--- a/.github/workflows/800-call-lint-format.yaml
+++ b/.github/workflows/800-call-lint-format.yaml
@@ -26,8 +26,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-format:
-    name: lint-and-format
+  format-and-lint:
+    name: format-and-lint
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4530,6 +4530,621 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@betterer/betterer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@betterer/betterer/-/betterer-5.4.0.tgz",
+      "integrity": "sha512-t91JDLdUv5t70TPn1rzTiYA2WhtehDV23/KKkePMDo2Q/7QaHyHiTDG40+BnDh9LB7bW0Q4jOZXClf0tupOXNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@betterer/constraints": "^5.3.0",
+        "@betterer/errors": "^5.3.0",
+        "@betterer/logger": "^5.3.4",
+        "@betterer/reporter": "^5.4.0",
+        "@phenomnomnominal/debug": "^0.2.5",
+        "@phenomnomnominal/worker-require": "^0.0.34",
+        "chokidar": "^3.3.1",
+        "djb2a": "^1.2.0",
+        "fast-memoize": "^2.5.2",
+        "lines-and-columns": "^2.0.3",
+        "minimatch": "^5.0.1",
+        "prettier": "^2.3.2",
+        "simple-git": "^3.6.0",
+        "ts-node": "^10.2.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/@betterer/betterer/node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@betterer/betterer/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@betterer/betterer/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/cli": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@betterer/cli/-/cli-5.4.0.tgz",
+      "integrity": "sha512-FtXbNLoxsg54w9LQWngXNuGNZj8BHG9qPv6r2Hvr5FYw1ZblAsTW9Vya9NlbOtSxIVrVf/aM9FVTIltTPhFHfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@betterer/betterer": "^5.4.0",
+        "@betterer/errors": "^5.3.0",
+        "@betterer/render": "^5.3.4",
+        "@betterer/tasks": "^5.3.6",
+        "@phenomnomnominal/tsquery": "^4.1.1",
+        "@phenomnomnominal/tstemplate": "^0.1.0",
+        "@phenomnomnominal/worker-require": "^0.0.34",
+        "chalk": "^4.1.2",
+        "commander": "^8.3.0",
+        "find-up": "^5.0.0",
+        "jest-diff": "^27.1.0",
+        "prettier": "^2.3.2",
+        "tslib": "^2.3.1"
+      },
+      "bin": {
+        "betterer": "bin/betterer"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/@phenomnomnominal/tsquery": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.2.0.tgz",
+      "integrity": "sha512-hR2U3uVcrrdkuG30ItQ+uFDs4ncZAybxWG0OjTE8ptPzVoU7GVeXpy+vMU8zX9EbmjGeITPw/su5HjYQyAH8bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esquery": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "^3 || ^4"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@betterer/cli/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/diff-sequences": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/jest-diff": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/jest-get-type": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/cli/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@betterer/cli/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@betterer/constraints": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@betterer/constraints/-/constraints-5.3.0.tgz",
+      "integrity": "sha512-YmaX30/S4PoYDqGspRmUBeBE1KkLbnSQCndqPar7ZH6sWOIo29d67B7as6ODEmwpJf+GGYfmrGtTJd5c69hTng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/errors": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@betterer/errors/-/errors-5.3.0.tgz",
+      "integrity": "sha512-Z4uCvA2oSuyEHNgIgMUo+WqIP/xwy40mGmkM/cJXLWWQOTOfzELa5CNgyz4t4XNebojko2bja8n2zaXlTUzViw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/logger": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@betterer/logger/-/logger-5.3.4.tgz",
+      "integrity": "sha512-Ns4KsZ5G0F5BsBF8K0VkmAUfEGKhgog9kv8QCKuZQQNcPAX5cESIYSeEs5H4bcMDqsk0dW/sQRt/7rZWGlrFSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.3",
+        "jest-diff": "^27.0.6",
+        "lines-and-columns": "^2.0.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@betterer/logger/node_modules/diff-sequences": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/jest-diff": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/jest-get-type": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/logger/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@betterer/render": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/@betterer/render/-/render-5.3.4.tgz",
+      "integrity": "sha512-zc91zlLxWafGxG25/kUsCDmxLvQhUb4PNIq4MRU/VpnncyhdelMY5OxaIAxu9IXhJFoC6FRJhL3I7eGdND64zQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/reporter": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@betterer/reporter/-/reporter-5.4.0.tgz",
+      "integrity": "sha512-+NB/zDkPv4q4oObWhvVpKghskf0K520NIm8rjfoBPAm75Y/PHWh2JSBeTSo6li25HRdvF5wZ+8tIJr1UAennmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@betterer/betterer": "^5.4.0",
+        "@betterer/errors": "^5.3.0",
+        "@betterer/logger": "^5.3.4",
+        "@betterer/render": "^5.3.4",
+        "@betterer/tasks": "^5.3.6",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/tasks": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@betterer/tasks/-/tasks-5.3.6.tgz",
+      "integrity": "sha512-UBx+My23z/q4deq5WPGNPDO/8OoK7epPpQftgaD8r1UXeD10aaV8BmjQ70Yjw/EQWDqVBBkDdbwmwspMOHjoMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@betterer/errors": "^5.3.0",
+        "@betterer/logger": "^5.3.4",
+        "@betterer/render": "^5.3.4",
+        "chalk": "^4.1.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@betterer/tasks/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/tasks/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@betterer/tasks/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@betterer/tasks/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
@@ -13048,6 +13663,23 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -15566,6 +16198,45 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@phenomnomnominal/debug": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/debug/-/debug-0.2.5.tgz",
+      "integrity": "sha512-5yAKsIqcvKUiTYfsEXTt6wiNW2jWVEpa6ej8RSPSRV681av1APBK+2BpEIdOo9DAmq2bwq45Ry3zi/wxBjndaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0",
+        "esprima": "^4.0.1",
+        "esquery": "^1.3.1",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/@phenomnomnominal/tstemplate": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tstemplate/-/tstemplate-0.1.0.tgz",
+      "integrity": "sha512-/v+GIVNFHAz4+nQtgy9e5ZAXK3xj6TbP5s9JTpnFuqkcLB+gB2lJ6x/nsDhkKhzR6o4REuzhsYoWYnXqKC/UnQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@phenomnomnominal/worker-require": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/worker-require/-/worker-require-0.0.34.tgz",
+      "integrity": "sha512-2GoVa1PRjrCjOpbMdzsZMQzkx/yFKqWizZc+ZNYSWE+Ym8BG+qAGDcWehUmUmGqy22wS13qitdVt6sR/DAWkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsite": "^1.0.0",
+        "comlink": "^4.3.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@phenomnomnominal/worker-require/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/@phosphor-icons/react": {
       "version": "2.0.9",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.0.9.tgz",
@@ -17795,6 +18466,23 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
@@ -27249,6 +27937,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -31044,6 +31741,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/djb2a": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/djb2a/-/djb2a-1.2.0.tgz",
+      "integrity": "sha512-rXrJYOPCGvHPYw8R2u/zczFTG3xXNqklrtT17vTPm8n/4a16PKEhrfgMwJ9Zyuz96PJwZzHuK2ChQO/SSChuKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -34110,6 +34817,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-redact": {
@@ -53363,6 +54077,24 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/sinon": {
       "version": "21.0.3",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.3.tgz",
@@ -62099,6 +62831,8 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@betterer/betterer": "5.4.0",
+        "@betterer/cli": "5.4.0",
         "@hashgraph/eslint-config": "*",
         "@hashgraph/sdk": "2.64.5",
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",

--- a/packages/ats/contracts/.betterer.results
+++ b/packages/ats/contracts/.betterer.results
@@ -1,0 +1,316 @@
+// BETTERER RESULTS V2.
+// 
+// If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
+// https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
+//
+exports[`ats contracts solhint`] = {
+  value: `{
+    "contracts/domain/asset/AmortizationStorageWrapper.sol:2444797827": [
+      [117, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [155, 4, 1, "function-max-lines: Function body contains 53 lines but allowed no more than 50 lines", "177603"],
+      [403, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [428, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
+    ],
+    "contracts/domain/asset/ClearingStorageWrapper.sol:657877060": [
+      [720, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
+    ],
+    "contracts/domain/asset/DividendStorageWrapper.sol:1104421331": [
+      [68, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [246, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [264, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
+    ],
+    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:1519984577": [
+      [298, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"],
+      [309, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"]
+    ],
+    "contracts/domain/asset/HoldStorageWrapper.sol:533726159": [
+      [800, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
+    ],
+    "contracts/domain/asset/KpisStorageWrapper.sol:821693499": [
+      [76, 20, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"],
+      [157, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"],
+      [179, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"]
+    ],
+    "contracts/domain/asset/LockStorageWrapper.sol:1857377066": [
+      [327, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
+    ],
+    "contracts/domain/asset/MaturityDateStorageWrapper.sol:4271145073": [
+      [56, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    ],
+    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:2827404587": [
+      [228, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
+      [472, 16, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177622"]
+    ],
+    "contracts/domain/asset/SnapshotsStorageWrapper.sol:2021841773": [
+      [139, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
+      [153, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
+      [1034, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    ],
+    "contracts/domain/asset/VotingStorageWrapper.sol:1130199794": [
+      [58, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [179, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [197, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
+    ],
+    "contracts/domain/asset/coupon/CouponStorageWrapper.sol:1759522121": [
+      [94, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [362, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [382, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [402, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177621"]
+    ],
+    "contracts/domain/core/CapStorageWrapper.sol:2272932499": [
+      [240, 37, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    ],
+    "contracts/domain/core/CorporateActionsStorageWrapper.sol:1633069601": [
+      [147, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
+    ],
+    "contracts/domain/orchestrator/ClearingOps.sol:1768944660": [
+      [57, 4, 1, "function-max-lines: Function body contains 57 lines but allowed no more than 50 lines", "177603"],
+      [57, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [57, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [137, 4, 1, "function-max-lines: Function body contains 66 lines but allowed no more than 50 lines", "177603"],
+      [137, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingRedeemCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [137, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingRedeemCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [221, 4, 1, "function-max-lines: Function body contains 58 lines but allowed no more than 50 lines", "177603"],
+      [221, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [221, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
+      [407, 4, 1, "function-max-lines: Function body contains 52 lines but allowed no more than 50 lines", "177603"]
+    ],
+    "contracts/domain/orchestrator/HoldOps.sol:2308870617": [
+      [29, 4, 1, "gas-calldata-parameters: GC: [_hold] argument on Function [createHoldByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [29, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [createHoldByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [50, 4, 1, "gas-calldata-parameters: GC: [_protectedHold] argument on Function [protectedCreateHoldByPartition] could be [calldata] if it\'s not being updated", "177603"]
+    ],
+    "contracts/domain/orchestrator/TokenCoreOps.sol:2677183411": [
+      [33, 4, 1, "gas-calldata-parameters: GC: [_basicTransferInfo] argument on Function [transferByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [33, 4, 1, "gas-calldata-parameters: GC: [_data] argument on Function [transferByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [33, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [transferByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [80, 4, 1, "gas-calldata-parameters: GC: [_issueData] argument on Function [issueByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [91, 4, 1, "gas-calldata-parameters: GC: [_data] argument on Function [redeemByPartition] could be [calldata] if it\'s not being updated", "177603"],
+      [91, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [redeemByPartition] could be [calldata] if it\'s not being updated", "177603"]
+    ],
+    "contracts/facets/adjustBalances/IAdjustBalances.sol:226845225": [
+      [21, 4, 1, "gas-indexed-events: GC: [factor] on Event [AdjustmentBalanceSet] could be Indexed", "177600"],
+      [21, 4, 1, "gas-indexed-events: GC: [decimals] on Event [AdjustmentBalanceSet] could be Indexed", "177600"]
+    ],
+    "contracts/facets/allowance/IAllowanceTypes.sol:2947429804": [
+      [19, 4, 1, "gas-indexed-events: GC: [value] on Event [Approval] could be Indexed", "177600"]
+    ],
+    "contracts/facets/amortization/IAmortization.sol:75918106": [
+      [32, 4, 1, "gas-struct-packing: GC: For [ AmortizationFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"],
+      [59, 4, 1, "gas-indexed-events: GC: [amortizationId] on Event [AmortizationSet] could be Indexed", "177600"],
+      [59, 4, 1, "gas-indexed-events: GC: [recordDate] on Event [AmortizationSet] could be Indexed", "177600"],
+      [59, 4, 1, "gas-indexed-events: GC: [executionDate] on Event [AmortizationSet] could be Indexed", "177600"],
+      [72, 4, 1, "gas-indexed-events: GC: [amortizationId] on Event [AmortizationCancelled] could be Indexed", "177600"],
+      [79, 4, 1, "gas-indexed-events: GC: [amortizationId] on Event [AmortizationForceCancelled] could be Indexed", "177600"]
+    ],
+    "contracts/facets/burn/IBurn.sol:3689975541": [
+      [27, 4, 1, "gas-indexed-events: GC: [value] on Event [Redeemed] could be Indexed", "177600"]
+    ],
+    "contracts/facets/cap/ICap.sol:277456862": [
+      [44, 4, 1, "gas-indexed-events: GC: [newMaxSupply] on Event [MaxSupplySet] could be Indexed", "177600"],
+      [44, 4, 1, "gas-indexed-events: GC: [previousMaxSupply] on Event [MaxSupplySet] could be Indexed", "177600"],
+      [53, 4, 1, "gas-indexed-events: GC: [newMaxSupply] on Event [MaxSupplyByPartitionSet] could be Indexed", "177600"],
+      [53, 4, 1, "gas-indexed-events: GC: [previousMaxSupply] on Event [MaxSupplyByPartitionSet] could be Indexed", "177600"]
+    ],
+    "contracts/facets/clearing/IClearing.sol:405778800": [
+      [24, 4, 1, "gas-indexed-events: GC: [clearingActive] on Event [ClearingInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/clearing/IClearingTypes.sol:3182196712": [
+      [215, 4, 1, "gas-indexed-events: GC: [clearingId] on Event [ClearedRedeemByPartition] could be Indexed", "177600"],
+      [215, 4, 1, "gas-indexed-events: GC: [amount] on Event [ClearedRedeemByPartition] could be Indexed", "177600"],
+      [215, 4, 1, "gas-indexed-events: GC: [expirationDate] on Event [ClearedRedeemByPartition] could be Indexed", "177600"],
+      [239, 4, 1, "gas-indexed-events: GC: [clearingId] on Event [ClearedRedeemFromByPartition] could be Indexed", "177600"],
+      [239, 4, 1, "gas-indexed-events: GC: [amount] on Event [ClearedRedeemFromByPartition] could be Indexed", "177600"],
+      [239, 4, 1, "gas-indexed-events: GC: [expirationDate] on Event [ClearedRedeemFromByPartition] could be Indexed", "177600"],
+      [262, 4, 1, "gas-indexed-events: GC: [clearingId] on Event [ClearedOperatorRedeemByPartition] could be Indexed", "177600"],
+      [262, 4, 1, "gas-indexed-events: GC: [amount] on Event [ClearedOperatorRedeemByPartition] could be Indexed", "177600"],
+      [262, 4, 1, "gas-indexed-events: GC: [expirationDate] on Event [ClearedOperatorRedeemByPartition] could be Indexed", "177600"]
+    ],
+    "contracts/facets/commonTypes/IERC3643Types.sol:1353093213": [
+      [52, 4, 1, "gas-indexed-events: GC: [lostWallet] on Event [RecoverySuccess] could be Indexed", "177600"],
+      [52, 4, 1, "gas-indexed-events: GC: [newWallet] on Event [RecoverySuccess] could be Indexed", "177600"],
+      [52, 4, 1, "gas-indexed-events: GC: [investorOnchainID] on Event [RecoverySuccess] could be Indexed", "177600"]
+    ],
+    "contracts/facets/compliance/IComplianceFacet.sol:3337960929": [
+      [18, 4, 1, "gas-indexed-events: GC: [compliance] on Event [ComplianceInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/controlList/IControlList.sol:589439686": [
+      [25, 4, 1, "gas-indexed-events: GC: [isWhiteList] on Event [ControlListInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/controller/IController.sol:3504905174": [
+      [22, 4, 1, "gas-indexed-events: GC: [controllable] on Event [ControllerInitialized] could be Indexed", "177600"],
+      [28, 4, 1, "gas-indexed-events: GC: [operator] on Event [FinalizedControllerFeature] could be Indexed", "177600"]
+    ],
+    "contracts/facets/controller/IControllerTypes.sol:262187541": [
+      [24, 4, 1, "gas-indexed-events: GC: [controller] on Event [ControllerTransfer] could be Indexed", "177600"],
+      [24, 4, 1, "gas-indexed-events: GC: [value] on Event [ControllerTransfer] could be Indexed", "177600"],
+      [41, 4, 1, "gas-indexed-events: GC: [controller] on Event [ControllerRedemption] could be Indexed", "177600"],
+      [41, 4, 1, "gas-indexed-events: GC: [value] on Event [ControllerRedemption] could be Indexed", "177600"]
+    ],
+    "contracts/facets/coupon/ICouponTypes.sol:430258162": [
+      [74, 4, 1, "gas-struct-packing: GC: For [ CouponFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
+    ],
+    "contracts/facets/dividend/IDividend.sol:3712337435": [
+      [55, 4, 1, "gas-indexed-events: GC: [dividendId] on Event [DividendCancelled] could be Indexed", "177600"],
+      [62, 4, 1, "gas-indexed-events: GC: [dividendId] on Event [DividendForceCancelled] could be Indexed", "177600"]
+    ],
+    "contracts/facets/dividend/IDividendTypes.sol:2960222249": [
+      [58, 4, 1, "gas-struct-packing: GC: For [ DividendFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
+    ],
+    "contracts/facets/erc20Votes/IERC20Votes.sol:1279752095": [
+      [19, 4, 1, "gas-indexed-events: GC: [activated] on Event [ERC20VotesInitialized] could be Indexed", "177600"],
+      [31, 4, 1, "gas-indexed-events: GC: [previousBalance] on Event [DelegateVotesChanged] could be Indexed", "177600"],
+      [31, 4, 1, "gas-indexed-events: GC: [newBalance] on Event [DelegateVotesChanged] could be Indexed", "177600"]
+    ],
+    "contracts/facets/externalControlListManagement/IExternalControlListManagement.sol:711531881": [
+      [41, 4, 1, "gas-indexed-events: GC: [controlList] on Event [AddedToExternalControlLists] could be Indexed", "177600"],
+      [48, 4, 1, "gas-indexed-events: GC: [controlList] on Event [RemovedFromExternalControlLists] could be Indexed", "177600"]
+    ],
+    "contracts/facets/externalKycListManagement/IExternalKycListManagement.sol:2007994945": [
+      [42, 4, 1, "gas-indexed-events: GC: [kycList] on Event [AddedToExternalKycLists] could be Indexed", "177600"],
+      [49, 4, 1, "gas-indexed-events: GC: [kycList] on Event [RemovedFromExternalKycLists] could be Indexed", "177600"]
+    ],
+    "contracts/facets/externalPauseManagement/IExternalPauseManagement.sol:4183814973": [
+      [40, 4, 1, "gas-indexed-events: GC: [pause] on Event [AddedToExternalPauses] could be Indexed", "177600"],
+      [47, 4, 1, "gas-indexed-events: GC: [pause] on Event [RemovedFromExternalPauses] could be Indexed", "177600"]
+    ],
+    "contracts/facets/fixedRate/IFixedRate.sol:1312599660": [
+      [39, 4, 1, "gas-indexed-events: GC: [newRate] on Event [RateUpdated] could be Indexed", "177600"],
+      [39, 4, 1, "gas-indexed-events: GC: [newRateDecimals] on Event [RateUpdated] could be Indexed", "177600"]
+    ],
+    "contracts/facets/freeze/IFreezeTypes.sol:1488340237": [
+      [20, 4, 1, "gas-indexed-events: GC: [amount] on Event [TokensFrozen] could be Indexed", "177600"],
+      [29, 4, 1, "gas-indexed-events: GC: [amount] on Event [TokensUnfrozen] could be Indexed", "177600"]
+    ],
+    "contracts/facets/hold/IHoldTypes.sol:2038004094": [
+      [131, 4, 1, "gas-indexed-events: GC: [holdId] on Event [HoldByPartitionExecuted] could be Indexed", "177600"],
+      [131, 4, 1, "gas-indexed-events: GC: [amount] on Event [HoldByPartitionExecuted] could be Indexed", "177600"],
+      [131, 4, 1, "gas-indexed-events: GC: [to] on Event [HoldByPartitionExecuted] could be Indexed", "177600"],
+      [146, 4, 1, "gas-indexed-events: GC: [holdId] on Event [HoldByPartitionReleased] could be Indexed", "177600"],
+      [146, 4, 1, "gas-indexed-events: GC: [amount] on Event [HoldByPartitionReleased] could be Indexed", "177600"]
+    ],
+    "contracts/facets/identity/IIdentity.sol:3212629228": [
+      [24, 4, 1, "gas-indexed-events: GC: [identityRegistry] on Event [IdentityInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/initializer/IInitializer.sol:3290905615": [
+      [19, 4, 1, "gas-indexed-events: GC: [maxInitializerFacetIndex] on Event [InitializerInitialized] could be Indexed", "177600"],
+      [29, 4, 1, "gas-indexed-events: GC: [sender] on Event [OperationalStatusPartialSet] could be Indexed", "177600"],
+      [29, 4, 1, "gas-indexed-events: GC: [version] on Event [OperationalStatusPartialSet] could be Indexed", "177600"],
+      [29, 4, 1, "gas-indexed-events: GC: [lastIndex] on Event [OperationalStatusPartialSet] could be Indexed", "177600"],
+      [38, 4, 1, "gas-indexed-events: GC: [sender] on Event [OperationalStatusSet] could be Indexed", "177600"],
+      [38, 4, 1, "gas-indexed-events: GC: [version] on Event [OperationalStatusSet] could be Indexed", "177600"],
+      [46, 4, 1, "gas-indexed-events: GC: [sender] on Event [MaxInitializerFacetIndexUpdated] could be Indexed", "177600"],
+      [46, 4, 1, "gas-indexed-events: GC: [newMaxInitializerFacetIndex] on Event [MaxInitializerFacetIndexUpdated] could be Indexed", "177600"]
+    ],
+    "contracts/facets/kpi/IKpis.sol:4077278714": [
+      [28, 4, 1, "gas-indexed-events: GC: [date] on Event [KpiDataAdded] could be Indexed", "177600"],
+      [28, 4, 1, "gas-indexed-events: GC: [value] on Event [KpiDataAdded] could be Indexed", "177600"]
+    ],
+    "contracts/facets/kyc/IKyc.sol:2653056954": [
+      [31, 4, 1, "gas-indexed-events: GC: [internalKycActivated] on Event [KycInitialized] could be Indexed", "177600"],
+      [45, 4, 1, "gas-indexed-events: GC: [activated] on Event [InternalKycStatusUpdated] could be Indexed", "177600"]
+    ],
+    "contracts/facets/loansPortfolio/ILoansPortfolio.sol:2743224819": [
+      [80, 4, 1, "gas-indexed-events: GC: [loanHoldingsAsset] on Event [LoanHoldingsAssetUpdated] could be Indexed", "177600"],
+      [88, 4, 1, "gas-indexed-events: GC: [assetAddress] on Event [LoansPortfolioWithdrawn] could be Indexed", "177600"],
+      [88, 4, 1, "gas-indexed-events: GC: [to] on Event [LoansPortfolioWithdrawn] could be Indexed", "177600"],
+      [88, 4, 1, "gas-indexed-events: GC: [amount] on Event [LoansPortfolioWithdrawn] could be Indexed", "177600"]
+    ],
+    "contracts/facets/mint/IMintTypes.sol:789955124": [
+      [20, 4, 1, "gas-indexed-events: GC: [value] on Event [Issued] could be Indexed", "177600"]
+    ],
+    "contracts/facets/nominalValue/INominalValue.sol:2003584758": [
+      [27, 4, 1, "gas-indexed-events: GC: [nominalValue] on Event [NominalValueInitialized] could be Indexed", "177600"],
+      [27, 4, 1, "gas-indexed-events: GC: [nominalValueDecimals] on Event [NominalValueInitialized] could be Indexed", "177600"],
+      [36, 4, 1, "gas-indexed-events: GC: [nominalValue] on Event [NominalValueSet] could be Indexed", "177600"],
+      [36, 4, 1, "gas-indexed-events: GC: [nominalValueDecimals] on Event [NominalValueSet] could be Indexed", "177600"]
+    ],
+    "contracts/facets/partitions/IPartitions.sol:165312895": [
+      [20, 4, 1, "gas-indexed-events: GC: [multiPartition] on Event [PartitionsInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/protectedClearingByPartition/IProtectedClearingByPartition.sol:2414024950": [
+      [40, 4, 1, "gas-indexed-events: GC: [clearingId] on Event [ProtectedClearedRedeemByPartition] could be Indexed", "177600"],
+      [40, 4, 1, "gas-indexed-events: GC: [amount] on Event [ProtectedClearedRedeemByPartition] could be Indexed", "177600"],
+      [40, 4, 1, "gas-indexed-events: GC: [expirationDate] on Event [ProtectedClearedRedeemByPartition] could be Indexed", "177600"]
+    ],
+    "contracts/facets/protectedPartition/IProtectedPartitions.sol:3841096614": [
+      [30, 4, 1, "gas-indexed-events: GC: [arePartitionsProtected] on Event [ProtectedPartitionsInitialized] could be Indexed", "177600"]
+    ],
+    "contracts/facets/scheduledBalanceAdjustment/IScheduledBalanceAdjustment.sol:2865309541": [
+      [45, 4, 1, "gas-indexed-events: GC: [balanceAdjustmentId] on Event [ScheduledBalanceAdjustmentSet] could be Indexed", "177600"],
+      [45, 4, 1, "gas-indexed-events: GC: [factor] on Event [ScheduledBalanceAdjustmentSet] could be Indexed", "177600"],
+      [45, 4, 1, "gas-indexed-events: GC: [decimals] on Event [ScheduledBalanceAdjustmentSet] could be Indexed", "177600"],
+      [59, 4, 1, "gas-indexed-events: GC: [balanceAdjustmentId] on Event [ScheduledBalanceAdjustmentCancelled] could be Indexed", "177600"],
+      [66, 4, 1, "gas-indexed-events: GC: [balanceAdjustmentId] on Event [ScheduledBalanceAdjustmentForceCancelled] could be Indexed", "177600"]
+    ],
+    "contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentBase.sol:3351011126": [
+      [109, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177600"]
+    ],
+    "contracts/facets/scheduledCrossOrderedTask/IScheduledCrossOrderedTasks.sol:1747555586": [
+      [22, 4, 1, "gas-indexed-events: GC: [scheduledTimestamp] on Event [TaskExecutionFailed] could be Indexed", "177600"]
+    ],
+    "contracts/facets/snapshot/ISnapshots.sol:4095973638": [
+      [67, 4, 1, "gas-indexed-events: GC: [snapshotId] on Event [SnapshotTriggered] could be Indexed", "177600"]
+    ],
+    "contracts/facets/transfer/ITransfer.sol:1049729304": [
+      [27, 4, 1, "gas-indexed-events: GC: [amount] on Event [TransferWithData] could be Indexed", "177600"],
+      [51, 4, 1, "gas-indexed-events: GC: [value] on Event [Transfer] could be Indexed", "177600"]
+    ],
+    "contracts/facets/transferAndLock/ITransferAndLockTypes.sol:1208796755": [
+      [23, 4, 1, "gas-indexed-events: GC: [to] on Event [PartitionTransferredAndLocked] could be Indexed", "177600"],
+      [23, 4, 1, "gas-indexed-events: GC: [value] on Event [PartitionTransferredAndLocked] could be Indexed", "177600"],
+      [23, 4, 1, "gas-indexed-events: GC: [expirationTimestamp] on Event [PartitionTransferredAndLocked] could be Indexed", "177600"],
+      [23, 4, 1, "gas-indexed-events: GC: [lockId] on Event [PartitionTransferredAndLocked] could be Indexed", "177600"]
+    ],
+    "contracts/facets/voting/IVoting.sol:2900349042": [
+      [24, 4, 1, "gas-indexed-events: GC: [voteId] on Event [VotingSet] could be Indexed", "177600"],
+      [35, 4, 1, "gas-indexed-events: GC: [voteId] on Event [VotingCancelled] could be Indexed", "177600"],
+      [40, 4, 1, "gas-indexed-events: GC: [voteId] on Event [VotingForceCancelled] could be Indexed", "177600"]
+    ],
+    "contracts/factory/IFactory.sol:4063378112": [
+      [115, 4, 1, "gas-struct-packing: GC: For [ EquityDetailsData ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
+    ],
+    "contracts/infrastructure/diamond/IDiamondCutManager.sol:1721314983": [
+      [72, 4, 1, "gas-indexed-events: GC: [version] on Event [DiamondBatchConfigurationCanceled] could be Indexed", "177600"]
+    ],
+    "contracts/infrastructure/diamond/IOwnership.sol:729129024": [
+      [23, 4, 1, "gas-indexed-events: GC: [owner] on Event [OwnershipTransfered] could be Indexed", "177600"],
+      [23, 4, 1, "gas-indexed-events: GC: [pendingOwner] on Event [OwnershipTransfered] could be Indexed", "177600"],
+      [33, 4, 1, "gas-indexed-events: GC: [previousOwner] on Event [OwnershipAccepted] could be Indexed", "177600"],
+      [33, 4, 1, "gas-indexed-events: GC: [newOwner] on Event [OwnershipAccepted] could be Indexed", "177600"]
+    ],
+    "contracts/infrastructure/proxy/ResolverProxy.sol:849945896": [
+      [54, 4, 1, "no-complex-fallback: Fallback function must be simple", "177603"]
+    ],
+    "contracts/infrastructure/utils/DecimalsLib.sol:1643088826": [
+      [6, 4, 1, "no-unused-import: imported name POW10_0 is not used", "177653"],
+      [7, 4, 1, "no-unused-import: imported name POW10_1 is not used", "177653"],
+      [8, 4, 1, "no-unused-import: imported name POW10_2 is not used", "177653"],
+      [9, 4, 1, "no-unused-import: imported name POW10_3 is not used", "177653"],
+      [10, 4, 1, "no-unused-import: imported name POW10_4 is not used", "177653"],
+      [11, 4, 1, "no-unused-import: imported name POW10_5 is not used", "177653"],
+      [12, 4, 1, "no-unused-import: imported name POW10_6 is not used", "177653"],
+      [13, 4, 1, "no-unused-import: imported name POW10_7 is not used", "177653"],
+      [14, 4, 1, "no-unused-import: imported name POW10_8 is not used", "177653"],
+      [15, 4, 1, "no-unused-import: imported name POW10_9 is not used", "177653"],
+      [16, 4, 1, "no-unused-import: imported name POW10_10 is not used", "177653"],
+      [17, 4, 1, "no-unused-import: imported name POW10_11 is not used", "177653"],
+      [18, 4, 1, "no-unused-import: imported name POW10_12 is not used", "177653"],
+      [19, 4, 1, "no-unused-import: imported name POW10_13 is not used", "177653"],
+      [20, 4, 1, "no-unused-import: imported name POW10_14 is not used", "177653"],
+      [21, 4, 1, "no-unused-import: imported name POW10_15 is not used", "177653"],
+      [22, 4, 1, "no-unused-import: imported name POW10_16 is not used", "177653"],
+      [23, 4, 1, "no-unused-import: imported name POW10_17 is not used", "177653"],
+      [24, 4, 1, "no-unused-import: imported name POW10_18 is not used", "177653"],
+      [78, 4, 1, "function-max-lines: Function body contains 70 lines but allowed no more than 50 lines", "177603"],
+      [79, 8, 1, "no-inline-assembly: Avoid to use inline assembly. It is acceptable only in rare cases", "177604"]
+    ],
+    "contracts/infrastructure/utils/EIP712.sol:1875754770": [
+      [205, 11, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    ],
+    "contracts/infrastructure/utils/Pagination.sol:813892419": [
+      [79, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
+      [82, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    ]
+  }`
+};

--- a/packages/ats/contracts/.betterer.ts
+++ b/packages/ats/contracts/.betterer.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { BettererFileTest } from "@betterer/betterer";
+
+// Solhint warning ratchet for the ATS contracts package. Snapshots every
+// solhint *warning* into `.betterer.results` so CI can guarantee the count
+// only ever stays equal or decreases (enforced by the `lint-ratchet` job in
+// `103-flow-ats-lint.yaml`). Errors are excluded — they already hard-fail `lint:sol`.
+
+const CONTRACTS_GLOB = "contracts/**/*.sol";
+const SOLHINT_CONFIG = "solhint.config.js";
+
+// Auto-generated, gitignored accessor library. It must exist (prod mode) before
+// solhint runs or its importers raise spurious `import-path-check` warnings, but
+// it carries no warnings of its own and has no committed source, so it is kept
+// out of the results entirely.
+const GENERATED_EXCLUDE = /infrastructure\/utils\/EvmAccessors\.sol$/;
+
+interface SolhintMessage {
+  line: number; // 1-based
+  column: number; // 1-based
+  severity: "Warning" | "Error";
+  message: string;
+  ruleId: string;
+  filePath: string;
+}
+
+function runSolhint(): SolhintMessage[] {
+  let stdout = "";
+  try {
+    stdout = execFileSync(
+      "npx",
+      ["--no-install", "solhint", "--disc", "--config", SOLHINT_CONFIG, "--formatter", "json", CONTRACTS_GLOB],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+  } catch (error) {
+    // solhint exits non-zero when error-level rules fire; its JSON still lands on stdout.
+    stdout = (error as { stdout?: Buffer | string }).stdout?.toString() ?? "";
+    if (!stdout) {
+      throw error;
+    }
+  }
+  const start = stdout.indexOf("[");
+  return start === -1 ? [] : (JSON.parse(stdout.slice(start)) as SolhintMessage[]);
+}
+
+const test = new BettererFileTest(async (_filePaths, fileTestResult) => {
+  const warnings = runSolhint().filter((m) => m.severity === "Warning" && !GENERATED_EXCLUDE.test(m.filePath));
+
+  const byFile = new Map<string, SolhintMessage[]>();
+  for (const warning of warnings) {
+    const absolutePath = resolve(process.cwd(), warning.filePath);
+    const bucket = byFile.get(absolutePath);
+    if (bucket) {
+      bucket.push(warning);
+    } else {
+      byFile.set(absolutePath, [warning]);
+    }
+  }
+
+  for (const [absolutePath, fileWarnings] of byFile) {
+    const file = fileTestResult.addFile(absolutePath, readFileSync(absolutePath, "utf8"));
+    for (const warning of fileWarnings) {
+      // 0-indexed line/column; the message embeds the ruleId so a swap of one
+      // rule's warning for another's changes the issue hash and is caught.
+      file.addIssue(
+        Math.max(0, warning.line - 1),
+        Math.max(0, warning.column - 1),
+        1,
+        `${warning.ruleId}: ${warning.message}`,
+      );
+    }
+  }
+});
+
+export default {
+  "ats contracts solhint": () => test,
+};

--- a/packages/ats/contracts/package.json
+++ b/packages/ats/contracts/package.json
@@ -59,8 +59,11 @@
     "clean:deps": "node -e \"const fs=require('fs'); fs.rmSync('node_modules',{recursive:true,force:true})\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "npm run lint:sol && npm run lint:js",
-    "lint:fix": "npm run lint:sol:fix; npm run lint:js:fix",
+    "lint": "npm run lint:sol && npm run lint:js && npm run lint:ratchet",
+    "lint:fix": "npm run lint:sol:fix; npm run lint:js:fix; npm run lint:ratchet:update",
+    "lint:ratchet": "npm run generate:accessors:prod && betterer ci",
+    "lint:ratchet:update": "npm run generate:accessors:prod && betterer",
+    "lint:ratchet:merge": "betterer merge",
     "generate:accessors": "npx tsx scripts/tools/accessor-generator/index.ts",
     "generate:accessors:prod": "ATS_TEST_MODE=false npx tsx scripts/tools/accessor-generator/index.ts",
     "lint:sol": "npm run generate:accessors:prod && solhint --config solhint.config.js 'contracts/**/*.sol'",
@@ -166,6 +169,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@betterer/betterer": "5.4.0",
+    "@betterer/cli": "5.4.0",
     "@hashgraph/eslint-config": "*",
     "@hashgraph/sdk": "2.64.5",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",

--- a/packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts
+++ b/packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Ratchet gate: the PR's solhint baseline must not be worse than the base branch's,
+// per rule. `betterer ci` (run separately) already proves the committed
+// `.betterer.results` matches the actual code; this guards against a PR that
+// regresses the code AND re-baselines `.betterer.results` upward to match — which
+// `betterer ci` alone would accept. Comparing per-rule counts (rather than the
+// per-issue hashes, which change on any code edit) keeps the gate stable across
+// legitimate refactors while still failing any rule whose warning count grows.
+//
+// Usage: npx tsx packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts <base-ref>  (run from repo root)
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const RESULTS_PATH = "packages/ats/contracts/.betterer.results";
+const baseRef = process.argv[2] || "develop";
+
+// A serialised betterer file issue: [line, column, length, message, hash].
+type SerialisedIssue = [number, number, number, string, string];
+type BettererResultsModule = Record<string, { value: string }>;
+
+/**
+ * Tally solhint warnings per rule from a `.betterer.results` source.
+ *
+ * The file is a CommonJS module that stores each test's serialised result as a
+ * template literal (`exports[name] = { value: `...` }`), so backslash escapes
+ * (e.g. `it\'s`) only resolve once JS evaluates it. We evaluate the module the
+ * same way betterer does, then JSON.parse each test's value.
+ */
+function parseResults(source: string): Map<string, number> {
+  const counts = new Map<string, number>(); // ruleId -> count
+  const exportsObject: BettererResultsModule = Object.create(null);
+  // eslint-disable-next-line no-new-func
+  new Function("exports", source)(exportsObject);
+  for (const entry of Object.values(exportsObject)) {
+    const byFile = JSON.parse(entry.value) as Record<string, SerialisedIssue[]>;
+    for (const issues of Object.values(byFile)) {
+      for (const issue of issues) {
+        const message = issue[3] ?? "";
+        // Issues are recorded as `"<ruleId>: <message>"` by `.betterer.ts`; the
+        // ruleId is the text before the first colon (solhint ruleIds have none).
+        const ruleId = message.slice(0, message.indexOf(":")) || "unknown";
+        counts.set(ruleId, (counts.get(ruleId) ?? 0) + 1);
+      }
+    }
+  }
+  return counts;
+}
+
+function readBaseResults(): string | null {
+  for (const ref of [`origin/${baseRef}`, baseRef]) {
+    try {
+      return execFileSync("git", ["show", `${ref}:${RESULTS_PATH}`], {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    } catch {
+      // try the next ref form
+    }
+  }
+  return null;
+}
+
+const baseSource = readBaseResults();
+if (baseSource === null) {
+  console.log(`✅ No \`${RESULTS_PATH}\` on \`${baseRef}\` yet — establishing the baseline. Skipping comparison.`);
+  process.exit(0);
+}
+
+const headSource = readFileSync(RESULTS_PATH, "utf8");
+const baseCounts = parseResults(baseSource);
+const headCounts = parseResults(headSource);
+
+const regressions: Array<{ ruleId: string; baseCount: number; headCount: number }> = [];
+for (const [ruleId, headCount] of headCounts) {
+  const baseCount = baseCounts.get(ruleId) ?? 0;
+  if (headCount > baseCount) {
+    regressions.push({ ruleId, baseCount, headCount });
+  }
+}
+
+const baseTotal = [...baseCounts.values()].reduce((a, b) => a + b, 0);
+const headTotal = [...headCounts.values()].reduce((a, b) => a + b, 0);
+
+if (regressions.length > 0) {
+  console.error(`❌ Solhint warnings increased vs \`${baseRef}\` (${baseTotal} → ${headTotal}). Regressed rules:`);
+  for (const { ruleId, baseCount, headCount } of regressions) {
+    console.error(`   • ${ruleId}: ${baseCount} → ${headCount}`);
+  }
+  console.error(
+    "\nFix the new warnings, then run `npm run ats:contracts:lint:fix` and commit the updated\n" +
+      "`packages/ats/contracts/.betterer.results`. The contracts lint baseline may only stay equal or shrink.",
+  );
+  process.exit(1);
+}
+
+console.log(`✅ Solhint warnings not worse than \`${baseRef}\` (${baseTotal} → ${headTotal}). No rule increased.`);

--- a/packages/ats/contracts/solhint.config.js
+++ b/packages/ats/contracts/solhint.config.js
@@ -52,5 +52,11 @@ module.exports = {
     "not-rely-on-time": "off",
 
     "use-natspec": "warn",
+
+    // Rules driven to zero and locked as errors so they can never regress. The
+    // remaining recommended warnings are governed by the betterer ratchet
+    // (.betterer.ts / .betterer.results) instead — see the contracts lint scripts.
+    "duplicated-imports": "error",
+    "gas-increment-by-one": "error",
   },
 };


### PR DESCRIPTION
## Description

Adds a betterer-based ratchet so the ATS contracts solhint warning count (181 baseline, post-cleanup) can only stay equal or decrease — never increase. A custom `BettererFileTest` snapshots every solhint warning into `packages/ats/contracts/.betterer.results`; the check rides inside the contracts `lint` script (`betterer ci`) and the baseline refresh inside `lint:fix`. CI enforces it via a new `lint-ratchet` job in workflow 103 with two read-only checks: `betterer ci` (baseline matches code) and a per-rule base comparison (`check-ratchet-vs-base.ts`). Rules driven to zero (`duplicated-imports`, `gas-increment-by-one`) were promoted to solhint errors. No functional/ABI/storage change.

### How the ratchet works

```mermaid
flowchart TD
    subgraph LOCAL["Local · developer"]
        direction TB
        A["Edit .sol files"] --> B["npm run lint:fix"]
        B -->|"runs .betterer.ts (the recipe)"| C[".betterer.results<br/>snapshot of every solhint warning"]
        C --> D["git commit + push"]
    end

    D --> J{"CI · lint-ratchet job<br/>workflow 103"}

    subgraph CI["CI · two read-only gates"]
        direction LR
        G1["<b>Gate 1 · betterer ci</b><br/>re-runs .betterer.ts<br/>snapshot == the code?"]
        G2["<b>Gate 2 · check-ratchet-vs-base.ts</b><br/>no solhint — compares snapshots<br/>PR vs origin/&lt;base&gt;<br/>did any rule's count go up?"]
    end

    J --> G1
    J --> G2
    G1 -->|pass| M(["merge allowed"])
    G2 -->|pass| M
    G1 -->|fail| F["fix warnings → lint:fix → commit results"]
    G2 -->|fail| F
    F -.->|re-push| A
    M --> DEV["develop · warning count<br/>can only stay = or go down"]
```

**Three artifacts, three roles:**

| File | Role | Runs in |
|---|---|---|
| `.betterer.ts` | **the recipe** — the only thing that runs solhint; keeps warnings, records each as `"<ruleId>: <message>"` so even *swapping* one rule's warning for another is detected | local (`betterer`) + Gate 1 (`betterer ci`) |
| `.betterer.results` | **the snapshot** — committed, per-file/per-issue baseline (keyed by `path:fileHash`) | read by both gates |
| `check-ratchet-vs-base.ts` | **the comparator** — no solhint; tallies per-rule counts of this PR's snapshot vs the base branch's (`git show origin/<base>:…`) and fails if any rule grew | Gate 2 only |

**Why two gates:** `betterer ci` alone could be defeated by a PR that regresses the code *and* re-baselines `.betterer.results` upward — it would still "match the code" and pass. Gate 2 catches that by comparing per-rule counts against the base branch. Gate 1 alone can't catch a stale snapshot. Together they make "never worse than `develop`" actually enforceable.

> **Merge-conflict note:** `.betterer.results` only churns for files that *have* warnings, and the sorted layout means independent files merge cleanly. If two PRs touch the same warning-bearing file and it conflicts, resolve by regenerating — `npm run lint:ratchet:merge` (`betterer merge`) or just re-run `npm run lint:fix` after rebase and commit.

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Local:
- `npm run ats:contracts:lint` passes — solhint 0 errors, `betterer ci` reports "stayed the same (181 issues)".
- Verified failure path 1: dropping an entry from `.betterer.results` causes `betterer ci` to fail.
- Verified failure path 2: injecting a per-rule increase causes `check-ratchet-vs-base.ts` to exit 1.

This PR is itself the live CI test — the `lint-ratchet` job in workflow 103 will exercise both checks on every push.

### Test Results (if any)

```
npm run ats:contracts:lint → 0 errors, 181 warnings (ratchet: stayed the same)
```

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
