### PR TITLE
feat: customData add new methods

### DIFF
--- a/.changeset/custom-data-batch-setter.md
+++ b/.changeset/custom-data-batch-setter.md
@@ -1,0 +1,10 @@
+---
+"@hashgraph/asset-tokenization-contracts": minor
+---
+
+Extends the `CustomData` facet with seed entries on init and a batch setter.
+
+- `initializeCustomData(CustomDataEntry[] entries)` — accepts an optional list of key/value pairs to seed atomically at deployment; empty array preserves existing behaviour.
+- `setCustomDataBatch(CustomDataEntry[] entries)` — new runtime setter that writes multiple entries in a single call; requires `ROLE_CUSTOM_DATA_MANAGER` and emits one `CustomDataBatchSet` event per invocation.
+- Fix: `setCustomData` was not emitting any event; now emits `CustomDataSet` on every write.
+- `CustomDataStorageWrapper` gains an internal `setCustomDataBatch` helper with no events and no access control; used by both init and batch paths.

--- a/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
@@ -40,18 +40,36 @@ library CustomDataStorageWrapper {
      * @dev Clears any previously stored array via `delete` and then pushes every element of
      *      `_value` in order, so the resulting state contains exactly `_value`. Passing an empty
      *      array effectively clears the entry. Gas cost scales linearly with `_value.length` and
-     *      with the size of each payload because each element is copied from calldata into
-     *      storage. Access control and pause checks are enforced by the calling facet, not by
-     *      this library.
+     *      with the size of each payload because each element is copied into storage. Access
+     *      control and pause checks are enforced by the calling facet, not by this library.
      * @param _key   The custom data key whose value is being written.
      * @param _value The ordered list of byte payloads to persist under `_key`.
      */
-    function setCustomData(bytes32 _key, bytes[] calldata _value) internal {
+    function setCustomData(bytes32 _key, bytes[] memory _value) internal {
         bytes[] storage stored = customDataStorage().customData[_key];
         delete customDataStorage().customData[_key];
         uint256 length = _value.length;
         for (uint256 i; i < length; ) {
             stored.push(_value[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Persists every key/value pair in `_entries`, replacing any existing array per key.
+     * @dev Loops the entries and delegates each write to `setCustomData`, so the full-overwrite
+     *      semantics and gas profile of the single-key path apply per entry. Emits no events and
+     *      enforces no access control — the calling facet owns both. An empty `_entries` array
+     *      is a silent no-op. If the same key appears more than once, the last write wins.
+     *      Gas scales with the number of entries and the total payload size across all entries.
+     * @param _entries The list of key/value pairs to persist.
+     */
+    function setCustomDataBatch(ICustomData.CustomDataEntry[] calldata _entries) internal {
+        uint256 length = _entries.length;
+        for (uint256 i; i < length; ) {
+            setCustomData(_entries[i].key, _entries[i].value);
             unchecked {
                 ++i;
             }

--- a/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/CustomDataStorageWrapper.sol
@@ -45,7 +45,7 @@ library CustomDataStorageWrapper {
      * @param _key   The custom data key whose value is being written.
      * @param _value The ordered list of byte payloads to persist under `_key`.
      */
-    function setCustomData(bytes32 _key, bytes[] memory _value) internal {
+    function setCustomData(bytes32 _key, bytes[] calldata _value) internal {
         bytes[] storage stored = customDataStorage().customData[_key];
         delete customDataStorage().customData[_key];
         uint256 length = _value.length;

--- a/packages/ats/contracts/contracts/facets/customData/CustomData.sol
+++ b/packages/ats/contracts/contracts/facets/customData/CustomData.sol
@@ -20,23 +20,34 @@ import { InitializerStorageWrapper } from "../../domain/core/InitializerStorageW
  */
 abstract contract CustomData is ICustomData, Modifiers {
     /// @inheritdoc ICustomData
-    function initializeCustomData()
-        external
-        override
-        onlyRole(DEFAULT_ADMIN_ROLE)
-        onlyFacetNotRegistered(RESOLVER_KEY_CUSTOM_DATA)
-    {
+    function initializeCustomData(
+        ICustomData.CustomDataEntry[] calldata _entries
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) onlyFacetNotRegistered(RESOLVER_KEY_CUSTOM_DATA) {
         InitializerStorageWrapper.setFacetToReady(RESOLVER_KEY_CUSTOM_DATA);
-        emit CustomDataInitialized();
+        CustomDataStorageWrapper.setCustomDataBatch(_entries);
+        emit CustomDataInitialized(_entries);
     }
+
     /// @inheritdoc ICustomData
     /// @dev Requires `ROLE_CUSTOM_DATA_MANAGER` and the token to be unpaused. Delegates persistence
-    ///      to `CustomDataStorageWrapper.setCustomData`, which overwrites any existing array.
+    ///      to `CustomDataStorageWrapper.setCustomData`, which overwrites any existing array, then
+    ///      emits `CustomDataSet`.
     function setCustomData(
         bytes32 _key,
         bytes[] calldata _value
     ) external onlyOperational onlyActivated onlyUnpaused onlyRole(ROLE_CUSTOM_DATA_MANAGER) {
         CustomDataStorageWrapper.setCustomData(_key, _value);
+        emit CustomDataSet(_key, _value);
+    }
+
+    /// @inheritdoc ICustomData
+    /// @dev Delegates all writes to `CustomDataStorageWrapper.setCustomDataBatch`, then emits a
+    ///      single `CustomDataBatchSet` event. An empty `_entries` array is a silent no-op.
+    function setCustomDataBatch(
+        ICustomData.CustomDataEntry[] calldata _entries
+    ) external onlyOperational onlyActivated onlyUnpaused onlyRole(ROLE_CUSTOM_DATA_MANAGER) {
+        CustomDataStorageWrapper.setCustomDataBatch(_entries);
+        emit CustomDataBatchSet(_entries);
     }
 
     /// @inheritdoc ICustomData

--- a/packages/ats/contracts/contracts/facets/customData/CustomDataFacet.sol
+++ b/packages/ats/contracts/contracts/facets/customData/CustomDataFacet.sol
@@ -27,7 +27,8 @@ contract CustomDataFacet is CustomData, IStaticFunctionSelectors {
             Bytes4Builder.build(
                 this.initializeCustomData.selector,
                 this.getCustomData.selector,
-                this.setCustomData.selector
+                this.setCustomData.selector,
+                this.setCustomDataBatch.selector
             );
     }
 

--- a/packages/ats/contracts/contracts/facets/customData/ICustomData.sol
+++ b/packages/ats/contracts/contracts/facets/customData/ICustomData.sol
@@ -8,7 +8,8 @@ bytes32 constant RESOLVER_KEY_CUSTOM_DATA = 0xfe752225f0f7bb1ac35587b02565558e9f
  * @title ICustomData
  * @author Asset Tokenization Studio Team
  * @notice Interface for storing arbitrary key/value custom data associated with a security token,
- *         where each key maps to an ordered list of byte payloads.
+ *         where each key maps to an ordered list of byte payloads. Supports atomic seeding of
+ *         entries at initialisation time via the `CustomDataEntry` struct.
  * @dev Part of the Diamond facet system. Custom data state is stored at
  *      `STORAGE_LOCATION_CUSTOM_DATA` via `CustomDataStorageWrapper`. Mutations require the
  *      `ROLE_CUSTOM_DATA_MANAGER` and the token to be unpaused; reads are unrestricted. Each call
@@ -18,17 +19,56 @@ bytes32 constant RESOLVER_KEY_CUSTOM_DATA = 0xfe752225f0f7bb1ac35587b02565558e9f
  */
 interface ICustomData {
     /**
-     * @notice Emitted once when the metadata capability is initialised on a token.
-     * @dev Fires exclusively from `initializeCustomData`.
+     * @notice Represents a single key/value entry used to seed custom data at initialisation time.
+     * @param key   The custom data key under which the value is stored.
+     * @param value The ordered list of byte payloads to associate with the key.
      */
-    event CustomDataInitialized();
+    struct CustomDataEntry {
+        bytes32 key;
+        bytes[] value;
+    }
 
     /**
-     * @notice Initialises the custom data capability on the token.
-     * @dev Callable once; subsequent calls revert with `FacetAlreadyRegistered`.
-     *      Requires `DEFAULT_ADMIN_ROLE`. Called by the factory during deployment.
+     * @notice Emitted once when the metadata capability is initialised on a token.
+     * @dev Fires exclusively from `initializeCustomData`, after all seed entries have been written.
+     * @param entries The list of key/value pairs seeded at initialisation time, or an empty array
+     *                if no seed data was provided.
      */
-    function initializeCustomData() external;
+    event CustomDataInitialized(CustomDataEntry[] entries);
+
+    /**
+     * @notice Emitted whenever the value stored under `key` is set or replaced by `setCustomData`.
+     * @dev Fires once per `setCustomData` call. Does NOT fire from `setCustomDataBatch` or
+     *      `initializeCustomData`. The emitted `value` is the full replacement array; an empty
+     *      array signals the key was cleared.
+     * @param key   The custom data key whose value was set.
+     * @param value The ordered list of byte payloads now stored under `key`.
+     */
+    event CustomDataSet(bytes32 indexed key, bytes[] value);
+
+    /**
+     * @notice Emitted once when multiple key/value entries are written atomically via
+     *         `setCustomDataBatch`.
+     * @dev Fires once per `setCustomDataBatch` call, after all entries have been persisted.
+     *      Does NOT fire from `initializeCustomData`, which emits `CustomDataInitialized`
+     *      instead. Each entry in `entries` follows the same full-overwrite semantics as
+     *      `setCustomData`; an empty inner array clears that key.
+     * @param entries The list of key/value pairs written in this batch call.
+     */
+    event CustomDataBatchSet(CustomDataEntry[] entries);
+
+    /**
+     * @notice Initialises the custom data capability on the token, optionally seeding key/value
+     *         entries atomically at the time of initialisation.
+     * @dev Callable once; subsequent calls revert with `FacetAlreadyRegistered`.
+     *      Requires `DEFAULT_ADMIN_ROLE`. Called by the factory during deployment. Entries are
+     *      written via `CustomDataStorageWrapper`, bypassing the role and state guards that protect
+     *      the runtime `setCustomData` function — this is intentional during one-time init. If the
+     *      same key appears more than once in `_entries`, the last write wins.
+     * @param _entries The optional list of key/value pairs to seed on initialisation. Pass an empty
+     *                 array to initialise with no data.
+     */
+    function initializeCustomData(CustomDataEntry[] calldata _entries) external;
 
     /**
      * @notice Sets the ordered list of byte payloads associated with `_key`, replacing any
@@ -40,6 +80,19 @@ interface ICustomData {
      * @param _value The ordered list of byte payloads to associate with the key.
      */
     function setCustomData(bytes32 _key, bytes[] calldata _value) external;
+
+    /**
+     * @notice Sets multiple key/value entries in a single call, replacing any previously stored
+     *         value under each key.
+     * @dev Requires `ROLE_CUSTOM_DATA_MANAGER` and the token to be operational, activated, and
+     *      unpaused — identical guards to `setCustomData`. Overwrites the entire array per key;
+     *      there is no append semantics. An empty `_entries` array is a silent no-op. Emits a
+     *      single `CustomDataBatchSet` event after all entries have been persisted. If a key
+     *      repeats within `_entries`, the last write wins. Gas scales with the number of entries
+     *      and total payload size.
+     * @param _entries The list of key/value pairs to set.
+     */
+    function setCustomDataBatch(CustomDataEntry[] calldata _entries) external;
 
     /**
      * @notice Returns the ordered list of byte payloads associated with `_key`.

--- a/packages/ats/contracts/contracts/factory/Factory.sol
+++ b/packages/ats/contracts/contracts/factory/Factory.sol
@@ -489,7 +489,7 @@ abstract contract Factory is IFactory {
         );
         ICap(_securityAddress).initializeCap(_securityData.maxSupply, new ICap.PartitionCap[](0));
         ICapByPartition(_securityAddress).initializeCapByPartition();
-        ICustomData(_securityAddress).initializeCustomData();
+        ICustomData(_securityAddress).initializeCustomData(new ICustomData.CustomDataEntry[](0));
         IDocumentation(_securityAddress).initializeDocumentation();
 
         IPartitions(_securityAddress).initializePartitions(_securityData.isMultiPartition);
@@ -637,7 +637,7 @@ abstract contract Factory is IFactory {
         // configure core adjusted
         ICoreAdjusted(_securityAddress).initializeCoreAdjusted();
         // configure custom data
-        ICustomData(_securityAddress).initializeCustomData();
+        ICustomData(_securityAddress).initializeCustomData(new ICustomData.CustomDataEntry[](0));
         // configure freeze
         IFreeze(_securityAddress).initializeFreeze();
         // configure batch freeze

--- a/packages/ats/contracts/test/contracts/integration/customData/customData.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/customData/customData.test.ts
@@ -9,6 +9,7 @@ import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { deployEquityTokenFixture, executeRbac } from "@test";
 
 const KEY_A = ethers.id("customData.test.key.A");
+const KEY_B = ethers.id("customData.test.key.B");
 const UNSET_KEY = ethers.id("customData.test.key.unset");
 
 const PAYLOAD_1 = ethers.hexlify(ethers.toUtf8Bytes("payload-one"));
@@ -57,6 +58,12 @@ describe("CustomData Tests", () => {
         "AccountHasNoRole",
       );
     });
+
+    it("GIVEN an account without custom data manager role WHEN setCustomDataBatch THEN transaction fails with AccountHasNoRole", async () => {
+      await expect(
+        asset.connect(signer_C).setCustomDataBatch([{ key: KEY_A, value: [PAYLOAD_1] }]),
+      ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
+    });
   });
 
   describe("Paused", () => {
@@ -70,9 +77,20 @@ describe("CustomData Tests", () => {
         "IsPaused",
       );
     });
+
+    it("GIVEN a paused Token WHEN setCustomDataBatch THEN transaction fails with IsPaused", async () => {
+      await expect(
+        asset.connect(signer_A).setCustomDataBatch([{ key: KEY_A, value: [PAYLOAD_1] }]),
+      ).to.be.revertedWithCustomError(asset, "IsPaused");
+    });
   });
 
   describe("setCustomData & getCustomData", () => {
+    it("GIVEN role and unpaused token WHEN setCustomData THEN emits CustomDataSet with correct key and value", async () => {
+      await expect(asset.connect(signer_A).setCustomData(KEY_A, [PAYLOAD_1]))
+        .to.emit(asset, "CustomDataSet")
+        .withArgs(KEY_A, [PAYLOAD_1]);
+    });
     it("GIVEN role and unpaused token WHEN setCustomData with a single payload THEN getCustomData returns it", async () => {
       await asset.connect(signer_A).setCustomData(KEY_A, [PAYLOAD_1]);
 
@@ -113,6 +131,33 @@ describe("CustomData Tests", () => {
     });
   });
 
+  describe("setCustomDataBatch", () => {
+    it("GIVEN role and unpaused token WHEN setCustomDataBatch with two entries THEN getCustomData returns each value", async () => {
+      await asset.connect(signer_A).setCustomDataBatch([
+        { key: KEY_A, value: [PAYLOAD_1] },
+        { key: KEY_B, value: [PAYLOAD_2] },
+      ]);
+
+      expect(await asset.getCustomData(KEY_A)).to.deep.equal([PAYLOAD_1]);
+      expect(await asset.getCustomData(KEY_B)).to.deep.equal([PAYLOAD_2]);
+    });
+
+    it("GIVEN role and unpaused token WHEN setCustomDataBatch with empty array THEN does not revert and no state change", async () => {
+      await expect(asset.connect(signer_A).setCustomDataBatch([])).to.not.be.reverted;
+      expect(await asset.getCustomData(KEY_A)).to.deep.equal([]);
+    });
+
+    it("GIVEN role and unpaused token WHEN setCustomDataBatch with two entries THEN emits a single CustomDataBatchSet with all entries", async () => {
+      const entries = [
+        { key: KEY_A, value: [PAYLOAD_1] },
+        { key: KEY_B, value: [PAYLOAD_2] },
+      ];
+      await expect(asset.connect(signer_A).setCustomDataBatch(entries))
+        .to.emit(asset, "CustomDataBatchSet")
+        .withArgs(entries.map((e) => [e.key, e.value]));
+    });
+  });
+
   describe("Deactivated", () => {
     it("GIVEN a deactivated asset WHEN setCustomData THEN transaction fails with Deactivated", async () => {
       const base = await deployEquityTokenFixture();
@@ -123,26 +168,102 @@ describe("CustomData Tests", () => {
         deactivatedAsset.connect(base.deployer).setCustomData(ethers.ZeroHash, []),
       ).to.be.revertedWithCustomError(deactivatedAsset, "Deactivated");
     });
+
+    it("GIVEN a deactivated asset WHEN setCustomDataBatch THEN transaction fails with Deactivated", async () => {
+      const base = await deployEquityTokenFixture();
+      const deactivatedAsset = await ethers.getContractAt("IAsset", base.diamond.target);
+      await deactivatedAsset.connect(base.deployer).grantRole(ATS_ROLES.ROLE_DEACTIVATE, base.deployer.address);
+      await deactivatedAsset.connect(base.deployer).deactivate();
+      await expect(deactivatedAsset.connect(base.deployer).setCustomDataBatch([])).to.be.revertedWithCustomError(
+        deactivatedAsset,
+        "Deactivated",
+      );
+    });
   });
 
   describe("initializeCustomData", () => {
+    const SEED_KEY_1 = ethers.encodeBytes32String("seed.key.one");
+    const SEED_KEY_2 = ethers.encodeBytes32String("seed.key.two");
+    const SEED_KEY_3 = ethers.encodeBytes32String("seed.key.three");
+    const SEED_VALUE_1 = ethers.toUtf8Bytes("value-one");
+    const SEED_VALUE_2 = ethers.toUtf8Bytes("value-two");
+    const SEED_VALUE_3 = ethers.toUtf8Bytes("value-three");
+
     it("GIVEN caller without DEFAULT_ADMIN_ROLE WHEN initializeCustomData is called THEN AccountHasNoRole", async () => {
-      await expect(asset.connect(signer_C).initializeCustomData())
+      await expect(asset.connect(signer_C).initializeCustomData([]))
         .to.be.revertedWithCustomError(asset, "AccountHasNoRole")
         .withArgs(signer_C.address, ATS_ROLES.DEFAULT_ADMIN_ROLE);
     });
 
     it("GIVEN already-initialised WHEN initializeCustomData is called again THEN FacetAlreadyRegistered", async () => {
-      await expect(asset.initializeCustomData())
+      await expect(asset.initializeCustomData([]))
         .to.be.revertedWithCustomError(asset, "FacetAlreadyRegistered")
         .withArgs(RESOLVER_KEY_CUSTOM_DATA, 1);
     });
-  });
 
-  describe("initializeCustomData event", () => {
-    it("GIVEN a fresh deployment WHEN initializeCustomData is called THEN emits CustomDataInitialized", async () => {
-      await mockDiamondCut.forceFacetNotRegistered(RESOLVER_KEY_CUSTOM_DATA);
-      await expect(asset.initializeCustomData()).to.emit(asset, "CustomDataInitialized");
+    describe("when not yet initialised", () => {
+      beforeEach(async () => {
+        await mockDiamondCut.forceFacetNotRegistered(RESOLVER_KEY_CUSTOM_DATA);
+      });
+
+      it("GIVEN empty entries WHEN initializeCustomData is called THEN emits CustomDataInitialized with empty entries", async () => {
+        await expect(asset.initializeCustomData([])).to.emit(asset, "CustomDataInitialized").withArgs([]);
+      });
+
+      it("GIVEN a single seed entry WHEN initializeCustomData is called THEN getCustomData returns the seeded value", async () => {
+        const entries = [{ key: SEED_KEY_1, value: [SEED_VALUE_1] }];
+
+        const receipt = await asset.initializeCustomData(entries);
+
+        expect(await asset.getCustomData(SEED_KEY_1)).to.deep.equal([ethers.hexlify(SEED_VALUE_1)]);
+        await expect(receipt)
+          .to.emit(asset, "CustomDataInitialized")
+          .withArgs([[SEED_KEY_1, [ethers.hexlify(SEED_VALUE_1)]]]);
+      });
+
+      it("GIVEN a seed entry with multiple payloads WHEN initializeCustomData is called THEN getCustomData returns all payloads in order", async () => {
+        const entries = [{ key: SEED_KEY_1, value: [SEED_VALUE_1, SEED_VALUE_2] }];
+
+        await asset.initializeCustomData(entries);
+
+        expect(await asset.getCustomData(SEED_KEY_1)).to.deep.equal([
+          ethers.hexlify(SEED_VALUE_1),
+          ethers.hexlify(SEED_VALUE_2),
+        ]);
+      });
+
+      it("GIVEN multiple distinct seed entries WHEN initializeCustomData is called THEN each key returns its correct value", async () => {
+        const entries = [
+          { key: SEED_KEY_1, value: [SEED_VALUE_1] },
+          { key: SEED_KEY_2, value: [SEED_VALUE_2] },
+          { key: SEED_KEY_3, value: [SEED_VALUE_3] },
+        ];
+
+        await asset.initializeCustomData(entries);
+
+        expect(await asset.getCustomData(SEED_KEY_1)).to.deep.equal([ethers.hexlify(SEED_VALUE_1)]);
+        expect(await asset.getCustomData(SEED_KEY_2)).to.deep.equal([ethers.hexlify(SEED_VALUE_2)]);
+        expect(await asset.getCustomData(SEED_KEY_3)).to.deep.equal([ethers.hexlify(SEED_VALUE_3)]);
+      });
+
+      it("GIVEN duplicate keys in seed entries WHEN initializeCustomData is called THEN last write wins", async () => {
+        const entries = [
+          { key: SEED_KEY_1, value: [SEED_VALUE_1] },
+          { key: SEED_KEY_1, value: [SEED_VALUE_2] },
+        ];
+
+        await asset.initializeCustomData(entries);
+
+        expect(await asset.getCustomData(SEED_KEY_1)).to.deep.equal([ethers.hexlify(SEED_VALUE_2)]);
+      });
+
+      it("GIVEN a seeded key WHEN getCustomData is called for an unseeded key THEN it returns an empty array", async () => {
+        const entries = [{ key: SEED_KEY_1, value: [SEED_VALUE_1] }];
+
+        await asset.initializeCustomData(entries);
+
+        expect(await asset.getCustomData(SEED_KEY_2)).to.deep.equal([]);
+      });
     });
   });
   describe("nonOperational", () => {
@@ -155,6 +276,10 @@ describe("CustomData Tests", () => {
         asset,
         "AssetNotOperational",
       );
+    });
+
+    it("GIVEN non-operational asset WHEN setCustomDataBatch THEN reverts with AssetNotOperational", async () => {
+      await expect(asset.setCustomDataBatch([])).to.be.revertedWithCustomError(asset, "AssetNotOperational");
     });
   });
 });

--- a/packages/ats/contracts/test/fixtures/tokens/loan.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/loan.fixture.ts
@@ -354,7 +354,7 @@ export async function deployLoanTokenFixture({
   await asset.initializeDeactivate();
   await asset.initializeOperatorHoldByPartition();
   await asset.initializeCoreAdjusted();
-  await asset.initializeCustomData();
+  await asset.initializeCustomData([]);
   await asset.initializeCompliance(ZeroAddress);
   await asset.initializeCouponListing();
   await asset.initializeCapByPartition();

--- a/packages/ats/contracts/test/fixtures/tokens/loansPortfolio.fixture.ts
+++ b/packages/ats/contracts/test/fixtures/tokens/loansPortfolio.fixture.ts
@@ -247,7 +247,7 @@ export async function deployLoansPortfolioTokenFixture({
   await asset.initializeDeactivate();
   await asset.initializeOperatorHoldByPartition();
   await asset.initializeCoreAdjusted();
-  await asset.initializeCustomData();
+  await asset.initializeCustomData([]);
   await asset.initializeCompliance(ZeroAddress);
   await asset.initializeCouponListing();
   await asset.initializeCapByPartition();


### PR DESCRIPTION
## Description
Extends the CustomData facet with two improvements:

- initializeCustomData(CustomDataEntry[] entries):  now accepts an optional list of key/value pairs to seed atomically at deployment. Empty array preserves existing behaviour.
- setCustomDataBatch(CustomDataEntry[] entries): new  setter that writes multiple entries in a single call.
- Fix: setCustomData was not emitting any event; now emits CustomDataSet on every write.

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

<!--
Describe how you verified your changes work and steps for reviewers to confirm. 🧪

	•	Automated tests – npm run test
	•	Manual verification – e.g., CLI or web interface actions
	•	Local GitHub Actions – act pull_request

For example:

	Run npm run test → All tests pass.
    Open the web UI → Click “Create Token” → See the new confirmation banner.

(If fixing a bug, reference the issue for reproduction steps and explain how the fix resolves it.)

### Test Results (if any)
-->

**Node version**:

- [ ] 20
- [ ] 22
- [ ] 24

## Checklist

- [ ] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️
- [ ] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅
