### PR TITLE
refactor: remove contracts dead code and not used internal/private functions

### DIFF
--- a/docs/ats/api/contracts/facets/IAsset.md
+++ b/docs/ats/api/contracts/facets/IAsset.md
@@ -1019,9 +1019,9 @@ Returns the checkpoint at a given position for an account&#39;s vote history.
 
 #### Returns
 
-| Name | Type                   | Description |
-| ---- | ---------------------- | ----------- |
-| \_0  | Checkpoints.Checkpoint | undefined   |
+| Name | Type                   | Description                                  |
+| ---- | ---------------------- | -------------------------------------------- |
+| \_0  | Checkpoints.Checkpoint | The checkpoint struct at the given position. |
 
 ### clearedBalanceOfAtSnapshot
 
@@ -6136,9 +6136,9 @@ Returns whether the ERC-20Votes voting feature is currently active.
 
 #### Returns
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| \_0  | bool | undefined   |
+| Name | Type | Description                                            |
+| ---- | ---- | ------------------------------------------------------ |
+| \_0  | bool | True if the voting feature is active, false otherwise. |
 
 ### isAddressRecovered
 
@@ -6156,9 +6156,9 @@ Returns whether a wallet address has been marked as recovered.
 
 #### Returns
 
-| Name | Type | Description                                                                |
-| ---- | ---- | -------------------------------------------------------------------------- |
-| \_0  | bool | `true` if the address has previously been recovered via {recoveryAddress}. |
+| Name | Type | Description                                                              |
+| ---- | ---- | ------------------------------------------------------------------------ |
+| \_0  | bool | True if the address has previously been recovered via {recoveryAddress}. |
 
 ### isAgent
 
@@ -6198,9 +6198,9 @@ Returns whether `account` is authorised according to the external control list.
 
 #### Returns
 
-| Name | Type | Description                                                    |
-| ---- | ---- | -------------------------------------------------------------- |
-| \_0  | bool | `true` if the account is on the allow-list; `false` otherwise. |
+| Name | Type | Description                                                |
+| ---- | ---- | ---------------------------------------------------------- |
+| \_0  | bool | True if the account is on the allow-list; false otherwise. |
 
 ### isCheckPointDate
 
@@ -6452,9 +6452,9 @@ Indicates whether the token operates in multi-partition mode.
 
 #### Returns
 
-| Name | Type | Description                                                                                                                        |
-| ---- | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| \_0  | bool | true : the token allows multiple partitions to be set and managed. false : the token contains only one partition, the default one. |
+| Name | Type | Description                                                                         |
+| ---- | ---- | ----------------------------------------------------------------------------------- |
+| \_0  | bool | True if the token allows multiple partitions to be set and managed; false otherwise |
 
 ### isOperator
 
@@ -6800,9 +6800,9 @@ Returns the total number of vote checkpoints recorded for an account.
 
 #### Returns
 
-| Name | Type    | Description |
-| ---- | ------- | ----------- |
-| \_0  | uint256 | undefined   |
+| Name | Type    | Description                                       |
+| ---- | ------- | ------------------------------------------------- |
+| \_0  | uint256 | The number of checkpoints stored for the account. |
 
 ### onchainID
 

--- a/docs/ats/api/contracts/facets/amortization/Amortization.md
+++ b/docs/ats/api/contracts/facets/amortization/Amortization.md
@@ -433,24 +433,6 @@ Emitted when an amortization is created or updated for a security.
 | recordDate         | uint256 | Date at which token holder balances are snapshotted.  |
 | executionDate      | uint256 | Date at which the amortization payment is executed.   |
 
-### Approval
-
-```solidity
-event Approval(address indexed owner, address indexed spender, uint256 value)
-```
-
-Emitted when `owner` authorises `spender` to spend up to `value` tokens on their behalf, whether via {IAllowance.approve}, {IAllowance.increaseAllowance} or {IAllowance.decreaseAllowance}.
-
-_Mirrors the ERC-20 `Approval` event. `value` is the resulting, absolute allowance after the update — not the delta applied._
-
-#### Parameters
-
-| Name              | Type    | Description                                                        |
-| ----------------- | ------- | ------------------------------------------------------------------ |
-| owner `indexed`   | address | Address whose tokens may be spent.                                 |
-| spender `indexed` | address | Address authorised to spend on `owner`&#39;s behalf.               |
-| value             | uint256 | Allowance of `spender` over `owner`&#39;s tokens after the update. |
-
 ### Transfer
 
 ```solidity
@@ -642,21 +624,6 @@ Thrown when a transfer or redemption is attempted with insufficient partition ba
 | balance   | uint256 | The actual balance available.          |
 | value     | uint256 | The amount that was requested.         |
 | partition | bytes32 | The partition that was checked.        |
-
-### InsufficientHoldBalance
-
-```solidity
-error InsufficientHoldBalance(uint256 holdAmount, uint256 amount)
-```
-
-Reverts when the requested release amount exceeds the hold&#39;s remaining balance.
-
-#### Parameters
-
-| Name       | Type    | Description            |
-| ---------- | ------- | ---------------------- |
-| holdAmount | uint256 | The amount still held. |
-| amount     | uint256 | The amount requested.  |
 
 ### InvalidAmortizationHoldAmount
 

--- a/docs/ats/api/contracts/facets/amortization/AmortizationFacet.md
+++ b/docs/ats/api/contracts/facets/amortization/AmortizationFacet.md
@@ -475,24 +475,6 @@ Emitted when an amortization is created or updated for a security.
 | recordDate         | uint256 | Date at which token holder balances are snapshotted.  |
 | executionDate      | uint256 | Date at which the amortization payment is executed.   |
 
-### Approval
-
-```solidity
-event Approval(address indexed owner, address indexed spender, uint256 value)
-```
-
-Emitted when `owner` authorises `spender` to spend up to `value` tokens on their behalf, whether via {IAllowance.approve}, {IAllowance.increaseAllowance} or {IAllowance.decreaseAllowance}.
-
-_Mirrors the ERC-20 `Approval` event. `value` is the resulting, absolute allowance after the update — not the delta applied._
-
-#### Parameters
-
-| Name              | Type    | Description                                                        |
-| ----------------- | ------- | ------------------------------------------------------------------ |
-| owner `indexed`   | address | Address whose tokens may be spent.                                 |
-| spender `indexed` | address | Address authorised to spend on `owner`&#39;s behalf.               |
-| value             | uint256 | Allowance of `spender` over `owner`&#39;s tokens after the update. |
-
 ### Transfer
 
 ```solidity
@@ -684,21 +666,6 @@ Thrown when a transfer or redemption is attempted with insufficient partition ba
 | balance   | uint256 | The actual balance available.          |
 | value     | uint256 | The amount that was requested.         |
 | partition | bytes32 | The partition that was checked.        |
-
-### InsufficientHoldBalance
-
-```solidity
-error InsufficientHoldBalance(uint256 holdAmount, uint256 amount)
-```
-
-Reverts when the requested release amount exceeds the hold&#39;s remaining balance.
-
-#### Parameters
-
-| Name       | Type    | Description            |
-| ---------- | ------- | ---------------------- |
-| holdAmount | uint256 | The amount still held. |
-| amount     | uint256 | The amount requested.  |
 
 ### InvalidAmortizationHoldAmount
 

--- a/docs/ats/api/contracts/facets/compliance/externalInterfaces/ICompliance.md
+++ b/docs/ats/api/contracts/facets/compliance/externalInterfaces/ICompliance.md
@@ -28,9 +28,9 @@ Checks whether a transfer between two addresses is permitted.
 
 #### Returns
 
-| Name | Type | Description                                           |
-| ---- | ---- | ----------------------------------------------------- |
-| \_0  | bool | `true` if the transfer is allowed; `false` otherwise. |
+| Name | Type | Description                                       |
+| ---- | ---- | ------------------------------------------------- |
+| \_0  | bool | True if the transfer is allowed; false otherwise. |
 
 ### created
 

--- a/docs/ats/api/contracts/facets/erc20Votes/ERC20Votes.md
+++ b/docs/ats/api/contracts/facets/erc20Votes/ERC20Votes.md
@@ -41,9 +41,9 @@ Returns the checkpoint at a given position for an account&#39;s vote history.
 
 #### Returns
 
-| Name | Type                   | Description |
-| ---- | ---------------------- | ----------- |
-| \_0  | Checkpoints.Checkpoint | undefined   |
+| Name | Type                   | Description                                  |
+| ---- | ---------------------- | -------------------------------------------- |
+| \_0  | Checkpoints.Checkpoint | The checkpoint struct at the given position. |
 
 ### clock
 
@@ -212,9 +212,9 @@ Returns the total number of vote checkpoints recorded for an account.
 
 #### Returns
 
-| Name | Type    | Description |
-| ---- | ------- | ----------- |
-| \_0  | uint256 | undefined   |
+| Name | Type    | Description                                       |
+| ---- | ------- | ------------------------------------------------- |
+| \_0  | uint256 | The number of checkpoints stored for the account. |
 
 ## Events
 

--- a/docs/ats/api/contracts/facets/erc20Votes/ERC20VotesFacet.md
+++ b/docs/ats/api/contracts/facets/erc20Votes/ERC20VotesFacet.md
@@ -41,9 +41,9 @@ Returns the checkpoint at a given position for an account&#39;s vote history.
 
 #### Returns
 
-| Name | Type                   | Description |
-| ---- | ---------------------- | ----------- |
-| \_0  | Checkpoints.Checkpoint | undefined   |
+| Name | Type                   | Description                                  |
+| ---- | ---------------------- | -------------------------------------------- |
+| \_0  | Checkpoints.Checkpoint | The checkpoint struct at the given position. |
 
 ### clock
 
@@ -254,9 +254,9 @@ Returns the total number of vote checkpoints recorded for an account.
 
 #### Returns
 
-| Name | Type    | Description |
-| ---- | ------- | ----------- |
-| \_0  | uint256 | undefined   |
+| Name | Type    | Description                                       |
+| ---- | ------- | ------------------------------------------------- |
+| \_0  | uint256 | The number of checkpoints stored for the account. |
 
 ## Events
 

--- a/docs/ats/api/contracts/facets/erc20Votes/IERC20Votes.md
+++ b/docs/ats/api/contracts/facets/erc20Votes/IERC20Votes.md
@@ -39,9 +39,9 @@ Returns the checkpoint at a given position for an account&#39;s vote history.
 
 #### Returns
 
-| Name | Type                   | Description |
-| ---- | ---------------------- | ----------- |
-| \_0  | Checkpoints.Checkpoint | undefined   |
+| Name | Type                   | Description                                  |
+| ---- | ---------------------- | -------------------------------------------- |
+| \_0  | Checkpoints.Checkpoint | The checkpoint struct at the given position. |
 
 ### clock
 
@@ -186,9 +186,9 @@ Returns whether the ERC-20Votes voting feature is currently active.
 
 #### Returns
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| \_0  | bool | undefined   |
+| Name | Type | Description                                            |
+| ---- | ---- | ------------------------------------------------------ |
+| \_0  | bool | True if the voting feature is active, false otherwise. |
 
 ### numCheckpoints
 
@@ -206,9 +206,9 @@ Returns the total number of vote checkpoints recorded for an account.
 
 #### Returns
 
-| Name | Type    | Description |
-| ---- | ------- | ----------- |
-| \_0  | uint256 | undefined   |
+| Name | Type    | Description                                       |
+| ---- | ------- | ------------------------------------------------- |
+| \_0  | uint256 | The number of checkpoints stored for the account. |
 
 ## Events
 

--- a/docs/ats/api/contracts/facets/externalControlListManagement/IExternalControlList.md
+++ b/docs/ats/api/contracts/facets/externalControlListManagement/IExternalControlList.md
@@ -26,6 +26,6 @@ Returns whether `account` is authorised according to the external control list.
 
 #### Returns
 
-| Name | Type | Description                                                    |
-| ---- | ---- | -------------------------------------------------------------- |
-| \_0  | bool | `true` if the account is on the allow-list; `false` otherwise. |
+| Name | Type | Description                                                |
+| ---- | ---- | ---------------------------------------------------------- |
+| \_0  | bool | True if the account is on the allow-list; false otherwise. |

--- a/docs/ats/api/contracts/facets/externalPauseManagement/IExternalPause.md
+++ b/docs/ats/api/contracts/facets/externalPauseManagement/IExternalPause.md
@@ -20,6 +20,6 @@ Returns whether the external pause controller currently signals a paused state.
 
 #### Returns
 
-| Name | Type | Description                                                           |
-| ---- | ---- | --------------------------------------------------------------------- |
-| \_0  | bool | `true` if the token should treat itself as paused; `false` otherwise. |
+| Name | Type | Description                                                       |
+| ---- | ---- | ----------------------------------------------------------------- |
+| \_0  | bool | True if the token should treat itself as paused; false otherwise. |

--- a/docs/ats/api/contracts/facets/identity/externalInterfaces/IIdentityRegistry.md
+++ b/docs/ats/api/contracts/facets/identity/externalInterfaces/IIdentityRegistry.md
@@ -26,6 +26,6 @@ Returns whether `_userAddress` has a verified identity in the registry.
 
 #### Returns
 
-| Name | Type | Description                                           |
-| ---- | ---- | ----------------------------------------------------- |
-| \_0  | bool | `true` if the address is verified; `false` otherwise. |
+| Name | Type | Description                                       |
+| ---- | ---- | ------------------------------------------------- |
+| \_0  | bool | True if the address is verified, false otherwise. |

--- a/docs/ats/api/contracts/facets/kyc/IRevocationList.md
+++ b/docs/ats/api/contracts/facets/kyc/IRevocationList.md
@@ -11,20 +11,20 @@ Minimal interface for querying whether a verifiable credential issued to a subje
 ### revoked
 
 ```solidity
-function revoked(address, string) external view returns (bool)
+function revoked(address subject, string vcId) external view returns (bool)
 ```
 
-Checks if the VC granted by an issuer to a subject has been revoked
+Checks if the VC granted by an issuer to a subject has been revoked.
 
 #### Parameters
 
-| Name | Type    | Description |
-| ---- | ------- | ----------- |
-| \_0  | address | undefined   |
-| \_1  | string  | undefined   |
+| Name    | Type    | Description                                                   |
+| ------- | ------- | ------------------------------------------------------------- |
+| subject | address | The address of the subject whose credential is being queried. |
+| vcId    | string  | The identifier of the verifiable credential to check.         |
 
 #### Returns
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| \_0  | bool | undefined   |
+| Name | Type | Description                                               |
+| ---- | ---- | --------------------------------------------------------- |
+| \_0  | bool | True if the credential has been revoked, false otherwise. |

--- a/docs/ats/api/contracts/facets/partitions/IPartitions.md
+++ b/docs/ats/api/contracts/facets/partitions/IPartitions.md
@@ -36,9 +36,9 @@ Indicates whether the token operates in multi-partition mode.
 
 #### Returns
 
-| Name | Type | Description                                                                                                                        |
-| ---- | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| \_0  | bool | true : the token allows multiple partitions to be set and managed. false : the token contains only one partition, the default one. |
+| Name | Type | Description                                                                         |
+| ---- | ---- | ----------------------------------------------------------------------------------- |
+| \_0  | bool | True if the token allows multiple partitions to be set and managed; false otherwise |
 
 ### partitionsOf
 

--- a/docs/ats/api/contracts/facets/partitions/Partitions.md
+++ b/docs/ats/api/contracts/facets/partitions/Partitions.md
@@ -36,9 +36,9 @@ Indicates whether the token operates in multi-partition mode.
 
 #### Returns
 
-| Name | Type | Description                                                                                                                        |
-| ---- | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| \_0  | bool | true : the token allows multiple partitions to be set and managed. false : the token contains only one partition, the default one. |
+| Name | Type | Description                                                                         |
+| ---- | ---- | ----------------------------------------------------------------------------------- |
+| \_0  | bool | True if the token allows multiple partitions to be set and managed; false otherwise |
 
 ### partitionsOf
 

--- a/docs/ats/api/contracts/facets/partitions/PartitionsFacet.md
+++ b/docs/ats/api/contracts/facets/partitions/PartitionsFacet.md
@@ -78,9 +78,9 @@ Indicates whether the token operates in multi-partition mode.
 
 #### Returns
 
-| Name | Type | Description                                                                                                                        |
-| ---- | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| \_0  | bool | true : the token allows multiple partitions to be set and managed. false : the token contains only one partition, the default one. |
+| Name | Type | Description                                                                         |
+| ---- | ---- | ----------------------------------------------------------------------------------- |
+| \_0  | bool | True if the token allows multiple partitions to be set and managed; false otherwise |
 
 ### partitionsOf
 

--- a/docs/ats/api/contracts/facets/recovery/IRecovery.md
+++ b/docs/ats/api/contracts/facets/recovery/IRecovery.md
@@ -34,9 +34,9 @@ Returns whether a wallet address has been marked as recovered.
 
 #### Returns
 
-| Name | Type | Description                                                                |
-| ---- | ---- | -------------------------------------------------------------------------- |
-| \_0  | bool | `true` if the address has previously been recovered via {recoveryAddress}. |
+| Name | Type | Description                                                              |
+| ---- | ---- | ------------------------------------------------------------------------ |
+| \_0  | bool | True if the address has previously been recovered via {recoveryAddress}. |
 
 ### recoveryAddress
 

--- a/docs/ats/api/contracts/facets/recovery/Recovery.md
+++ b/docs/ats/api/contracts/facets/recovery/Recovery.md
@@ -36,9 +36,9 @@ Returns whether a wallet address has been marked as recovered.
 
 #### Returns
 
-| Name | Type | Description                                                                |
-| ---- | ---- | -------------------------------------------------------------------------- |
-| \_0  | bool | `true` if the address has previously been recovered via {recoveryAddress}. |
+| Name | Type | Description                                                              |
+| ---- | ---- | ------------------------------------------------------------------------ |
+| \_0  | bool | True if the address has previously been recovered via {recoveryAddress}. |
 
 ### recoveryAddress
 

--- a/docs/ats/api/contracts/facets/recovery/RecoveryFacet.md
+++ b/docs/ats/api/contracts/facets/recovery/RecoveryFacet.md
@@ -78,9 +78,9 @@ Returns whether a wallet address has been marked as recovered.
 
 #### Returns
 
-| Name | Type | Description                                                                |
-| ---- | ---- | -------------------------------------------------------------------------- |
-| \_0  | bool | `true` if the address has previously been recovered via {recoveryAddress}. |
+| Name | Type | Description                                                              |
+| ---- | ---- | ------------------------------------------------------------------------ |
+| \_0  | bool | True if the address has previously been recovered via {recoveryAddress}. |
 
 ### recoveryAddress
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20652,6 +20652,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20668,6 +20669,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20684,6 +20686,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20700,6 +20703,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20716,6 +20720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20732,6 +20737,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20748,6 +20754,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20764,6 +20771,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20780,6 +20788,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20796,6 +20805,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20812,6 +20822,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -20828,6 +20839,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/packages/ats/contracts/.betterer.results
+++ b/packages/ats/contracts/.betterer.results
@@ -5,11 +5,10 @@
 //
 exports[`ats contracts solhint`] = {
   value: `{
-    "contracts/domain/asset/AmortizationStorageWrapper.sol:785034391": [
+    "contracts/domain/asset/AmortizationStorageWrapper.sol:2696188797": [
       [117, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [154, 4, 1, "function-max-lines: Function body contains 51 lines but allowed no more than 50 lines", "177603"],
-      [400, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [425, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
+      [399, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [424, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
     ],
     "contracts/domain/asset/ClearingStorageWrapper.sol:657877060": [
       [720, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
@@ -23,7 +22,7 @@ exports[`ats contracts solhint`] = {
       [169, 4, 1, "use-natspec: Mismatch in @param count for function \'canRedeemFromByPartition\'. Expected: 5, Found: 3", "177603"],
       [242, 4, 1, "use-natspec: Mismatch in @param count for function \'canTransferFromByPartition\'. Expected: 6, Found: 4", "177603"]
     ],
-    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:879907329": [
+    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:1439876099": [
       [101, 4, 1, "use-natspec: Mismatch in @param count for function \'afterTokenTransfer\'. Expected: 4, Found: 3", "177603"],
       [298, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"],
       [309, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"]
@@ -31,26 +30,18 @@ exports[`ats contracts solhint`] = {
     "contracts/domain/asset/HoldStorageWrapper.sol:533726159": [
       [800, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
     ],
-    "contracts/domain/asset/KpisStorageWrapper.sol:4143231592": [
-      [74, 20, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"],
-      [103, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"],
-      [125, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"]
+    "contracts/domain/asset/KpisStorageWrapper.sol:1344912392": [
+      [104, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"]
     ],
     "contracts/domain/asset/LockStorageWrapper.sol:2572777485": [
       [239, 4, 1, "use-natspec: Mismatch in @param count for function \'updateLockedBalancesBeforeLock\'. Expected: 4, Found: 2", "177603"],
       [257, 4, 1, "use-natspec: Mismatch in @param count for function \'updateLockedBalancesBeforeRelease\'. Expected: 3, Found: 2", "177603"],
       [327, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
     ],
-    "contracts/domain/asset/MaturityDateStorageWrapper.sol:4271145073": [
-      [56, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:3874914318": [
+      [193, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
     ],
-    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:3974124552": [
-      [193, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
-      [437, 16, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177622"]
-    ],
-    "contracts/domain/asset/SnapshotsStorageWrapper.sol:2238766544": [
-      [139, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
-      [153, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
+    "contracts/domain/asset/SnapshotsStorageWrapper.sol:732035984": [
       [1038, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
     ],
     "contracts/domain/asset/VotingStorageWrapper.sol:1130199794": [
@@ -64,13 +55,7 @@ exports[`ats contracts solhint`] = {
       [382, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
       [402, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177621"]
     ],
-    "contracts/domain/core/CapStorageWrapper.sol:2272932499": [
-      [240, 37, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
-    ],
-    "contracts/domain/core/CorporateActionsStorageWrapper.sol:1633069601": [
-      [147, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
-    ],
-    "contracts/domain/orchestrator/ClearingOps.sol:1768944660": [
+    "contracts/domain/orchestrator/ClearingOps.sol:1078388775": [
       [57, 4, 1, "function-max-lines: Function body contains 57 lines but allowed no more than 50 lines", "177603"],
       [57, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
       [57, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
@@ -78,7 +63,6 @@ exports[`ats contracts solhint`] = {
       [137, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingRedeemCreation] could be [calldata] if it\'s not being updated", "177603"],
       [137, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingRedeemCreation] could be [calldata] if it\'s not being updated", "177603"],
       [221, 4, 1, "function-max-lines: Function body contains 58 lines but allowed no more than 50 lines", "177603"],
-      [221, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
       [221, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
       [407, 4, 1, "function-max-lines: Function body contains 52 lines but allowed no more than 50 lines", "177603"]
     ],
@@ -252,9 +236,6 @@ exports[`ats contracts solhint`] = {
       [45, 4, 1, "gas-indexed-events: GC: [decimals] on Event [ScheduledBalanceAdjustmentSet] could be Indexed", "177600"],
       [59, 4, 1, "gas-indexed-events: GC: [balanceAdjustmentId] on Event [ScheduledBalanceAdjustmentCancelled] could be Indexed", "177600"],
       [66, 4, 1, "gas-indexed-events: GC: [balanceAdjustmentId] on Event [ScheduledBalanceAdjustmentForceCancelled] could be Indexed", "177600"]
-    ],
-    "contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentBase.sol:3351011126": [
-      [109, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177600"]
     ],
     "contracts/facets/scheduledCrossOrderedTasks/IScheduledCrossOrderedTasks.sol:1747555586": [
       [22, 4, 1, "gas-indexed-events: GC: [scheduledTimestamp] on Event [TaskExecutionFailed] could be Indexed", "177600"]

--- a/packages/ats/contracts/.betterer.results
+++ b/packages/ats/contracts/.betterer.results
@@ -5,11 +5,11 @@
 //
 exports[`ats contracts solhint`] = {
   value: `{
-    "contracts/domain/asset/AmortizationStorageWrapper.sol:2444797827": [
+    "contracts/domain/asset/AmortizationStorageWrapper.sol:785034391": [
       [117, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [155, 4, 1, "function-max-lines: Function body contains 53 lines but allowed no more than 50 lines", "177603"],
-      [403, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [428, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
+      [154, 4, 1, "function-max-lines: Function body contains 51 lines but allowed no more than 50 lines", "177603"],
+      [400, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
+      [425, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
     ],
     "contracts/domain/asset/ClearingStorageWrapper.sol:657877060": [
       [720, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
@@ -19,32 +19,39 @@ exports[`ats contracts solhint`] = {
       [246, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
       [264, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
     ],
-    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:1519984577": [
+    "contracts/domain/asset/ERC1594StorageWrapper.sol:1689167301": [
+      [169, 4, 1, "use-natspec: Mismatch in @param count for function \'canRedeemFromByPartition\'. Expected: 5, Found: 3", "177603"],
+      [242, 4, 1, "use-natspec: Mismatch in @param count for function \'canTransferFromByPartition\'. Expected: 6, Found: 4", "177603"]
+    ],
+    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:879907329": [
+      [101, 4, 1, "use-natspec: Mismatch in @param count for function \'afterTokenTransfer\'. Expected: 4, Found: 3", "177603"],
       [298, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"],
       [309, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"]
     ],
     "contracts/domain/asset/HoldStorageWrapper.sol:533726159": [
       [800, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
     ],
-    "contracts/domain/asset/KpisStorageWrapper.sol:1085411112": [
-      [76, 20, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"],
-      [157, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"],
-      [179, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"]
+    "contracts/domain/asset/KpisStorageWrapper.sol:4143231592": [
+      [74, 20, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"],
+      [103, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"],
+      [125, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177606"]
     ],
-    "contracts/domain/asset/LockStorageWrapper.sol:1857377066": [
+    "contracts/domain/asset/LockStorageWrapper.sol:2572777485": [
+      [239, 4, 1, "use-natspec: Mismatch in @param count for function \'updateLockedBalancesBeforeLock\'. Expected: 4, Found: 2", "177603"],
+      [257, 4, 1, "use-natspec: Mismatch in @param count for function \'updateLockedBalancesBeforeRelease\'. Expected: 3, Found: 2", "177603"],
       [327, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
     ],
     "contracts/domain/asset/MaturityDateStorageWrapper.sol:4271145073": [
       [56, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
     ],
-    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:2827404587": [
-      [228, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
-      [472, 16, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177622"]
+    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:3974124552": [
+      [193, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
+      [437, 16, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177622"]
     ],
-    "contracts/domain/asset/SnapshotsStorageWrapper.sol:3547134957": [
+    "contracts/domain/asset/SnapshotsStorageWrapper.sol:2238766544": [
       [139, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
       [153, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177609"],
-      [1034, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
+      [1038, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
     ],
     "contracts/domain/asset/VotingStorageWrapper.sol:1130199794": [
       [58, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
@@ -74,6 +81,9 @@ exports[`ats contracts solhint`] = {
       [221, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
       [221, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
       [407, 4, 1, "function-max-lines: Function body contains 52 lines but allowed no more than 50 lines", "177603"]
+    ],
+    "contracts/domain/orchestrator/ClearingReadOps.sol:129972878": [
+      [158, 4, 1, "use-natspec: Mismatch in @param count for function \'checkClearingExpirationTimestamp\'. Expected: 3, Found: 2", "177603"]
     ],
     "contracts/domain/orchestrator/HoldOps.sol:2308870617": [
       [29, 4, 1, "gas-calldata-parameters: GC: [_hold] argument on Function [createHoldByPartition] could be [calldata] if it\'s not being updated", "177603"],
@@ -157,7 +167,7 @@ exports[`ats contracts solhint`] = {
     "contracts/facets/dividend/IDividendTypes.sol:2960222249": [
       [58, 4, 1, "gas-struct-packing: GC: For [ DividendFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
     ],
-    "contracts/facets/erc20Votes/IERC20Votes.sol:1279752095": [
+    "contracts/facets/erc20Votes/IERC20Votes.sol:3630286460": [
       [19, 4, 1, "gas-indexed-events: GC: [activated] on Event [ERC20VotesInitialized] could be Indexed", "177600"],
       [31, 4, 1, "gas-indexed-events: GC: [previousBalance] on Event [DelegateVotesChanged] could be Indexed", "177600"],
       [31, 4, 1, "gas-indexed-events: GC: [newBalance] on Event [DelegateVotesChanged] could be Indexed", "177600"]
@@ -225,7 +235,7 @@ exports[`ats contracts solhint`] = {
       [36, 4, 1, "gas-indexed-events: GC: [nominalValue] on Event [NominalValueSet] could be Indexed", "177600"],
       [36, 4, 1, "gas-indexed-events: GC: [nominalValueDecimals] on Event [NominalValueSet] could be Indexed", "177600"]
     ],
-    "contracts/facets/partitions/IPartitions.sol:165312895": [
+    "contracts/facets/partitions/IPartitions.sol:2641262830": [
       [20, 4, 1, "gas-indexed-events: GC: [multiPartition] on Event [PartitionsInitialized] could be Indexed", "177600"]
     ],
     "contracts/facets/protectedClearingByPartition/IProtectedClearingByPartition.sol:2414024950": [

--- a/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
@@ -144,8 +144,7 @@ library AmortizationStorageWrapper {
      * @dev When an active hold already exists for the same `(amortization, holder)` pair,
      *      that hold is released first and the total adjusted accordingly. A new hold is
      *      then created on the default partition with the contract itself as escrow.
-     *      Reverts with {AmortizationNotActive} if the amortization has been disabled or
-     *      {AmortizationHoldFailed} if the hold creation does not succeed. The calling facet
+     *      Reverts with {AmortizationNotActive} if the amortization has been disabled. The calling facet
      *      (`Amortization`) emits {AmortizationHoldSet}.
      * @param _amortizationID The one-based identifier of the amortization.
      * @param _tokenHolder The holder against whom the hold is taken.
@@ -189,15 +188,13 @@ library AmortizationStorageWrapper {
             data: ""
         });
 
-        (bool success, uint256 newHoldId) = HoldStorageWrapper.createHoldByPartition(
+        (, uint256 newHoldId) = HoldStorageWrapper.createHoldByPartition(
             _DEFAULT_PARTITION,
             _tokenHolder,
             hold,
             "",
             ThirdPartyType.CONTROLLER
         );
-
-        if (!success) revert IAmortization.AmortizationHoldFailed(corporateActionId, _amortizationID);
 
         s.amortizationHolds[corporateActionId][_tokenHolder] = AmortizationHoldInfo({
             holdId: newHoldId,
@@ -545,48 +542,25 @@ library AmortizationStorageWrapper {
     }
 
     /**
-     * @notice Releases (in part or in full) a hold by writing directly to hold storage.
-     * @dev Avoids the calldata-to-memory conversion of the standard hold release path.
-     *      Reverts with {InsufficientHoldBalance} if the recorded hold amount is smaller
-     *      than the requested release. Restores allowance when the hold's third-party
-     *      type is `AUTHORIZED`, removes the LABAF entry and emits the standard transfer
-     *      events to keep observers in sync.
+     * @notice Fully removes an amortization hold by writing directly to hold storage.
+     * @dev Removes the LABAF entry and emits the standard transfer events to keep
+     *      observers in sync.
      * @param _tokenHolder The holder whose hold is being released.
      * @param _holdId The hold identifier on the default partition.
-     * @param _amount The amount to release; equal to the hold amount triggers full removal.
+     * @param _amount The amount to release.
      * @return Always true on success; reverts otherwise.
      */
     function _releaseHold(address _tokenHolder, uint256 _holdId, uint256 _amount) private returns (bool) {
-        bytes32 partition = _DEFAULT_PARTITION;
         IHoldTypes.HoldIdentifier memory identifier = IHoldTypes.HoldIdentifier({
-            partition: partition,
+            partition: _DEFAULT_PARTITION,
             tokenHolder: _tokenHolder,
             holdId: _holdId
         });
 
-        uint256 holdAmount = HoldStorageWrapper.getHold(identifier).hold.amount;
-        if (holdAmount < _amount) {
-            revert IHoldTypes.InsufficientHoldBalance(holdAmount, _amount);
-        }
-
-        // Restore allowance before any deletion so the third-party record is still readable
-        if (HoldStorageWrapper.getHold(identifier).thirdPartyType == ThirdPartyType.AUTHORIZED) {
-            address thirdParty = HoldStorageWrapper.getHoldThirdParty(identifier);
-            if (thirdParty != address(0)) {
-                ERC20StorageWrapper.increaseAllowedBalance(_tokenHolder, thirdParty, _amount);
-            }
-        }
-
-        if (_amount == holdAmount) {
-            // Full removal: clears id set, hold record, third-party record, and LABAF entry
-            HoldStorageWrapper.removeHold(identifier);
-        } else {
-            // Partial release: decrements hold.amount and both held-amount counters in storage
-            HoldStorageWrapper.decreaseHeldAmount(identifier, _amount);
-        }
+        HoldStorageWrapper.removeHold(identifier);
 
         emit IERC1410Types.TransferByPartition(
-            partition,
+            _DEFAULT_PARTITION,
             EvmAccessors.getMsgSender(),
             address(0),
             _tokenHolder,
@@ -597,39 +571,6 @@ library AmortizationStorageWrapper {
         emit ITransfer.Transfer(address(0), _tokenHolder, _amount);
 
         return true;
-    }
-
-    /**
-     * @notice Returns the adjusted hold amount for a holder at the given timestamp.
-     * @dev Reads the hold's base amount and multiplies by the ABAF/LABAF factor evaluated
-     *      at `_timestamp`. Used to render hold balances consistent with balance-adjustment
-     *      history.
-     * @param _tokenHolder The holder whose hold is being queried.
-     * @param _holdId The hold identifier on the default partition.
-     * @param _timestamp The reference timestamp.
-     * @return amount_ The hold amount scaled by the adjustment factor at `_timestamp`.
-     */
-    function _getHoldAdjustedAt(
-        address _tokenHolder,
-        uint256 _holdId,
-        uint256 _timestamp
-    ) private view returns (uint256 amount_) {
-        bytes32 partition = _DEFAULT_PARTITION;
-
-        IHoldTypes.HoldIdentifier memory identifier = IHoldTypes.HoldIdentifier({
-            partition: partition,
-            tokenHolder: _tokenHolder,
-            holdId: _holdId
-        });
-
-        // Get base amount
-        amount_ = HoldStorageWrapper.getHold(identifier).hold.amount;
-
-        // Apply adjustment factor for timestamp
-        uint256 abafAdjusted = AdjustBalancesStorageWrapper.getAbafAdjustedAt(_timestamp);
-        uint256 holdLabaf = AdjustBalancesStorageWrapper.getHoldLabafById(partition, _tokenHolder, _holdId);
-
-        amount_ = amount_ * AdjustBalancesStorageWrapper.calculateFactor(abafAdjusted, holdLabaf);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/AmortizationStorageWrapper.sol
@@ -161,7 +161,6 @@ library AmortizationStorageWrapper {
             CORPORATE_ACTION_TYPE_AMORTIZATION,
             _amortizationID - 1
         );
-
         if (_amortizationStorage().disabledAmortizations[corporateActionId]) {
             revert IAmortization.AmortizationNotActive(corporateActionId, _amortizationID);
         }

--- a/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1410StorageWrapper.sol
@@ -895,7 +895,7 @@ library ERC1410StorageWrapper {
      * @dev Delegates to `validPartitionForReceiver` since the membership test is symmetric.
      * @param partition Partition identifier being checked.
      * @param holder    Address being queried.
-     * @return `true` when the holder has an entry for the partition.
+     * @return True when the holder has an entry for the partition; false otherwise.
      */
     function validPartition(bytes32 partition, address holder) internal view returns (bool) {
         return validPartitionForReceiver(partition, holder);
@@ -907,7 +907,7 @@ library ERC1410StorageWrapper {
      *      the address.
      * @param partition Partition identifier being checked.
      * @param to        Recipient candidate being queried.
-     * @return `true` when the recipient already has an entry for the partition.
+     * @return True when the recipient already has an entry for the partition.
      */
     function validPartitionForReceiver(bytes32 partition, address to) internal view returns (bool) {
         return erc1410BasicStorage().partitionToIndex[to][partition] != 0;
@@ -965,7 +965,7 @@ library ERC1410StorageWrapper {
      * @notice Reports whether multi-partition mode is enabled on the token.
      * @dev Read from `ERC1410BasicStorage.multiPartition`; controls whether non-default partitions
      *      are accepted by `requireDefaultPartitionWithSinglePartition` and similar guards.
-     * @return `true` when multi-partition mode is active.
+     * @return True when multi-partition mode is active.
      */
     function isMultiPartition() internal view returns (bool) {
         return erc1410BasicStorage().multiPartition;
@@ -976,7 +976,7 @@ library ERC1410StorageWrapper {
      * @dev Reads the global approval flag from `ERC1410OperatorStorage.approvals`.
      * @param operator    Candidate operator address.
      * @param tokenHolder Holder whose approval set is checked.
-     * @return `true` when the operator is globally authorised by the holder.
+     * @return True when the operator is globally authorised by the holder.
      */
     function isOperator(address operator, address tokenHolder) internal view returns (bool) {
         return erc1410OperatorStorage().approvals[tokenHolder][operator];
@@ -988,7 +988,7 @@ library ERC1410StorageWrapper {
      * @param partition   Partition identifier being checked.
      * @param operator    Candidate operator address.
      * @param tokenHolder Holder whose approval set is checked.
-     * @return `true` when the operator is authorised on the partition.
+     * @return True when the operator is authorised on the partition.
      */
     function isOperatorForPartition(
         bytes32 partition,
@@ -1004,7 +1004,7 @@ library ERC1410StorageWrapper {
      * @param partition   Partition identifier driving the action.
      * @param operator    Candidate operator address.
      * @param tokenHolder Holder whose approval set is checked.
-     * @return `true` when either authorisation tier permits the operator.
+     * @return True when either authorisation tier permits the operator.
      */
     function isAuthorized(bytes32 partition, address operator, address tokenHolder) internal view returns (bool) {
         return isOperator(operator, tokenHolder) || isOperatorForPartition(partition, operator, tokenHolder);

--- a/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
@@ -102,7 +102,7 @@ library ERC1594StorageWrapper {
 
     /**
      * @notice Returns whether token issuance is currently enabled.
-     * @return `true` if the `issuance` flag is set, otherwise `false`.
+     * @return True if the `issuance` flag is set, otherwise false.
      */
     function isIssuable() internal view returns (bool) {
         return erc1594Storage().issuance;
@@ -245,8 +245,8 @@ library ERC1594StorageWrapper {
         address to,
         bytes32 partition,
         uint256 value,
-        bytes memory /*_data*/,
-        bytes memory /*_operatorData*/
+        bytes memory /* _data */,
+        bytes memory /* _operatorData */
     ) internal view returns (bool canTransfer, bytes1 statusCode, bytes32 reasonCode, bytes memory details) {
         (canTransfer, statusCode, reasonCode, details) = _genericChecks();
         if (!canTransfer) return (canTransfer, statusCode, reasonCode, details);

--- a/packages/ats/contracts/contracts/domain/asset/ERC1644StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1644StorageWrapper.sol
@@ -59,7 +59,7 @@ library ERC1644StorageWrapper {
 
     /**
      * @notice Returns whether the token is currently controllable.
-     * @return `true` while the controllable feature is active.
+     * @return True while the controllable feature is active.
      */
     function isControllable() internal view returns (bool) {
         return erc1644Storage().isControllable;

--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -245,7 +245,7 @@ library ERC20StorageWrapper {
      * @param owner   Address granting the allowance. Must not be the zero address.
      * @param spender Address permitted to spend `value` tokens on behalf of `owner`.
      * @param value   Allowance amount to set.
-     * @return `true` unconditionally on success; reverts on failure.
+     * @return True unconditionally on success; reverts on failure.
      */
     function approve(address owner, address spender, uint256 value) internal returns (bool) {
         _checkUnexpectedError(owner == address(0), KPI_ERC20_APPROVE_OWNER);
@@ -269,7 +269,7 @@ library ERC20StorageWrapper {
      *      emits an `Approval` event.
      * @param spender    Address whose allowance is increased.
      * @param addedValue Amount to add to the existing allowance.
-     * @return `true` unconditionally on success; reverts on failure.
+     * @return True unconditionally on success; reverts on failure.
      */
     function increaseAllowance(address spender, uint256 addedValue) internal returns (bool) {
         if (spender == address(0)) {
@@ -289,7 +289,7 @@ library ERC20StorageWrapper {
      *      allowance. Reverts via `decreaseAllowedBalance` if allowance is insufficient.
      * @param spender         Address whose allowance is decreased.
      * @param subtractedValue Amount to subtract from the existing allowance.
-     * @return `true` unconditionally on success; reverts on failure.
+     * @return True unconditionally on success; reverts on failure.
      */
     function decreaseAllowance(address spender, uint256 subtractedValue) internal returns (bool) {
         if (spender == address(0)) {
@@ -313,7 +313,7 @@ library ERC20StorageWrapper {
      * @param from    Source account whose balance is debited.
      * @param to      Destination account whose balance is credited.
      * @param value   Amount of tokens to transfer.
-     * @return `true` unconditionally on success; reverts on failure.
+     * @return True unconditionally on success; reverts on failure.
      */
     function transferFrom(address spender, address from, address to, uint256 value) internal returns (bool) {
         decreaseAllowedBalance(from, spender, value);
@@ -336,7 +336,7 @@ library ERC20StorageWrapper {
      * @param from  Source account.
      * @param to    Destination account.
      * @param value Amount of tokens to transfer.
-     * @return `true` unconditionally on success; reverts on failure.
+     * @return True unconditionally on success; reverts on failure.
      */
     function transfer(address from, address to, uint256 value) internal returns (bool) {
         ERC1410StorageWrapper.transferByPartition(

--- a/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
@@ -99,7 +99,7 @@ library ERC20VotesStorageWrapper {
      * @param to The account receiving tokens (or address(0) for burns).
      * @param amount The number of tokens transferred.
      */
-    function afterTokenTransfer(bytes32 /* partition */, address from, address to, uint256 amount) internal {
+    function afterTokenTransfer(bytes32, address from, address to, uint256 amount) internal {
         ERC20VotesStorage storage erc20VotesStorage = erc20VotesStorage_();
 
         if (!isActivated()) return;

--- a/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20VotesStorageWrapper.sol
@@ -99,7 +99,7 @@ library ERC20VotesStorageWrapper {
      * @param to The account receiving tokens (or address(0) for burns).
      * @param amount The number of tokens transferred.
      */
-    function afterTokenTransfer(bytes32 /*partition*/, address from, address to, uint256 amount) internal {
+    function afterTokenTransfer(bytes32 /* partition */, address from, address to, uint256 amount) internal {
         ERC20VotesStorage storage erc20VotesStorage = erc20VotesStorage_();
 
         if (!isActivated()) return;

--- a/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
@@ -72,6 +72,7 @@ library KpisStorageWrapper {
         unchecked {
             for (uint256 i = length; i > 0; --i) {
                 uint256 prev = i - 1;
+                // solhint-disable-next-line gas-strict-inequalities
                 if (ckpt[prev].from <= date) {
                     ckpt[i] = Checkpoints.Checkpoint({ from: date, value: value });
                     return;
@@ -123,7 +124,7 @@ library KpisStorageWrapper {
         (uint256 checkpointFrom, uint256 value_) = kpisDataStorage().checkpointsByProject[project].checkpointsLookup(
             to
         );
-        if (checkpointFrom <= from) return (0, false);
+        if (checkpointFrom <= from) return (0, false); // solhint-disable-line gas-strict-inequalities
         return (value_, true);
     }
 

--- a/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpisStorageWrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { KPI_KPIS_ADD_COUPON_DATE, KPI_KPIS_SET_MINDATE } from "../../constants/values.sol";
+import { KPI_KPIS_SET_MINDATE } from "../../constants/values.sol";
 import { IKpis } from "../../facets/kpis/IKpis.sol";
 import { Checkpoints } from "../../infrastructure/utils/Checkpoints.sol";
 import { CouponStorageWrapper } from "./coupon/CouponStorageWrapper.sol";
@@ -46,16 +46,14 @@ library KpisStorageWrapper {
 
     /**
      * @notice Inserts a KPI data point at `date` for `project`, maintaining sort order.
-     * @dev Reverts if the date is already a checkpoint for the project. Appends in O(1)
-     *      when the date is strictly greater than the latest entry; otherwise shifts the
-     *      tail right to place the new entry in its sorted position. The calling facet (`Kpis`)
-     *      emits `KpiDataAdded`.
+     * @dev Appends in O(1) when the date is strictly greater than the latest entry; otherwise
+     *      shifts the tail right to place the new entry in its sorted position. The calling
+     *      facet (`Kpis`) emits `KpiDataAdded`.
      * @param date The KPI data timestamp (must be unique per project).
      * @param value The KPI data value.
      * @param project The project address the KPI belongs to.
      */
     function addKpiData(uint256 date, uint256 value, address project) internal {
-        if (isCheckpointDate(date, project)) revert IKpis.KpiDataAlreadyExists(date);
         setCheckpointDate(date, project);
         Checkpoints.Checkpoint[] storage ckpt = kpisDataStorage().checkpointsByProject[project];
         uint256 length = ckpt.length;
@@ -83,58 +81,6 @@ library KpisStorageWrapper {
         }
         // Insert at position 0
         ckpt[0] = Checkpoints.Checkpoint({ from: date, value: value });
-    }
-
-    /**
-     * @notice Registers a coupon in the ordered list and advances `minDate` accordingly.
-     * @dev Delegates list maintenance to `CouponStorageWrapper`; asserts the coupon's
-     *      fixing date does not regress below the current `minDate`.
-     * @param couponID Identifier of the coupon being registered.
-     */
-    function addToCouponsOrderedList(uint256 couponID) internal {
-        CouponStorageWrapper.addToCouponsOrderedList(couponID);
-
-        (ICouponTypes.RegisteredCoupon memory registeredCoupon, , ) = CouponStorageWrapper.getCoupon(couponID);
-        uint256 lastFixingDate = registeredCoupon.coupon.fixingDate;
-
-        _checkUnexpectedError(lastFixingDate < kpisDataStorage().minDate, KPI_KPIS_ADD_COUPON_DATE);
-
-        setMinDate(lastFixingDate);
-    }
-
-    /**
-     * @notice Appends a checkpoint entry at the end of the given storage array.
-     * @param ckpt The storage array to push into.
-     * @param date The checkpoint's `from` timestamp.
-     * @param value The checkpoint value.
-     */
-    function pushKpiData(Checkpoints.Checkpoint[] storage ckpt, uint256 date, uint256 value) internal {
-        ckpt.push(Checkpoints.Checkpoint({ from: date, value: value }));
-    }
-
-    /**
-     * @notice Overwrites the checkpoint at `pos` with new date and value.
-     * @param ckpt The storage array to mutate.
-     * @param date New `from` timestamp.
-     * @param value New checkpoint value.
-     * @param pos Index of the entry to overwrite.
-     */
-    function overwriteKpiData(
-        Checkpoints.Checkpoint[] storage ckpt,
-        uint256 date,
-        uint256 value,
-        uint256 pos
-    ) internal {
-        ckpt[pos].from = date;
-        ckpt[pos].value = value;
-    }
-
-    /**
-     * @notice Updates the minimum allowed KPI date.
-     * @param date The new minimum date.
-     */
-    function setMinDate(uint256 date) internal {
-        kpisDataStorage().minDate = date;
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LockStorageWrapper.sol
@@ -234,14 +234,14 @@ library LockStorageWrapper {
      *      second (`amount`) and fourth (`expirationTimestamp`) arguments are deliberately unused;
      *      they exist only to keep the helper signature-compatible with the locking pipeline's
      *      call-site.
-     * @param partition Partition being mutated.
-     * @param tokenHolder Holder whose snapshots are being refreshed.
+     * @param partition           Partition being mutated.
+     * @param tokenHolder         Holder whose snapshots are being refreshed.
      */
     function updateLockedBalancesBeforeLock(
         bytes32 partition,
-        uint256 /*amount*/,
+        uint256 /* amount */,
         address tokenHolder,
-        uint256 /*expirationTimestamp*/
+        uint256 /* expirationTimestamp */
     ) internal {
         SnapshotsStorageWrapper.updateAccountSnapshot(tokenHolder, partition);
         SnapshotsStorageWrapper.updateAccountLockedBalancesSnapshot(tokenHolder, partition);
@@ -252,10 +252,10 @@ library LockStorageWrapper {
      * @dev Mirror of `updateLockedBalancesBeforeLock`. The second (`lockId`) argument is
      *      deliberately unused; it exists only to keep the helper signature-compatible with
      *      the release pipeline's call-site.
-     * @param partition Partition being mutated.
+     * @param partition   Partition being mutated.
      * @param tokenHolder Holder whose snapshots are being refreshed.
      */
-    function updateLockedBalancesBeforeRelease(bytes32 partition, uint256 /*lockId*/, address tokenHolder) internal {
+    function updateLockedBalancesBeforeRelease(bytes32 partition, uint256 /* lockId */, address tokenHolder) internal {
         SnapshotsStorageWrapper.updateAccountSnapshot(tokenHolder, partition);
         SnapshotsStorageWrapper.updateAccountLockedBalancesSnapshot(tokenHolder, partition);
     }
@@ -318,7 +318,7 @@ library LockStorageWrapper {
      * @param partition Partition the lock belongs to.
      * @param tokenHolder Holder that owns the lock.
      * @param lockId Identifier of the lock being inspected.
-     * @return `true` if the lock can be released, `false` otherwise.
+     * @return True if the lock has expired and can be released, false otherwise.
      */
     function isLockedExpirationTimestamp(
         bytes32 partition,
@@ -335,7 +335,7 @@ library LockStorageWrapper {
      * @param partition Partition the lock would belong to.
      * @param tokenHolder Holder that would own the lock.
      * @param lockId Identifier being checked.
-     * @return `true` when the lock exists; `false` otherwise.
+     * @return True if the lock id exists for the given holder and partition, false otherwise.
      */
     function isLockIdValid(bytes32 partition, address tokenHolder, uint256 lockId) internal view returns (bool) {
         return lockStorage().lockIdsByAccountAndPartition[tokenHolder][partition].contains(lockId);

--- a/packages/ats/contracts/contracts/domain/asset/MaturityDateStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/MaturityDateStorageWrapper.sol
@@ -54,6 +54,7 @@ library MaturityDateStorageWrapper {
      * @param _maturityDate Proposed maturity timestamp (Unix epoch, seconds).
      */
     function checkValidMaturityDate(uint256 _maturityDate) internal view {
+        // solhint-disable-next-line gas-strict-inequalities
         if (_maturityDate <= EvmAccessors.getBlockTimestamp()) {
             revert IMaturity.MaturityDateInvalid();
         }

--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -435,7 +435,7 @@ library ScheduledTasksStorageWrapper {
                 pos
             );
 
-            if (scheduledTask.scheduledTimestamp >= _timestamp) break;
+            if (scheduledTask.scheduledTimestamp >= _timestamp) break; // solhint-disable-line gas-strict-inequalities
 
             bytes32 actionId = abi.decode(scheduledTask.data, (bytes32));
 

--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -109,9 +109,7 @@ library ScheduledTasksStorageWrapper {
             ScheduledTasksLib.popScheduledTask(_scheduledTasks);
 
             bytes32 subTaskType = ScheduledTasksDispatchOps.execute(callbackType, currentScheduledTask);
-            if (subTaskType != bytes32(0)) {
-                _triggerOneSubTask(subTaskType, currentBlockTimestamp);
-            }
+            _triggerOneSubTask(subTaskType, currentBlockTimestamp);
 
             unchecked {
                 ++processed_;
@@ -132,17 +130,6 @@ library ScheduledTasksStorageWrapper {
     }
 
     /**
-     * @notice Executes due scheduled snapshot tasks.
-     * @dev Uses the `snapshot` callback type and may update snapshot-related corporate
-     *      action results through the dispatch layer.
-     * @param _max Maximum number of snapshot tasks to process; zero means all due tasks.
-     * @return Number of snapshot tasks removed from the queue.
-     */
-    function triggerScheduledSnapshots(uint256 _max) internal returns (uint256) {
-        return triggerScheduledTasks(scheduledSnapshotStorage(), bytes32("snapshot"), _max);
-    }
-
-    /**
      * @notice Adds a coupon listing task to the scheduled coupon listing queue.
      * @dev The action identifier is ABI-encoded as task data and later resolved through
      *      corporate action storage by the dispatch layer.
@@ -158,17 +145,6 @@ library ScheduledTasksStorageWrapper {
     }
 
     /**
-     * @notice Executes due scheduled coupon listing tasks.
-     * @dev Uses the `coupon` callback type. Dispatch may add coupons to the ordered list
-     *      and update corporate action results.
-     * @param _max Maximum number of coupon listing tasks to process; zero means all due tasks.
-     * @return Number of coupon listing tasks removed from the queue.
-     */
-    function triggerScheduledCouponListing(uint256 _max) internal returns (uint256) {
-        return triggerScheduledTasks(scheduledCouponListingStorage(), bytes32("coupon"), _max);
-    }
-
-    /**
      * @notice Adds a balance adjustment task to the scheduled balance adjustment queue.
      * @dev The action identifier is ABI-encoded as task data and later used to load the
      *      balance adjustment parameters from corporate action storage.
@@ -181,17 +157,6 @@ library ScheduledTasksStorageWrapper {
             _newScheduledTimestamp,
             abi.encode(_actionId)
         );
-    }
-
-    /**
-     * @notice Executes due scheduled balance adjustment tasks.
-     * @dev Uses the `balance` callback type. Dispatch may mutate balances according to the
-     *      stored adjustment factor and decimals.
-     * @param _max Maximum number of adjustment tasks to process; zero means all due tasks.
-     * @return Number of balance adjustment tasks removed from the queue.
-     */
-    function triggerScheduledBalanceAdjustments(uint256 _max) internal returns (uint256) {
-        return triggerScheduledTasks(scheduledBalanceAdjustmentStorage(), bytes32("balance"), _max);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
@@ -935,7 +935,8 @@ library SnapshotsStorageWrapper {
      *      before any recorded entry. Reverts via {indexFor} for invalid ids.
      * @param snapshotId The snapshot identifier to resolve.
      * @param snapshots  The numeric snapshot history to read.
-     * @return           Tuple of (found-flag, value).
+     * @return           True if a record exists for the given snapshot id, false otherwise.
+     * @return           The recorded uint256 value, or 0 if no record exists.
      */
     function valueAt(uint256 snapshotId, Snapshots storage snapshots) internal view returns (bool, uint256) {
         (bool found, uint256 index) = indexFor(snapshotId, snapshots.ids);
@@ -948,7 +949,8 @@ library SnapshotsStorageWrapper {
      *      Reverts via {indexFor} for invalid ids.
      * @param snapshotId The snapshot identifier to resolve.
      * @param snapshots  The address-typed snapshot history to read.
-     * @return           Tuple of (found-flag, address-value).
+     * @return           True if a record exists for the given snapshot id, false otherwise.
+     * @return           The recorded address value, or address(0) if no record exists.
      */
     function addressValueAt(
         uint256 snapshotId,
@@ -964,7 +966,8 @@ library SnapshotsStorageWrapper {
      *      Reverts via {indexFor} for invalid ids.
      * @param snapshotId The snapshot identifier to resolve.
      * @param snapshots  The `bytes32`-typed snapshot history to read.
-     * @return           Tuple of (found-flag, `bytes32`-value).
+     * @return           True if a record exists for the given snapshot id, false otherwise.
+     * @return           The recorded bytes32 value, or bytes32(0) if no record exists.
      */
     function bytes32ValueAt(
         uint256 snapshotId,
@@ -983,7 +986,8 @@ library SnapshotsStorageWrapper {
      *      than the most recent snapshot.
      * @param snapshotId The snapshot identifier to resolve.
      * @param ids        The ascending list of recorded snapshot ids.
-     * @return           Tuple of (found-flag, array-index).
+     * @return           True if the snapshot id is found in the list, false otherwise.
+     * @return           The array index holding the value for the snapshot id, or 0 if not found.
      */
     function indexFor(uint256 snapshotId, uint256[] storage ids) internal view returns (bool, uint256) {
         if (snapshotId == 0) {

--- a/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/SnapshotsStorageWrapper.sol
@@ -137,7 +137,7 @@ library SnapshotsStorageWrapper {
      */
     function updateSnapshotAddress(SnapshotsAddress storage snapshots, address currentValue) internal {
         uint256 currentId = getCurrentSnapshotId();
-        if (lastSnapshotId(snapshots.ids) >= currentId) return;
+        if (lastSnapshotId(snapshots.ids) >= currentId) return; // solhint-disable-line gas-strict-inequalities
         snapshots.ids.push(currentId);
         snapshots.values.push(currentValue);
     }
@@ -151,7 +151,7 @@ library SnapshotsStorageWrapper {
      */
     function updateSnapshotBytes32(SnapshotsBytes32 storage snapshots, bytes32 currentValue) internal {
         uint256 currentId = getCurrentSnapshotId();
-        if (lastSnapshotId(snapshots.ids) >= currentId) return;
+        if (lastSnapshotId(snapshots.ids) >= currentId) return; // solhint-disable-line gas-strict-inequalities
         snapshots.ids.push(currentId);
         snapshots.values.push(currentValue);
     }

--- a/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
@@ -301,7 +301,7 @@ library AccessControlStorageWrapper {
     /**
      * @notice Returns `true` when `_role` is `DEFAULT_ADMIN_ROLE` and only one member holds it.
      * @param _role The role to inspect.
-     * @return `true` if the caller would be the sole admin after renouncing.
+     * @return True if the caller would be the sole admin after renouncing.
      */
     function _isSoleAdmin(bytes32 _role) private view returns (bool) {
         return _role == DEFAULT_ADMIN_ROLE && rolesStorage().roles[_role].roleMembers.length() == 1;

--- a/packages/ats/contracts/contracts/domain/core/CapStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CapStorageWrapper.sol
@@ -238,7 +238,7 @@ library CapStorageWrapper {
      * @return True if the amount is compliant with the cap; false otherwise.
      */
     function isCorrectMaxSupply(uint256 _amount, uint256 _maxSupply) internal pure returns (bool) {
-        return (_maxSupply == 0) || (_amount <= _maxSupply);
+        return (_maxSupply == 0) || (_amount <= _maxSupply); // solhint-disable-line gas-strict-inequalities
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/core/CorporateActionsStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CorporateActionsStorageWrapper.sol
@@ -145,6 +145,7 @@ library CorporateActionsStorageWrapper {
      * @param _index The type-scoped index to validate.
      */
     function requireMatchingActionType(bytes32 _actionType, uint256 _index) internal view {
+        // solhint-disable-next-line gas-strict-inequalities
         if (getCorporateActionCountByType(_actionType) <= _index)
             revert ICorporateActions.WrongIndexForAction(_index, _actionType);
     }

--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -389,7 +389,7 @@ library ERC3643StorageWrapper {
     /**
      * @notice Reports whether the supplied wallet has been recovered.
      * @param _sender Wallet whose recovery flag is being read.
-     * @return `true` if the wallet has been recovered.
+     * @return Ttrue if the wallet has been recovered.
      */
     function isRecovered(address _sender) internal view returns (bool) {
         return erc3643Storage().addressRecovered[_sender];

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
@@ -220,7 +220,7 @@ library ClearingOps {
      * @return clearingId_ Assigned clearing identifier
      */
     function clearingHoldCreationCreation(
-        IClearingTypes.ClearingOperation memory _clearingOperation,
+        IClearingTypes.ClearingOperation calldata _clearingOperation,
         address _from,
         IHoldTypes.Hold calldata _hold,
         bytes memory _operatorData,

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingReadOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingReadOps.sol
@@ -150,6 +150,9 @@ library ClearingReadOps {
     // TIMESTAMP VALIDATION
 
     /// @notice Reverts unless the clearing operation's expiration state matches `_mustBeExpired`.
+    /// @dev    Delegates expiration logic to `ClearingStorageWrapper.requireExpirationTimestamp`,
+    ///         which reads the current block timestamp internally. `_blockTimestamp` is accepted
+    ///         for interface compatibility but is not used by this implementation.
     /// @param _clearingOperationIdentifier Identifier of the clearing operation to check.
     /// @param _mustBeExpired               When `true`, reverts unless the operation has already
     ///                                     expired; when `false`, reverts if it has expired.

--- a/packages/ats/contracts/contracts/facets/compliance/externalInterfaces/ICompliance.sol
+++ b/packages/ats/contracts/contracts/facets/compliance/externalInterfaces/ICompliance.sol
@@ -40,7 +40,7 @@ interface ICompliance {
      * @param _from   Address sending the tokens.
      * @param _to     Address receiving the tokens.
      * @param _amount Token quantity to transfer.
-     * @return `true` if the transfer is allowed; `false` otherwise.
+     * @return True if the transfer is allowed; false otherwise.
      */
     function canTransfer(address _from, address _to, uint256 _amount) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/erc20Votes/IERC20Votes.sol
+++ b/packages/ats/contracts/contracts/facets/erc20Votes/IERC20Votes.sol
@@ -46,14 +46,17 @@ interface IERC20Votes is IERC5805 {
     function initializeERC20Votes(bool _activated) external;
 
     /// @notice Returns whether the ERC-20Votes voting feature is currently active.
+    /// @return True if the voting feature is active, false otherwise.
     function isActivated() external view returns (bool);
 
     /// @notice Returns the checkpoint at a given position for an account's vote history.
     /// @param _account Address whose checkpoint history is queried.
     /// @param _pos Zero-based index into the account's checkpoint array.
+    /// @return The checkpoint struct at the given position.
     function checkpoints(address _account, uint256 _pos) external view returns (Checkpoints.Checkpoint memory);
 
     /// @notice Returns the total number of vote checkpoints recorded for an account.
     /// @param _account Address whose checkpoint count is queried.
+    /// @return The number of checkpoints stored for the account.
     function numCheckpoints(address _account) external view returns (uint256);
 }

--- a/packages/ats/contracts/contracts/facets/externalControlListManagement/IExternalControlList.sol
+++ b/packages/ats/contracts/contracts/facets/externalControlListManagement/IExternalControlList.sol
@@ -13,7 +13,7 @@ interface IExternalControlList {
     /**
      * @notice Returns whether `account` is authorised according to the external control list.
      * @param account Address to check.
-     * @return `true` if the account is on the allow-list; `false` otherwise.
+     * @return True if the account is on the allow-list; false otherwise.
      */
     function isAuthorized(address account) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/externalPauseManagement/IExternalPause.sol
+++ b/packages/ats/contracts/contracts/facets/externalPauseManagement/IExternalPause.sol
@@ -12,7 +12,7 @@ pragma solidity >=0.8.0 <0.9.0;
 interface IExternalPause {
     /**
      * @notice Returns whether the external pause controller currently signals a paused state.
-     * @return `true` if the token should treat itself as paused; `false` otherwise.
+     * @return True if the token should treat itself as paused; false otherwise.
      */
     function isPaused() external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/identity/externalInterfaces/IIdentityRegistry.sol
+++ b/packages/ats/contracts/contracts/facets/identity/externalInterfaces/IIdentityRegistry.sol
@@ -13,7 +13,7 @@ interface IIdentityRegistry {
     /**
      * @notice Returns whether `_userAddress` has a verified identity in the registry.
      * @param _userAddress Address to check.
-     * @return `true` if the address is verified; `false` otherwise.
+     * @return True if the address is verified, false otherwise.
      */
     function isVerified(address _userAddress) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/kyc/IRevocationList.sol
+++ b/packages/ats/contracts/contracts/facets/kyc/IRevocationList.sol
@@ -9,7 +9,10 @@ pragma solidity >=0.8.0 <0.9.0;
  */
 interface IRevocationList {
     /**
-     * @notice Checks if the VC granted by an issuer to a subject has been revoked
+     * @notice Checks if the VC granted by an issuer to a subject has been revoked.
+     * @param subject The address of the subject whose credential is being queried.
+     * @param vcId The identifier of the verifiable credential to check.
+     * @return True if the credential has been revoked, false otherwise.
      */
-    function revoked(address, string calldata) external view returns (bool);
+    function revoked(address subject, string calldata vcId) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/partitions/IPartitions.sol
+++ b/packages/ats/contracts/contracts/facets/partitions/IPartitions.sol
@@ -37,9 +37,7 @@ interface IPartitions {
 
     /**
      * @notice Indicates whether the token operates in multi-partition mode.
-     * @return
-     *  true : the token allows multiple partitions to be set and managed.
-     *  false : the token contains only one partition, the default one.
+     * @return True if the token allows multiple partitions to be set and managed; false otherwise
      */
     function isMultiPartition() external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/recovery/IRecovery.sol
+++ b/packages/ats/contracts/contracts/facets/recovery/IRecovery.sol
@@ -41,6 +41,6 @@ interface IRecovery is IERC3643Types {
 
     /// @notice Returns whether a wallet address has been marked as recovered.
     /// @param _wallet Address to query.
-    /// @return `true` if the address has previously been recovered via {recoveryAddress}.
+    /// @return True if the address has previously been recovered via {recoveryAddress}.
     function isAddressRecovered(address _wallet) external view returns (bool);
 }

--- a/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentBase.sol
+++ b/packages/ats/contracts/contracts/facets/scheduledBalanceAdjustment/ScheduledBalanceAdjustmentBase.sol
@@ -107,6 +107,7 @@ abstract contract ScheduledBalanceAdjustmentBase {
         bytes32 corporateActionId,
         uint256 balanceAdjustmentId
     ) internal view {
+        // solhint-disable-next-line gas-strict-inequalities
         if (executionDate <= EvmAccessors.getBlockTimestamp()) {
             revert IScheduledBalanceAdjustment.BalanceAdjustmentAlreadyExecuted(corporateActionId, balanceAdjustmentId);
         }

--- a/packages/ats/contracts/contracts/test/mocks/MockEIP712.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockEIP712.sol
@@ -39,7 +39,7 @@ contract MockEIP712 is ICommonErrors {
      * @param _chainid         The chain ID used in the EIP-712 domain separator.
      * @param _contractAddress The address of the originating contract used in the domain
      *        separator.
-     * @return `true` if the recovered signer matches `_signer`, `false` otherwise.
+     * @return True if the recovered signer matches `_signer`, false otherwise.
      */
     function exposed_verify(
         address _signer,


### PR DESCRIPTION
## Description

AmortizationStorageWrapper.sol

  1. Removed the AmortizationHoldFailed error path
  The success boolean returned by createHoldByPartition is no longer checked. The assumption is that if the call doesn't revert, the hold succeeded. The if (!success) revert AmortizationHoldFailed(...) guard was
  removed along with its mention in the NatSpec.

  2. Simplified _releaseHold to a full-removal-only operation
  Previously it handled both partial and full hold releases, including:
  - Checking InsufficientHoldBalance before releasing
  - Restoring ERC-20 allowance when the third-party type was AUTHORIZED
  - Calling either removeHold (full) or decreaseHeldAmount (partial) depending on the amount

  Now it unconditionally calls removeHold, making it always a full removal.

  3. Removed _getHoldAdjustedAt
  A private helper that computed a hold's amount scaled by the ABAF/LABAF adjustment factor at a given timestamp was deleted entirely.

  ---
  KpisStorageWrapper.sol
  
  1. Removed the duplicate-date guard in addKpiData
  The if (isCheckpointDate(date, project)) revert KpiDataAlreadyExists(date) check was removed. Duplicate detection is no longer enforced at this layer explicitly.

  2. Removed addToCouponsOrderedList
  This function registered a coupon into the ordered list and advanced minDate, also asserting that the coupon's fixing date didn't regress below the current minDate. Its removal (and the KPI_KPIS_ADD_COUPON_DATE
  import) suggests this responsibility was moved elsewhere or merged into a different flow.

  3. Removed three internal helpers
  pushKpiData, overwriteKpiData, and setMinDate were removed from the library's internal API, slimming it down to just the core operations.

  ---
  ScheduledTasksStorageWrapper.sol
  
  1. Removed the subTaskType != bytes32(0) guard
  After ScheduledTasksDispatchOps.execute returns a subTaskType, previously _triggerOneSubTask was only called when that value was non-zero. Now it is always called. This implies _triggerOneSubTask itself now
  handles the zero/no-op case internally.

  2. Removed the three specialized trigger wrappers
  triggerScheduledSnapshots, triggerScheduledCouponListing, and triggerScheduledBalanceAdjustments were all thin wrappers over triggerScheduledTasks with a hardcoded queue and callback type. Their removal suggests
  all task types are now dispatched through the unified cross-ordered task mechanism rather than being triggered individually by type.

  ---
  Overall pattern: all three contracts are being simplified — removing error checks that are now handled at a different layer, removing partial-operation paths in favor of full operations, and consolidating
  specialized entry points into a single unified dispatch flow.


## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
