### PR TITLE
feat(ats:sdk): recognize a configurable HashSphere network

### DIFF
--- a/.changeset/hashsphere-network.md
+++ b/.changeset/hashsphere-network.md
@@ -1,0 +1,7 @@
+---
+"@hashgraph/asset-tokenization-sdk": minor
+---
+
+Recognize a HashSphere network, so a wallet connected to a private HashSphere deployment resolves its configured factory, resolver, mirror node and JSON-RPC relay instead of being reported as an unrecognized network.
+
+HashSphere chain ids differ per instance, so the id is read from `HASHSPHERE_CHAIN_ID` (or `REACT_APP_HASHSPHERE_CHAIN_ID` for the web app) rather than built in. The network is registered only when that variable holds a positive integer that no public Hedera network already uses; with it unset, `HederaNetworks` is unchanged.

--- a/apps/ats/web/.env.example
+++ b/apps/ats/web/.env.example
@@ -23,6 +23,9 @@ REACT_APP_MIRROR_NODE='https://testnet.mirrornode.hedera.com/api/v1/'
 # Hedera JSON-RPC Relay - used for contract interactions
 REACT_APP_RPC_NODE='https://testnet.hashio.io/api'
 
+# HashSphere chain id - varies per instance; use with REACT_APP_NETWORK='hashsphere'
+# REACT_APP_HASHSPHERE_CHAIN_ID='4618'
+
 # * Smart Contract Addresses
 # Replace with your deployed contract IDs (Hedera format: 0.0.XXXXX)
 # See packages/ats/contracts for deployment instructions

--- a/packages/ats/sdk/src/domain/context/network/Environment.ts
+++ b/packages/ats/sdk/src/domain/context/network/Environment.ts
@@ -4,11 +4,12 @@ export const testnet = "testnet";
 export const previewnet = "previewnet";
 export const mainnet = "mainnet";
 export const local = "local";
+export const hashsphere = "hashsphere";
 export const unrecognized = "unrecognized";
 
-export type Environment = "testnet" | "previewnet" | "mainnet" | "local" | "unrecognized" | string;
+export type Environment = "testnet" | "previewnet" | "mainnet" | "local" | "hashsphere" | "unrecognized" | string;
 
-export const HederaNetworks = [
+const publicHederaNetworks = [
   {
     network: testnet,
     chainId: 296,
@@ -25,4 +26,39 @@ export const HederaNetworks = [
     network: local,
     chainId: 298,
   },
+];
+
+export const reservedChainIds = publicHederaNetworks.map(({ chainId }) => chainId);
+
+export const hashsphereChainIdEnvVars = ["HASHSPHERE_CHAIN_ID", "REACT_APP_HASHSPHERE_CHAIN_ID"];
+
+export const resolveHashsphereChainId = (env: Record<string, string | undefined>): number | undefined => {
+  for (const key of hashsphereChainIdEnvVars) {
+    const raw = env[key];
+    if (raw === undefined || raw.trim() === "") continue;
+    const chainId = Number(raw);
+    if (!Number.isInteger(chainId) || chainId <= 0) continue;
+    if (reservedChainIds.includes(chainId)) continue;
+    return chainId;
+  }
+  return undefined;
+};
+
+const readEnv = (): Record<string, string | undefined> => {
+  try {
+    if (typeof process === "undefined" || !process.env) return {};
+    return {
+      HASHSPHERE_CHAIN_ID: process.env.HASHSPHERE_CHAIN_ID,
+      REACT_APP_HASHSPHERE_CHAIN_ID: process.env.REACT_APP_HASHSPHERE_CHAIN_ID,
+    };
+  } catch {
+    return {};
+  }
+};
+
+const hashsphereChainId = resolveHashsphereChainId(readEnv());
+
+export const HederaNetworks = [
+  ...publicHederaNetworks,
+  ...(hashsphereChainId === undefined ? [] : [{ network: hashsphere, chainId: hashsphereChainId }]),
 ];

--- a/packages/ats/sdk/src/domain/context/network/Environment.unit.test.ts
+++ b/packages/ats/sdk/src/domain/context/network/Environment.unit.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { hashsphereChainIdEnvVars, reservedChainIds, resolveHashsphereChainId } from "./Environment";
+
+describe("Environment", () => {
+  describe("resolveHashsphereChainId", () => {
+    it("returns undefined when no variable is set", () => {
+      expect(resolveHashsphereChainId({})).toBeUndefined();
+    });
+
+    it.each([["HASHSPHERE_CHAIN_ID"], ["REACT_APP_HASHSPHERE_CHAIN_ID"]])("reads %s", (key) => {
+      expect(resolveHashsphereChainId({ [key]: "4618" })).toBe(4618);
+    });
+
+    it("supports differing chain ids across HashSphere instances", () => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: "1234" })).toBe(1234);
+    });
+
+    it("prefers HASHSPHERE_CHAIN_ID over the web-app prefixed variable", () => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: "4618", REACT_APP_HASHSPHERE_CHAIN_ID: "1234" })).toBe(
+        4618,
+      );
+    });
+
+    it("falls back to the next variable when the first is blank", () => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: "  ", REACT_APP_HASHSPHERE_CHAIN_ID: "4618" })).toBe(4618);
+    });
+
+    it.each([[""], ["   "], ["not-a-number"], ["0"], ["-1"], ["4618.5"]])("ignores the invalid value %p", (value) => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: value })).toBeUndefined();
+    });
+
+    it.each(reservedChainIds)("ignores %i, which is reserved by a public network", (chainId) => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: String(chainId) })).toBeUndefined();
+    });
+
+    it("falls back to the next variable when the first is a reserved chain id", () => {
+      expect(resolveHashsphereChainId({ HASHSPHERE_CHAIN_ID: "296", REACT_APP_HASHSPHERE_CHAIN_ID: "4618" })).toBe(
+        4618,
+      );
+    });
+
+    it("exposes the variables it reads, in precedence order", () => {
+      expect(hashsphereChainIdEnvVars).toEqual(["HASHSPHERE_CHAIN_ID", "REACT_APP_HASHSPHERE_CHAIN_ID"]);
+    });
+  });
+
+  describe("HederaNetworks", () => {
+    const saved: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of hashsphereChainIdEnvVars) {
+        saved[key] = process.env[key];
+        delete process.env[key];
+      }
+      jest.resetModules();
+    });
+
+    afterEach(() => {
+      for (const key of hashsphereChainIdEnvVars) {
+        if (saved[key] === undefined) delete process.env[key];
+        else process.env[key] = saved[key];
+      }
+      jest.resetModules();
+    });
+
+    const load = () => import("./Environment");
+
+    it("registers only the public Hedera networks when HashSphere is not configured", async () => {
+      const { HederaNetworks, testnet, previewnet, mainnet, local } = await load();
+
+      expect(HederaNetworks).toEqual([
+        { network: testnet, chainId: 296 },
+        { network: previewnet, chainId: 297 },
+        { network: mainnet, chainId: 295 },
+        { network: local, chainId: 298 },
+      ]);
+    });
+
+    it("appends HashSphere when its chain id is configured", async () => {
+      process.env.HASHSPHERE_CHAIN_ID = "4618";
+
+      const { HederaNetworks, hashsphere } = await load();
+
+      expect(HederaNetworks).toHaveLength(reservedChainIds.length + 1);
+      expect(HederaNetworks).toContainEqual({ network: hashsphere, chainId: 4618 });
+    });
+
+    it("leaves a public network as the sole owner of its chain id", async () => {
+      process.env.HASHSPHERE_CHAIN_ID = "296";
+
+      const { HederaNetworks, hashsphere, testnet } = await load();
+
+      expect(HederaNetworks.filter(({ chainId }) => chainId === 296)).toEqual([{ network: testnet, chainId: 296 }]);
+      expect(HederaNetworks.map(({ network }) => network)).not.toContain(hashsphere);
+    });
+  });
+});


### PR DESCRIPTION
## Description

A wallet connected to a private HashSphere deployment is reported as an unrecognized network. `MetamaskService.setMetamaskNetwork` resolves the wallet's chain by looking its chain id up in `HederaNetworks`; with no entry for HashSphere the lookup misses, the environment falls back to `unrecognized`, and the factory, resolver, mirror node and JSON-RPC relay are all left empty. The dApp then cannot query or create securities against that deployment — `getRegulationDetails` and `createBond` fail with "Factory not found in request", and mirror queries fail on an empty base URL.

This registers a `hashsphere` network alongside the public ones. HashSphere is a private deployment and instances can use different chain ids, so the id is not built in: it is read from `HASHSPHERE_CHAIN_ID`, or `REACT_APP_HASHSPHERE_CHAIN_ID` for the web app, and the network is registered only when that variable holds a positive integer. Ids already used by a public Hedera network are rejected, because a duplicate would make `HederaNetworks.find` return the public network and reproduce the original failure. With the variable unset, `HederaNetworks` is byte-for-byte what it is today, so existing setups are unaffected.

Supersedes #1363, and incorporates the review feedback there that the chain id should be configurable rather than hardcoded.

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Automated, in `packages/ats/sdk`:

- `npx jest src/domain/context/network/Environment.unit.test.ts` — 21 tests covering variable precedence, the fallback when a value is blank or invalid, rejection of reserved public chain ids, and `HederaNetworks` with the variable set and unset (the latter two reload the module so each case is asserted in isolation).
- `npx jest src/app/service/network/NetworkService.unit.test.ts src/app/service/wallet/metamask/MetamaskService.unit.test.ts` — the existing suites that consume `Environment`; 34 tests pass in total with the above.
- `npx eslint` on both changed files — clean, no new warnings.
- `node .changeset/lint-changesets.mjs .changeset/hashsphere-network.md` — passes.

Manual verification against a live HashSphere deployment (chain id 4618), driving the web app with a stubbed EIP-1193 provider reporting that chain:

- With `REACT_APP_HASHSPHERE_CHAIN_ID=4618` and `REACT_APP_NETWORK=hashsphere`, the wallet pairs and reports `{"name":"hashsphere","recognized":true,"factoryId":"0.0.1199","resolverId":"0.0.1078"}`, and the mirror node resolves the account. Previously the same setup logged `0x120a not an hedera network` and left the factory unset.
- With the variable removed, the wallet is reported as unrecognized again, confirming the entry is opt-in.

**Node version**:

- [x] 20
- [ ] 22
- [ ] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅