### PR TITLE
refactor: record solhint ratchet as per-rule counts

### DIFF
--- a/.changeset/betterer-count-baseline.md
+++ b/.changeset/betterer-count-baseline.md
@@ -1,0 +1,5 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Record the solhint warning ratchet (`.betterer.results`) as per-file/per-rule counts instead of per-issue line and hash data, so the committed baseline changes only when a warning count changes and stops producing merge conflicts on unrelated edits. No functional, ABI or storage change.

--- a/packages/ats/contracts/.betterer.results
+++ b/packages/ats/contracts/.betterer.results
@@ -5,96 +5,58 @@
 //
 exports[`ats contracts solhint`] = {
   value: `{
-    "contracts/domain/asset/AmortizationStorageWrapper.sol:3599700578": [
-      [117, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [395, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [420, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
-    ],
-    "contracts/domain/asset/ClearingStorageWrapper.sol:240867812": [
-      [720, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
-    ],
-    "contracts/domain/asset/DividendStorageWrapper.sol:1104421331": [
-      [68, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [246, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [264, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
-    ],
-    "contracts/domain/asset/ERC20VotesStorageWrapper.sol:1755450486": [
-      [300, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"],
-      [311, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177617"]
-    ],
-    "contracts/domain/asset/HoldStorageWrapper.sol:2799269957": [
-      [801, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177632"]
-    ],
-    "contracts/domain/asset/KpisStorageWrapper.sol:3109432168": [
-      [104, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177601"]
-    ],
-    "contracts/domain/asset/LockStorageWrapper.sol:4065266281": [
-      [333, 15, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177602"]
-    ],
-    "contracts/domain/asset/ScheduledTasksStorageWrapper.sol:3509877729": [
-      [194, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"],
-      [482, 4, 1, "ats/storage-accessor-private: ATS-PRIV-001: StorageWrapper accessor \'_scheduledBalanceAdjustmentStorage\' must be \'private\', not \'internal\'.", "177603"],
-      [499, 4, 1, "ats/storage-accessor-private: ATS-PRIV-001: StorageWrapper accessor \'_scheduledCrossOrderedTaskStorage\' must be \'private\', not \'internal\'.", "177603"]
-    ],
-    "contracts/domain/asset/SnapshotsStorageWrapper.sol:732035984": [
-      [1038, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177658"]
-    ],
-    "contracts/domain/asset/VotingStorageWrapper.sol:1699818420": [
-      [180, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [198, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"]
-    ],
-    "contracts/domain/asset/coupon/CouponStorageWrapper.sol:1759522121": [
-      [94, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [362, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [382, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177623"],
-      [402, 12, 1, "gas-strict-inequalities: GC: Non strict inequality found. Try converting to a strict one", "177621"]
-    ],
-    "contracts/domain/orchestrator/ClearingOps.sol:3707322407": [
-      [61, 4, 1, "function-max-lines: Function body contains 57 lines but allowed no more than 50 lines", "177603"],
-      [61, 4, 1, "gas-calldata-parameters: GC: [_clearingOperation] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
-      [61, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingTransferCreation] could be [calldata] if it\'s not being updated", "177603"],
-      [141, 4, 1, "function-max-lines: Function body contains 66 lines but allowed no more than 50 lines", "177603"],
-      [229, 4, 1, "function-max-lines: Function body contains 58 lines but allowed no more than 50 lines", "177603"],
-      [229, 4, 1, "gas-calldata-parameters: GC: [_operatorData] argument on Function [clearingHoldCreationCreation] could be [calldata] if it\'s not being updated", "177603"],
-      [415, 4, 1, "function-max-lines: Function body contains 52 lines but allowed no more than 50 lines", "177603"]
-    ],
-    "contracts/facets/amortization/IAmortization.sol:75918106": [
-      [32, 4, 1, "gas-struct-packing: GC: For [ AmortizationFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
-    ],
-    "contracts/facets/coupon/ICouponTypes.sol:430258162": [
-      [74, 4, 1, "gas-struct-packing: GC: For [ CouponFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
-    ],
-    "contracts/facets/dividend/IDividendTypes.sol:2960222249": [
-      [58, 4, 1, "gas-struct-packing: GC: For [ DividendFor ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
-    ],
-    "contracts/factory/IFactory.sol:2734389583": [
-      [111, 4, 1, "gas-struct-packing: GC: For [ EquityDetailsData ] struct, packing seems inefficient. Try rearranging to achieve 32bytes slots", "177622"]
-    ],
-    "contracts/infrastructure/proxy/ResolverProxy.sol:3628079828": [
-      [52, 4, 1, "no-complex-fallback: Fallback function must be simple", "177603"]
-    ],
-    "contracts/infrastructure/utils/DecimalsLib.sol:1687496794": [
-      [6, 4, 1, "no-unused-import: imported name POW10_0 is not used", "177653"],
-      [7, 4, 1, "no-unused-import: imported name POW10_1 is not used", "177653"],
-      [8, 4, 1, "no-unused-import: imported name POW10_2 is not used", "177653"],
-      [9, 4, 1, "no-unused-import: imported name POW10_3 is not used", "177653"],
-      [10, 4, 1, "no-unused-import: imported name POW10_4 is not used", "177653"],
-      [11, 4, 1, "no-unused-import: imported name POW10_5 is not used", "177653"],
-      [12, 4, 1, "no-unused-import: imported name POW10_6 is not used", "177653"],
-      [13, 4, 1, "no-unused-import: imported name POW10_7 is not used", "177653"],
-      [14, 4, 1, "no-unused-import: imported name POW10_8 is not used", "177653"],
-      [15, 4, 1, "no-unused-import: imported name POW10_9 is not used", "177653"],
-      [16, 4, 1, "no-unused-import: imported name POW10_10 is not used", "177653"],
-      [17, 4, 1, "no-unused-import: imported name POW10_11 is not used", "177653"],
-      [18, 4, 1, "no-unused-import: imported name POW10_12 is not used", "177653"],
-      [19, 4, 1, "no-unused-import: imported name POW10_13 is not used", "177653"],
-      [20, 4, 1, "no-unused-import: imported name POW10_14 is not used", "177653"],
-      [21, 4, 1, "no-unused-import: imported name POW10_15 is not used", "177653"],
-      [22, 4, 1, "no-unused-import: imported name POW10_16 is not used", "177653"],
-      [23, 4, 1, "no-unused-import: imported name POW10_17 is not used", "177653"],
-      [24, 4, 1, "no-unused-import: imported name POW10_18 is not used", "177653"],
-      [78, 4, 1, "function-max-lines: Function body contains 70 lines but allowed no more than 50 lines", "177603"],
-      [79, 8, 1, "no-inline-assembly: Avoid to use inline assembly. It is acceptable only in rare cases", "177604"]
-    ]
-  }`
+  "contracts/domain/asset/AmortizationStorageWrapper.sol": {
+    "gas-strict-inequalities": 3
+  },
+  "contracts/domain/asset/ClearingStorageWrapper.sol": {
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/DividendStorageWrapper.sol": {
+    "gas-strict-inequalities": 3
+  },
+  "contracts/domain/asset/ERC20VotesStorageWrapper.sol": {
+    "gas-strict-inequalities": 2
+  },
+  "contracts/domain/asset/HoldStorageWrapper.sol": {
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/KpisStorageWrapper.sol": {
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/LockStorageWrapper.sol": {
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/ScheduledTasksStorageWrapper.sol": {
+    "ats/storage-accessor-private": 2,
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/SnapshotsStorageWrapper.sol": {
+    "gas-strict-inequalities": 1
+  },
+  "contracts/domain/asset/VotingStorageWrapper.sol": {
+    "gas-strict-inequalities": 2
+  },
+  "contracts/domain/asset/coupon/CouponStorageWrapper.sol": {
+    "gas-strict-inequalities": 4
+  },
+  "contracts/domain/orchestrator/ClearingOps.sol": {
+    "function-max-lines": 4,
+    "gas-calldata-parameters": 3
+  },
+  "contracts/facets/amortization/IAmortization.sol": {
+    "gas-struct-packing": 1
+  },
+  "contracts/facets/coupon/ICouponTypes.sol": { "gas-struct-packing": 1 },
+  "contracts/facets/dividend/IDividendTypes.sol": { "gas-struct-packing": 1 },
+  "contracts/factory/IFactory.sol": { "gas-struct-packing": 1 },
+  "contracts/infrastructure/proxy/ResolverProxy.sol": {
+    "no-complex-fallback": 1
+  },
+  "contracts/infrastructure/utils/DecimalsLib.sol": {
+    "function-max-lines": 1,
+    "no-inline-assembly": 1,
+    "no-unused-import": 19
+  }
+}
+`
 };

--- a/packages/ats/contracts/.betterer.ts
+++ b/packages/ats/contracts/.betterer.ts
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-import { BettererFileTest } from "@betterer/betterer";
+import { BettererTest } from "@betterer/betterer";
 
-// Solhint warning ratchet for the ATS contracts package. Snapshots every
-// solhint *warning* into `.betterer.results` so CI can guarantee the count
-// only ever stays equal or decreases (enforced by the `lint-ratchet` job in
-// `103-flow-ats-lint.yaml`). Errors are excluded — they already hard-fail `lint:sol`.
+// Solhint warning ratchet for the ATS contracts package. Snapshots solhint
+// *warning* counts per file and per rule into `.betterer.results` so CI can
+// guarantee the count only ever stays equal or decreases (enforced by the
+// `lint-ratchet` job in `103-flow-ats-lint.yaml`). Errors are excluded — they
+// already hard-fail `lint:sol`.
+//
+// The baseline records only a count per (file, rule), never line/column or
+// per-issue hashes: it changes solely when a file's warning count for a rule
+// changes, not when unrelated edits shift a warned line. That keeps the
+// committed file stable and merge-conflict resistant. On a conflict, do not
+// hand-edit it — regenerate with `npm run ats:contracts:lint:fix`.
 
 const CONTRACTS_GLOB = "contracts/**/*.sol";
 const SOLHINT_CONFIG = "solhint.config.js";
@@ -47,33 +52,58 @@ function runSolhint(): SolhintMessage[] {
   return start === -1 ? [] : (JSON.parse(stdout.slice(start)) as SolhintMessage[]);
 }
 
-const test = new BettererFileTest(async (_filePaths, fileTestResult) => {
+// Repo-relative file path -> solhint ruleId -> warning count.
+type WarningCounts = Record<string, Record<string, number>>;
+
+function countWarnings(): WarningCounts {
   const warnings = runSolhint().filter((m) => m.severity === "Warning" && !GENERATED_EXCLUDE.test(m.filePath));
 
-  const byFile = new Map<string, SolhintMessage[]>();
+  const raw: WarningCounts = {};
   for (const warning of warnings) {
-    const absolutePath = resolve(process.cwd(), warning.filePath);
-    const bucket = byFile.get(absolutePath);
-    if (bucket) {
-      bucket.push(warning);
-    } else {
-      byFile.set(absolutePath, [warning]);
-    }
+    const byRule = (raw[warning.filePath] ??= {});
+    byRule[warning.ruleId] = (byRule[warning.ruleId] ?? 0) + 1;
   }
 
-  for (const [absolutePath, fileWarnings] of byFile) {
-    const file = fileTestResult.addFile(absolutePath, readFileSync(absolutePath, "utf8"));
-    for (const warning of fileWarnings) {
-      // 0-indexed line/column; the message embeds the ruleId so a swap of one
-      // rule's warning for another's changes the issue hash and is caught.
-      file.addIssue(
-        Math.max(0, warning.line - 1),
-        Math.max(0, warning.column - 1),
-        1,
-        `${warning.ruleId}: ${warning.message}`,
-      );
+  // Deterministic key order so the serialised file is stable across solhint
+  // runs regardless of the order solhint reports findings in.
+  const sorted: WarningCounts = {};
+  for (const filePath of Object.keys(raw).sort()) {
+    const byRule = raw[filePath];
+    sorted[filePath] = {};
+    for (const ruleId of Object.keys(byRule).sort()) {
+      sorted[filePath][ruleId] = byRule[ruleId];
     }
   }
+  return sorted;
+}
+
+// Ratchet constraint: the result is `worse` if any (file, rule) count grows,
+// `better` if some count shrinks and none grows, otherwise `same`. The return
+// values match `@betterer/constraints`' `BettererConstraintResult` string enum,
+// so they are returned as literals without pulling in that package.
+function ratchet(result: WarningCounts, expected: WarningCounts): "better" | "same" | "worse" {
+  let decreased = false;
+  for (const filePath of new Set([...Object.keys(result), ...Object.keys(expected)])) {
+    const current = result[filePath] ?? {};
+    const previous = expected[filePath] ?? {};
+    for (const ruleId of new Set([...Object.keys(current), ...Object.keys(previous)])) {
+      const currentCount = current[ruleId] ?? 0;
+      const previousCount = previous[ruleId] ?? 0;
+      if (currentCount > previousCount) {
+        return "worse";
+      }
+      if (currentCount < previousCount) {
+        decreased = true;
+      }
+    }
+  }
+  return decreased ? "better" : "same";
+}
+
+const test = new BettererTest({
+  test: async (): Promise<WarningCounts> => countWarnings(),
+  constraint: async (result: WarningCounts, expected: WarningCounts) => ratchet(result, expected),
+  goal: async (result: WarningCounts) => Object.keys(result).length === 0,
 });
 
 export default {

--- a/packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts
+++ b/packages/ats/contracts/scripts/ci/check-ratchet-vs-base.ts
@@ -15,8 +15,11 @@ import { readFileSync } from "node:fs";
 const RESULTS_PATH = "packages/ats/contracts/.betterer.results";
 const baseRef = process.argv[2] || "develop";
 
-// A serialised betterer file issue: [line, column, length, message, hash].
+// A serialised betterer file issue from the legacy per-issue format:
+// [line, column, length, message, hash].
 type SerialisedIssue = [number, number, number, string, string];
+// New format: file path -> ruleId -> warning count.
+type RuleCounts = Record<string, number>;
 type BettererResultsModule = Record<string, { value: string }>;
 
 /**
@@ -26,6 +29,11 @@ type BettererResultsModule = Record<string, { value: string }>;
  * template literal (`exports[name] = { value: `...` }`), so backslash escapes
  * (e.g. `it\'s`) only resolve once JS evaluates it. We evaluate the module the
  * same way betterer does, then JSON.parse each test's value.
+ *
+ * Two on-disk shapes are tolerated during the migration to per-rule counts:
+ *   - new: `{ "<file>": { "<ruleId>": <count> } }`
+ *   - legacy: `{ "<file>": [[line, col, len, "<ruleId>: <msg>", hash], ...] }`
+ * The base branch may still carry the legacy shape until it adopts the new one.
  */
 function parseResults(source: string): Map<string, number> {
   const counts = new Map<string, number>(); // ruleId -> count
@@ -33,14 +41,20 @@ function parseResults(source: string): Map<string, number> {
   // eslint-disable-next-line no-new-func
   new Function("exports", source)(exportsObject);
   for (const entry of Object.values(exportsObject)) {
-    const byFile = JSON.parse(entry.value) as Record<string, SerialisedIssue[]>;
-    for (const issues of Object.values(byFile)) {
-      for (const issue of issues) {
-        const message = issue[3] ?? "";
-        // Issues are recorded as `"<ruleId>: <message>"` by `.betterer.ts`; the
-        // ruleId is the text before the first colon (solhint ruleIds have none).
-        const ruleId = message.slice(0, message.indexOf(":")) || "unknown";
-        counts.set(ruleId, (counts.get(ruleId) ?? 0) + 1);
+    const byFile = JSON.parse(entry.value) as Record<string, RuleCounts | SerialisedIssue[]>;
+    for (const fileResult of Object.values(byFile)) {
+      if (Array.isArray(fileResult)) {
+        // Legacy per-issue format: one entry per warning, ruleId before the colon.
+        for (const issue of fileResult) {
+          const message = issue[3] ?? "";
+          const ruleId = message.slice(0, message.indexOf(":")) || "unknown";
+          counts.set(ruleId, (counts.get(ruleId) ?? 0) + 1);
+        }
+      } else {
+        // New per-rule count format.
+        for (const [ruleId, count] of Object.entries(fileResult)) {
+          counts.set(ruleId, (counts.get(ruleId) ?? 0) + count);
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

The contracts solhint warning ratchet (`.betterer.results`) generated frequent merge conflicts and reviewer noise because betterer's `BettererFileTest` records each warning's line/column plus content/issue hashes, so the file churned on any edit that shifted a warned line — even though the CI gate only enforces per-rule counts.

This rewrites `.betterer.ts` to a custom `BettererTest` that records per-file, per-rule warning **counts** (no line/column, no hashes), so the committed baseline changes only when a file's per-rule count actually changes. `scripts/ci/check-ratchet-vs-base.ts` now parses both the new count shape and the legacy per-issue shape so the gate keeps working while `develop` still carries the old format. No new tooling or dependencies introduced; both ratchet guarantees (warnings only decrease; comparable to develop) are preserved.

## Type of change

- [ ] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [x] Refactor 🔧

## Testing

- `betterer ci` round-trips clean ("stayed the same") with the new baseline format.
- `check-ratchet-vs-base.ts develop` reads old format (57 warnings) → new format (57 warnings); no regression reported.
- Negative test: under-counting a rule causes `betterer ci` to report "got worse" and exit 1.
- `npm run ats:contracts:lint:sol` / `lint:js` / `format` all pass — 0 errors, 57 pre-existing warnings unchanged.

### Test Results (if any)

All local gates pass. No new warnings introduced.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [ ] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [ ] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅