### PR TITLE
As2 3525 ats find 033 version status deactivated is unimplemented and register business logics allows partial re registration to silently desync active facet versions

### DIFF
--- a/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ERC3643StorageWrapper.sol
@@ -523,7 +523,8 @@ library ERC3643StorageWrapper {
             LockStorageWrapper.getLockedAmountFor(_tokenHolder) +
                 HoldStorageWrapper.getHeldAmountFor(_tokenHolder) +
                 ClearingStorageWrapper.getClearedAmountFor(_tokenHolder) ==
-            0;
+            0 &&
+            AccessControlStorageWrapper.getRoleCountFor(_tokenHolder) == 0;
     }
 
     /**

--- a/packages/ats/contracts/contracts/infrastructure/README.md
+++ b/packages/ats/contracts/contracts/infrastructure/README.md
@@ -128,7 +128,7 @@ The BLR supports multiple concurrent configurations, allowing different token ty
 #### Configuration Management
 
 - **Configuration ID**: A `bytes32` identifier (e.g., `bytes32(1)` for EQUITY, `bytes32(2)` for BOND)
-- **Facet Blacklist**: Per-configuration blacklist of function selectors that should not be delegated
+- **Facet Blacklist**: Per-configuration blacklist checked when a selector is **registered** into a new configuration or configuration version (`_registerSelectors()`). It prevents that selector from being wired into the new version — it does not affect a selector already resolved in an already-active configuration.
 - **Version Tracking**: Each configuration maintains its own version pointer independent of others
 
 #### Multi-Configuration Usage

--- a/packages/ats/contracts/contracts/infrastructure/README.md
+++ b/packages/ats/contracts/contracts/infrastructure/README.md
@@ -85,40 +85,41 @@ Asset Tokenization Studio implements complex token functionality by splitting bu
 
 **Business Logic Address (BLA)**: The deployed contract address for a specific facet at a specific version.
 
-**Version**: An unsigned integer representing a specific set of compatible facets. All facets are versioned together—registering a new facet or updating an existing facet increments the global latest version.
+**Version**: An unsigned integer scoped to a single business logic key. Each key keeps its own independent version counter — registering a new implementation for one key increments only that key's counter; other keys are unaffected.
 
 **Configuration ID**: A `bytes32` identifier for a facet set configuration (e.g., `EQUITY_CONFIG_ID`, `BOND_CONFIG_ID`). Different token types may have different facet configurations.
 
 ### Version Management
 
-The BLR maintains a multi-dimensional registry of facets: each facet can have multiple versions, and multiple configurations can exist simultaneously.
+The BLR maintains a multi-dimensional registry of facets: each business logic key has its own independent version history, and multiple configurations can exist simultaneously.
 
 #### Version Evolution Example
 
-This example demonstrates how versions evolve as new facets are registered:
+This example demonstrates how each business logic key's version evolves independently as facets are registered:
 
-| Version | BLK: Compliance | BLK: Transfer | BLK: Pause | Status    |
-| ------- | --------------- | ------------- | ---------- | --------- |
-| 1       | 0x1000...       | 0x2000...     | 0x3000...  | ACTIVATED |
-| 2       | 0x1100...       | 0x2000...     | 0x3000...  | ACTIVATED |
-| 3       | 0x1100...       | 0x2100...     | 0x3000...  | ACTIVATED |
-| 4       | 0x1100...       | 0x2100...     | 0x3100...  | ACTIVATED |
-| 5       | 0x1200...       | 0x2100...     | 0x3100...  | DRAFT     |
+| Business Logic Key | Version | Address   | Status      |
+| ------------------ | ------- | --------- | ----------- |
+| Compliance         | 1       | 0x1000... | ACTIVATED   |
+| Compliance         | 2       | 0x1100... | ACTIVATED   |
+| Compliance         | 3       | 0x1200... | DEACTIVATED |
+| Transfer           | 1       | 0x2000... | ACTIVATED   |
+| Transfer           | 2       | 0x2100... | ACTIVATED   |
+| Pause              | 1       | 0x3000... | ACTIVATED   |
+| Pause              | 2       | 0x3100... | ACTIVATED   |
 
 **Reading the table**:
 
-- **V1**: Initial deployment with three facets (Compliance, Transfer, Pause)
-- **V2**: Compliance facet upgraded (new address 0x1100...), others unchanged
-- **V3**: Transfer facet upgraded (new address 0x2100...), others unchanged
-- **V4**: Pause facet upgraded (new address 0x3100...), all three facets updated
-- **V5**: Compliance upgraded again (new address 0x1200...), but marked as DRAFT (not yet activated)
+- **Compliance** has been registered three times: v1 (initial deployment), v2 (upgraded address), v3 (upgraded again, then explicitly retired via `setVersionStatus(..., DEACTIVATED)`)
+- **Transfer** and **Pause** each have their own independent version history — registering a new Compliance version never touches their counters
+- A configuration selects one `(key, version)` pair per facet explicitly; it is never resolved automatically to "the latest version" of anything
 
 **Important invariants**:
 
-- All facets share the same version number (V1–V4 include all three)
-- Adding a new facet or updating any facet increments the version for all facets
-- A facet's address may remain the same across versions (Transfer and Pause in V2)
-- Status applies to the entire version, not individual facets
+- Each business logic key has its own independent version counter — registering one key never advances another key's counter
+- A `registerBusinessLogics()` call may include any subset of keys; omitting a previously-registered key leaves that key's counter untouched rather than erroring
+- A facet's address may remain the same across versions if it is re-registered without changing the implementation
+- `VersionStatus` (`ACTIVATED`/`DEACTIVATED`) is set per `(key, version)` pair via `setVersionStatus()`, not per a version shared across facets
+- `createConfiguration()`/`createBatchConfiguration()` reject selecting a `DEACTIVATED` version for a new configuration
 - Clients should only use facets from activated versions
 
 ### Configuration System
@@ -154,18 +155,14 @@ BLR Registry:
 The BLR inherits from `DiamondCutManager` which provides functions to:
 
 - Register new facets: `registerBusinessLogics()`
-- Manage facet versions: `setPartialVersion()`, `completeVersion()`
+- Manage facet version status: `setVersionStatus()`
 - Control function access: `addSelectorsToBlacklist()`, `removeSelectorsFromBlacklist()`
 
-#### Partial Versions
+#### Registering in Batches
 
-When registering a large number of facets, a single transaction may exceed gas limits. The BLR supports a "partial" mechanism:
+`registerBusinessLogics()` accepts any subset of business logic keys per call — there is no dedicated "partial" mode or finalization step. Because each key's version counter is independent (see above), registering a large facet set across multiple transactions to stay under gas limits is safe: split the keys into batches and call `registerBusinessLogics()` once per batch, in any order. Keys not yet included in any call simply haven't been registered yet — there is no intermediate state to finalize.
 
-1. Call `registerBusinessLogics()` with `isPartial = true` and first batch of facets
-2. Call `registerBusinessLogics()` again with more facets (still partial)
-3. Call `registerBusinessLogics()` with final batch and `isPartial = false` to finalize
-
-This allows splitting large version updates across multiple transactions without creating inconsistent state.
+`scripts/infrastructure/operations/registerAdditionalFacets.ts` uses this to register facets in batches of `FACET_REGISTRATION_BATCH_SIZE`.
 
 ### BLR Files
 
@@ -425,22 +422,22 @@ The infrastructure implements EIP-2535 Diamond Pattern with the following charac
 1. **Single Proxy Address**: All token functionality accessible through one address
 2. **Multiple Facets**: Business logic split across multiple facet contracts
 3. **Facet Registry**: BLR maintains mapping of function selectors to facet addresses
-4. **Versioning**: All facets versioned together for compatibility
+4. **Versioning**: Each facet key keeps its own independent version; a configuration selects a specific `(key, version)` pair per facet
 5. **Upgradeability**: Add/remove/modify facets without touching proxy
 
 ### Version Synchronization
 
-All facets across the system maintain synchronized versions:
+Each business logic key keeps its own independent version. A **configuration** groups one specific `(key, version)` pair per facet, explicitly chosen by whoever creates it — it is not a single number that governs every facet's version:
 
 ```
-Proxy points to Version 3:
-├── ComplianceFacet V3 (address 0x1234...)
-├── TransferFacet V3 (address 0x5678...)
-├── PauseFacet V3 (address 0x9abc...)
-└── (All other registered facets at V3)
+Configuration #3 selects:
+├── ComplianceFacet at key version 2 (address 0x1234...)
+├── TransferFacet at key version 5 (address 0x5678...)
+├── PauseFacet at key version 1 (address 0x9abc...)
+└── (any other facet key, each at its own explicitly chosen version)
 ```
 
-Updating any facet creates a new global version that includes all current facets (at their current addresses) plus the updated facet.
+Registering a new implementation for a facet key advances that key's own version counter only — it does not affect any other key's version, and it does not change what any existing configuration resolves to. A new configuration must explicitly select the new `(key, version)` pair to start using it.
 
 ### Configuration-Based Routing
 
@@ -474,7 +471,7 @@ Typical upgrade process:
 
 1. **Deploy new facet versions**: New contracts with updated logic
 2. **Register with BLR**: `registerBusinessLogics([{key, newAddress}])`
-3. **New version created**: BLR increments global version counter
+3. **New version created**: BLR increments that key's own version counter; other keys are unaffected
 4. **Update proxies**: Call `proxy.updateConfigVersion(newVersion)`
 5. **New calls route to new facets**: Future calls use new version
 

--- a/packages/ats/contracts/contracts/infrastructure/README.md
+++ b/packages/ats/contracts/contracts/infrastructure/README.md
@@ -70,7 +70,7 @@ The **Business Logic Resolver (BLR)** is a smart contract that centralizes the m
 
 Asset Tokenization Studio implements complex token functionality by splitting business logic into multiple smart contracts (facets). As the system evolves, newer versions of these facets are deployed, older versions are maintained, and new facets are added. The BLR manages this version complexity, ensuring that:
 
-1. All facets across the system maintain synchronized versions
+1. Each business logic key maintains its own independent version counter
 2. Any previous version can be resolved for any registered facet
 3. Consumers can query compatible facet sets for a given version
 4. Version status can be tracked (ACTIVATED, DEACTIVATED, NONE)
@@ -425,7 +425,7 @@ The infrastructure implements EIP-2535 Diamond Pattern with the following charac
 4. **Versioning**: Each facet key keeps its own independent version; a configuration selects a specific `(key, version)` pair per facet
 5. **Upgradeability**: Add/remove/modify facets without touching proxy
 
-### Version Synchronization
+### Version Independence
 
 Each business logic key keeps its own independent version. A **configuration** groups one specific `(key, version)` pair per facet, explicitly chosen by whoever creates it — it is not a single number that governs every facet's version:
 
@@ -470,10 +470,10 @@ Facets are isolated but can share storage:
 Typical upgrade process:
 
 1. **Deploy new facet versions**: New contracts with updated logic
-2. **Register with BLR**: `registerBusinessLogics([{key, newAddress}])`
-3. **New version created**: BLR increments that key's own version counter; other keys are unaffected
-4. **Update proxies**: Call `proxy.updateConfigVersion(newVersion)`
-5. **New calls route to new facets**: Future calls use new version
+2. **Register with BLR**: `registerBusinessLogics([{key, newAddress}])` — advances that key's own version counter only; other keys are unaffected
+3. **Create a new configuration**: `createConfiguration()`/`createBatchConfiguration()`, explicitly selecting the new `(key, version)` pair alongside the existing versions of every other facet. A facet's version counter and a configuration's version are different things — bumping the former does not by itself change what any configuration resolves to
+4. **Point the proxy at it**: Call `proxy.updateConfigVersion(newConfigurationVersion)` to activate that configuration version
+5. **New calls route to new facets**: Future calls use the new configuration
 
 ---
 

--- a/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolver.sol
@@ -93,6 +93,17 @@ contract BusinessLogicResolver is IBusinessLogicResolver, DiamondCutManager {
     }
 
     /// @inheritdoc IBusinessLogicResolver
+    function setVersionStatus(
+        bytes32 _businessLogicKey,
+        uint256 _version,
+        VersionStatus _status
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) onlyUnpaused validVersion(_businessLogicKey, _version) {
+        if (_status == VersionStatus.NONE) revert InvalidVersionStatus();
+        _setVersionStatus(_businessLogicKey, _version, _status);
+        emit VersionStatusUpdated(_businessLogicKey, _version, _status);
+    }
+
+    /// @inheritdoc IBusinessLogicResolver
     function getReplacementAddress(address _replacedAddress) external view returns (address replacementAddress_) {
         replacementAddress_ = _getReplacementAddress(_replacedAddress);
     }

--- a/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolverWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolverWrapper.sol
@@ -237,6 +237,26 @@ abstract contract BusinessLogicResolverWrapper is IBusinessLogicResolver {
     }
 
     /**
+     * @notice Sets the status of a registered business logic version.
+     * @dev Callers must validate `_version` (via `validVersion`) and reject
+     *      `IBusinessLogicResolver.VersionStatus.NONE` before calling this function.
+     * @param _businessLogicKey Business logic key whose version status is updated.
+     * @param _version Version number to update.
+     * @param _status New status to assign to the version.
+     */
+    function _setVersionStatus(
+        bytes32 _businessLogicKey,
+        uint256 _version,
+        IBusinessLogicResolver.VersionStatus _status
+    ) internal {
+        BusinessLogicResolverDataStorage storage businessLogicResolverDataStorage = _businessLogicResolverStorage();
+        businessLogicResolverDataStorage.statusByFacetIdAndVersion[
+            keccak256(abi.encodePacked(_businessLogicKey, _version))
+        ] = _status;
+        businessLogicResolverDataStorage.businessLogics[_businessLogicKey][_version - 1].versionData.status = _status;
+    }
+
+    /**
      * @notice Returns the status stored for a business logic version.
      * @dev Returns `NONE` for keys or versions without an explicit status entry.
      * @param _businessLogicKey Business logic key to query.

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -192,6 +192,9 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, Ownership, Bus
             if (addr == address(0)) {
                 revert FacetIdNotRegistered(_configurationId, facetId);
             }
+            if (_getVersionStatus(facetId, facetVersion) == VersionStatus.DEACTIVATED) {
+                revert DeactivatedVersionNotAllowed(facetId, facetVersion);
+            }
             if (_dcms.addr[configVersionFacetHash] != address(0)) {
                 revert DuplicatedFacetInConfiguration(facetId);
             }

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
@@ -6,9 +6,15 @@ import { IDiamondCutManager } from "./IDiamondCutManager.sol";
  * @title IBusinessLogicResolver
  * @author Asset Tokenization Studio Team
  * @notice Registry for resolving Business Logic (facet) addresses by a bytes32 key and version.
- *         All registered Business Logics share a common version counter so consumers can safely
- *         target a single version and know it is fully compatible across every registered key.
- *         Registering or updating any Business Logic increments the shared latest version by 1.
+ * @dev Each business logic key has its own independent version counter — `registerBusinessLogics()`
+ *      increments `latestVersionByFacetId` only for the keys included in a given call. Omitting a
+ *      previously-registered key from a call leaves that key's counter untouched; it does not
+ *      advance alongside the keys that were included. Callers intending a full re-registration of
+ *      every active key must supply all of them in the same call (or across the batches of the
+ *      same registration operation) — the registry does not enforce this on their behalf, so a
+ *      partial call is a valid, if incomplete, update rather than a rejected one. Marking a
+ *      version `VersionStatus.DEACTIVATED` (see `setVersionStatus`) is the supported way to retire
+ *      a key from future full re-registrations without needing to keep re-supplying it.
  */
 interface IBusinessLogicResolver is IDiamondCutManager {
     /// @notice Lifecycle state of a registered business logic version.
@@ -55,9 +61,19 @@ interface IBusinessLogicResolver is IDiamondCutManager {
     /// @param replacementAddressRemoved removed replacement address.
     event ReplacementAddressRemoved(address indexed replacedAddress, address indexed replacementAddressRemoved);
 
+    /// @notice Event emitted when a business logic version's status is updated.
+    /// @param businessLogicKey Business logic key whose version status changed.
+    /// @param version Version number whose status changed.
+    /// @param status New status assigned to the version.
+    event VersionStatusUpdated(bytes32 indexed businessLogicKey, uint256 version, VersionStatus status);
+
     /// @notice Thrown when the requested version has never been registered for any business logic key.
     /// @param version The version number that does not exist in the registry.
     error BusinessLogicVersionDoesNotExist(uint256 version);
+
+    /// @notice Thrown when `setVersionStatus` is called with `VersionStatus.NONE`, which represents
+    ///         an unregistered version rather than a settable lifecycle state.
+    error InvalidVersionStatus();
 
     /// @notice Thrown when two entries in a registration batch share the same business logic key.
     /// @param businessLogicKey The duplicated key found in the batch.
@@ -125,6 +141,19 @@ interface IBusinessLogicResolver is IDiamondCutManager {
      * @param _oldAddress the address for which to remove the replacement
      */
     function removeReplacementAddress(address _oldAddress) external;
+
+    /**
+     * @notice Sets the status of a registered business logic version.
+     * @dev Restricted to `DEFAULT_ADMIN_ROLE`. Reverts with `InvalidVersionStatus` when `_status`
+     *      is `VersionStatus.NONE`, and with `BusinessLogicVersionDoesNotExist` when `_version` is
+     *      zero or has never been registered for `_businessLogicKey`. Marking a version
+     *      `DEACTIVATED` prevents it from being selected into any new resolver-proxy
+     *      configuration, but does not affect configurations that already reference it.
+     * @param _businessLogicKey The bytes32 key identifying the business logic to update.
+     * @param _version The version number to update.
+     * @param _status The new status (`ACTIVATED` or `DEACTIVATED`) to assign to the version.
+     */
+    function setVersionStatus(bytes32 _businessLogicKey, uint256 _version, VersionStatus _status) external;
 
     /**
      * @notice Returns the replacement address for a given address, or address(0) if none exists

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
@@ -12,9 +12,13 @@ import { IDiamondCutManager } from "./IDiamondCutManager.sol";
  *      advance alongside the keys that were included. Callers intending a full re-registration of
  *      every active key must supply all of them in the same call (or across the batches of the
  *      same registration operation) — the registry does not enforce this on their behalf, so a
- *      partial call is a valid, if incomplete, update rather than a rejected one. Marking a
- *      version `VersionStatus.DEACTIVATED` (see `setVersionStatus`) is the supported way to retire
- *      a key from future full re-registrations without needing to keep re-supplying it.
+ *      partial call is a valid, if incomplete, update rather than a rejected one.
+ *
+ *      `VersionStatus.DEACTIVATED` (see `setVersionStatus`) is unrelated to registration: it does
+ *      not affect `registerBusinessLogics()` in any way and does not retire a key. It only blocks
+ *      that one specific `(key, version)` pair from being selected into a new resolver-proxy
+ *      configuration going forward; other versions of the same key remain selectable, and
+ *      configurations that already reference the deactivated version are unaffected.
  */
 interface IBusinessLogicResolver is IDiamondCutManager {
     /// @notice Lifecycle state of a registered business logic version.

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
@@ -110,7 +110,9 @@ interface IBusinessLogicResolver is IDiamondCutManager {
     /**
      * @notice Update existing business logics addresses or add new business logics to the register.
      *         the BusinessLogicsRegistered event must be emitted.
-     *         The latest "version" for all business logics is increased by 1.
+     *         Each business logic key included in `_businessLogics` has its own independent
+     *         version counter, increased by 1 for that key only. Keys omitted from the call keep
+     *         their existing latest version untouched — see the per-key versioning note above.
      * @param _businessLogics list of business logics to be registered.
      */
     function registerBusinessLogics(BusinessLogicRegistryData[] calldata _businessLogics) external;

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IDiamondCutManager.sol
@@ -97,6 +97,15 @@ interface IDiamondCutManager {
     error DuplicatedFacetInConfiguration(bytes32 facetId);
 
     /**
+     * @notice Thrown when a configuration selects a facet version whose status has been set
+     *         to `DEACTIVATED`. Configurations that already reference the version are unaffected;
+     *         this only blocks the version from being selected into a new configuration.
+     * @param facetId Facet id whose selected version is deactivated.
+     * @param version Deactivated version that was selected.
+     */
+    error DeactivatedVersionNotAllowed(bytes32 facetId, uint256 version);
+
+    /**
      * @notice Thrown when {createConfiguration} is called for a configuration id that already
      *         has an in-progress batch, which would prematurely finalise the incomplete batch
      *         and absorb any facets that were intended for subsequent batch additions.

--- a/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
@@ -123,13 +123,17 @@ export function batchMintTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN a recovered caller WHEN batchMint THEN transaction fails with WalletRecovered", async () => {
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ethers.ZeroAddress);
+          await asset.recoveryAddress(signer_D.address, signer_B.address, ethers.ZeroAddress);
+          await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_D.address);
 
           const mintAmount = AMOUNT / 2;
-          const toList = [signer_D.address];
+          const toList = [signer_E.address];
           const amounts = [mintAmount];
 
-          await expect(asset.batchMint(toList, amounts)).to.be.revertedWithCustomError(asset, "WalletRecovered");
+          await expect(asset.connect(signer_D).batchMint(toList, amounts)).to.be.revertedWithCustomError(
+            asset,
+            "WalletRecovered",
+          );
         });
       });
     });

--- a/packages/ats/contracts/test/contracts/integration/burn/burn.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/burn/burn.test.ts
@@ -245,6 +245,7 @@ export function burnTests(getCtx: () => AssetMockCtx): void {
 
           it("GIVEN a recovered msgSender WHEN redeemFrom THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_E).approve(signer_C.address, AMOUNT / 2);
+            await asset.connect(signer_A).revokeRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
             await asset.recoveryAddress(signer_C.address, signer_D.address, ethers.ZeroAddress);
             expect(await asset.isAddressRecovered(signer_C.address)).to.be.true;
             await expect(

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -149,14 +149,14 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a recovered sender WHEN clearingRedeemByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperation = {
           partition: _DEFAULT_PARTITION,
           expirationTimestamp: EXPIRATION_TIMESTAMP,
           data: EMPTY_HEX_BYTES,
         };
         await expect(
-          asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+          asset.connect(signer_C).clearingRedeemByPartition(clearingOperation, _AMOUNT),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 
@@ -280,38 +280,22 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
         ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN a recovered sender WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
+      it("GIVEN a recovered tokenHolder WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperationFrom = {
           clearingOperation: {
             partition: _DEFAULT_PARTITION,
             expirationTimestamp: EXPIRATION_TIMESTAMP,
             data: EMPTY_HEX_BYTES,
           },
-          from: signer_A.address,
+          from: signer_C.address,
           operatorData: EMPTY_HEX_BYTES,
         };
-        await expect(
-          asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
-        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
-      });
-
-      it("GIVEN a recovered from address WHEN clearingRedeemFromByPartition THEN reverts with WalletRecovered", async () => {
-        await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
-        const clearingOperationFrom = {
-          clearingOperation: {
-            partition: _DEFAULT_PARTITION,
-            expirationTimestamp: EXPIRATION_TIMESTAMP,
-            data: EMPTY_HEX_BYTES,
-          },
-          from: signer_A.address,
-          operatorData: EMPTY_HEX_BYTES,
-        };
-        await expect(
-          asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT),
-        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+        await expect(asset.clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT)).to.be.revertedWithCustomError(
+          asset,
+          "WalletRecovered",
+        );
       });
 
       it("GIVEN clearing deactivated WHEN clearingRedeemFromByPartition THEN reverts with ClearingIsDisabled", async () => {
@@ -525,27 +509,27 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a recovered sender WHEN clearingTransferByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperation = {
           partition: _DEFAULT_PARTITION,
           expirationTimestamp: EXPIRATION_TIMESTAMP,
           data: EMPTY_HEX_BYTES,
         };
         await expect(
-          asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+          asset.connect(signer_C).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 
       it("GIVEN a recovered destination WHEN clearingTransferByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperation = {
           partition: _DEFAULT_PARTITION,
           expirationTimestamp: EXPIRATION_TIMESTAMP,
           data: EMPTY_HEX_BYTES,
         };
         await expect(
-          asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+          asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_C.address),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 
@@ -691,7 +675,7 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a recovered sender WHEN clearingTransferFromByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperationFrom = {
           clearingOperation: {
             partition: _DEFAULT_PARTITION,
@@ -702,7 +686,7 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
           operatorData: EMPTY_HEX_BYTES,
         };
         await expect(
-          asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+          asset.connect(signer_C).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_D.address),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 
@@ -725,7 +709,7 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a recovered from address WHEN clearingTransferFromByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
         const clearingOperationFrom = {
           clearingOperation: {
             partition: _DEFAULT_PARTITION,
@@ -736,7 +720,7 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
           operatorData: EMPTY_HEX_BYTES,
         };
         await expect(
-          asset.connect(signer_B).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_C.address),
+          asset.connect(signer_C).clearingTransferFromByPartition(clearingOperationFrom, _AMOUNT, signer_D.address),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 

--- a/packages/ats/contracts/test/contracts/integration/clearingHoldByPartition/clearingHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingHoldByPartition/clearingHoldByPartition.test.ts
@@ -53,6 +53,7 @@ export function clearingHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
     let unknownSigner: HardhatEthersSigner;
 
     let asset: IAssetMock;
@@ -89,6 +90,7 @@ export function clearingHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       unknownSigner = ctx.unknownSigner;
       asset = ctx.asset;
 
@@ -249,14 +251,15 @@ export function clearingHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
 
         describe("onlyUnrecoveredAddress modifier", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, unknownSigner.address, ADDRESS_ZERO);
             await expect(
-              asset.connect(signer_A).clearingCreateHoldByPartition(clearingOperation, hold),
+              asset.connect(signer_F).clearingCreateHoldByPartition(clearingOperation, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered hold.to address WHEN calling clearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, unknownSigner.address, ADDRESS_ZERO);
+            hold.to = signer_F.address;
             await expect(
               asset.connect(signer_A).clearingCreateHoldByPartition(clearingOperation, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -425,18 +428,20 @@ export function clearingHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
         describe("onlyUnrecoveredAddress modifier", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingCreateHoldFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, unknownSigner.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = { ...clearingOperationFrom, from: signer_B.address };
             await expect(
-              asset.connect(signer_A).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
+              asset.connect(signer_F).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered hold.to WHEN calling clearingCreateHoldFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.connect(signer_B).increaseAllowance(signer_A.address, _AMOUNT);
+            await asset.recoveryAddress(signer_F.address, unknownSigner.address, ADDRESS_ZERO);
 
+            hold.to = signer_F.address;
             const clearingOperationFromB = { ...clearingOperationFrom, from: signer_B.address };
             await expect(
               asset.connect(signer_A).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
@@ -445,9 +450,9 @@ export function clearingHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
 
           it("GIVEN a recovered from address WHEN calling clearingCreateHoldFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, unknownSigner.address, ADDRESS_ZERO);
 
-            const clearingOperationFromB = { ...clearingOperationFrom, from: signer_B.address };
+            const clearingOperationFromB = { ...clearingOperationFrom, from: signer_F.address };
             await expect(
               asset.connect(signer_A).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");

--- a/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
@@ -49,6 +49,7 @@ export function holdByPartitionTests(getCtx: () => AssetMockCtx): void {
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -174,6 +175,7 @@ export function holdByPartitionTests(getCtx: () => AssetMockCtx): void {
         signer_C = ctx.user2;
         signer_D = ctx.user3;
         signer_E = ctx.user4;
+        signer_F = ctx.user5;
         asset = ctx.asset;
 
         await executeRbac(asset, set_initRbacs());
@@ -400,12 +402,11 @@ export function holdByPartitionTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN msg.sender recovering WHEN createHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-          await asset.connect(signer_A).recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.connect(signer_A).recoveryAddress(signer_F.address, signer_E.address, ADDRESS_ZERO);
 
-          await expect(asset.createHoldByPartition(_DEFAULT_PARTITION, hold)).to.be.revertedWithCustomError(
-            asset,
-            "WalletRecovered",
-          );
+          await expect(
+            asset.connect(signer_F).createHoldByPartition(_DEFAULT_PARTITION, hold),
+          ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
         it("GIVEN hold.to recovering WHEN createHoldByPartition THEN transaction fails with WalletRecovered", async () => {
@@ -413,11 +414,11 @@ export function holdByPartitionTests(getCtx: () => AssetMockCtx): void {
             amount: _AMOUNT,
             expirationTimestamp: expirationTimestamp,
             escrow: signer_B.address,
-            to: signer_C.address,
+            to: signer_F.address,
             data: _DATA,
           };
 
-          await asset.connect(signer_A).recoveryAddress(signer_C.address, signer_B.address, ADDRESS_ZERO);
+          await asset.connect(signer_A).recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
 
           await expect(
             asset.createHoldByPartition(_DEFAULT_PARTITION, hold_with_destination),

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
@@ -90,6 +90,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -279,6 +280,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       asset = ctx.asset;
 
       const block = await ethers.provider.getBlock("latest");
@@ -2788,21 +2790,19 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             // Grant _AGENT_ROLE to call recoveryAddress
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
             // First recover signer_A's address
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             // Try to create clearing hold with recovered address
             await expect(
-              asset.connect(signer_A).clearingCreateHoldByPartition(clearingOperation, hold),
+              asset.connect(signer_F).clearingCreateHoldByPartition(clearingOperation, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered hold.to address WHEN calling clearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-            // Grant _AGENT_ROLE to call recoveryAddress
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            // Recover the hold.to address (signer_C - the actual hold.to)
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
-            // Try to create clearing hold with recovered hold.to
+            hold.to = signer_F.address;
             await expect(
               asset.connect(signer_A).clearingCreateHoldByPartition(clearingOperation, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -2813,7 +2813,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling clearingCreateHoldFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -2821,7 +2821,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
+              asset.connect(signer_F).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
@@ -2829,13 +2829,13 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
             // Recover the hold.to address (signer_C)
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
               from: signer_B.address,
             };
-
+            hold.to = signer_F.address;
             await expect(
               asset.connect(signer_A).clearingCreateHoldFromByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -2844,11 +2844,11 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered from address WHEN calling clearingCreateHoldFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -2860,10 +2860,10 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
         describe("clearingRedeemByPartition", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+              asset.connect(signer_F).clearingRedeemByPartition(clearingOperation, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
         });
@@ -2872,7 +2872,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling clearingRedeemFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -2880,18 +2880,18 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).clearingRedeemFromByPartition(clearingOperationFromB, _AMOUNT),
+              asset.connect(signer_F).clearingRedeemFromByPartition(clearingOperationFromB, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling clearingRedeemFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -2904,7 +2904,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -2912,18 +2912,18 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).operatorClearingRedeemByPartition(clearingOperationFromB, _AMOUNT),
+              asset.connect(signer_F).operatorClearingRedeemByPartition(clearingOperationFromB, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -2935,19 +2935,19 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
         describe("clearingTransferByPartition", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+              asset.connect(signer_F).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered to address WHEN calling clearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
         });
@@ -2956,7 +2956,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -2965,7 +2965,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
 
             await expect(
               asset
-                .connect(signer_A)
+                .connect(signer_F)
                 .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
@@ -2973,7 +2973,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered to address WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -2983,18 +2983,18 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             await expect(
               asset
                 .connect(signer_A)
-                .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
+                .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3009,7 +3009,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3018,7 +3018,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
 
             await expect(
               asset
-                .connect(signer_A)
+                .connect(signer_F)
                 .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
@@ -3026,7 +3026,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered to address WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3036,18 +3036,18 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             await expect(
               asset
                 .connect(signer_A)
-                .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
+                .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3416,11 +3416,11 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
       describe("onlyUnrecoveredAddress modifier for protectedClearingCreateHoldByPartition", () => {
         it("GIVEN a recovered from address WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-          await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const protectedClearingOperation = {
             clearingOperation: clearingOperation,
-            from: signer_A.address,
+            from: signer_F.address,
             deadline: expirationTimestamp,
             nonce: 1,
           };
@@ -3435,7 +3435,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
         it("GIVEN a recovered hold.to address WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
           // Recover the hold.to address (signer_C)
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const protectedClearingOperation = {
             clearingOperation: clearingOperation,
@@ -3445,7 +3445,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           };
 
           const signature = "0x1234"; // Dummy signature
-
+          hold.to = signer_F.address;
           await expect(
             asset.protectedClearingCreateHoldByPartition(protectedClearingOperation, hold, signature),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -4797,13 +4797,13 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
 
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
 
           const message = {
             _protectedClearingOperation: protectedClearingTransfer,
@@ -4811,8 +4811,8 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             _amount: _AMOUNT,
           };
 
-          const signature = await signer_A.signTypedData(domain, clearingTransferType, message);
-
+          const signature = await signer_F.signTypedData(domain, clearingTransferType, message);
+          protectedClearingTransfer.from = signer_F.address;
           await expect(
             asset
               .connect(signer_B)
@@ -4831,11 +4831,11 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           });
 
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const message = {
             _protectedClearingOperation: protectedClearingTransfer,
-            _to: signer_C.address,
+            _to: signer_F.address,
             _amount: _AMOUNT,
           };
 
@@ -4844,7 +4844,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           await expect(
             asset
               .connect(signer_B)
-              .protectedClearingTransferByPartition(protectedClearingTransfer, _AMOUNT, signer_C.address, signature),
+              .protectedClearingTransferByPartition(protectedClearingTransfer, _AMOUNT, signer_F.address, signature),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
@@ -4871,7 +4871,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
@@ -4886,8 +4886,8 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           await asset.grantRole(protectedPartitionRole, signer_B.address);
 
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
-
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
+          protectedClearingRedeem.from = signer_F.address;
           // Try to call - should hit onlyUnrecoveredAddress before signature validation
           await expect(
             asset.connect(signer_B).protectedClearingRedeemByPartition(protectedClearingRedeem, _AMOUNT, "0x1234"),
@@ -4899,13 +4899,13 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
 
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
 
           const holdForClearing = {
             amount: _AMOUNT,
@@ -4920,8 +4920,9 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
             _hold: holdForClearing,
           };
 
-          const signature = await signer_A.signTypedData(domain, clearingHoldType, message);
+          const signature = await signer_F.signTypedData(domain, clearingHoldType, message);
 
+          protectedClearingHoldCreation.from = signer_F.address;
           await expect(
             asset
               .connect(signer_B)
@@ -4940,13 +4941,13 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           });
 
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const holdForClearing = {
             amount: _AMOUNT,
             expirationTimestamp: expirationTimestamp,
             escrow: signer_D.address,
-            to: signer_C.address,
+            to: signer_F.address,
             data: _DATA,
           };
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
@@ -90,6 +90,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -299,6 +300,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       asset = ctx.asset;
 
       const block = await ethers.provider.getBlock("latest");
@@ -3018,7 +3020,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling operatorClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3026,18 +3028,18 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).operatorClearingCreateHoldByPartition(clearingOperationFromB, hold),
+              asset.connect(signer_F).operatorClearingCreateHoldByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling operatorClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3046,7 +3048,6 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           });
 
           it("GIVEN a recovered hold.to WHEN calling operatorClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-            // Give signer_B some tokens and authorize operator
             await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
             await asset.issueByPartition({
               partition: _DEFAULT_PARTITION,
@@ -3056,14 +3057,13 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             });
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            // Recover the hold.to address (signer_C - the actual hold.to)
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
               from: signer_B.address,
             };
-
+            hold.to = signer_F.address;
             await expect(
               asset.connect(signer_A).operatorClearingCreateHoldByPartition(clearingOperationFromB, hold),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -3073,10 +3073,10 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
         describe("clearingRedeemByPartition", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT),
+              asset.connect(signer_F).clearingRedeemByPartition(clearingOperation, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
         });
@@ -3085,7 +3085,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling clearingRedeemFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3093,18 +3093,18 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).clearingRedeemFromByPartition(clearingOperationFromB, _AMOUNT),
+              asset.connect(signer_F).clearingRedeemFromByPartition(clearingOperationFromB, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling clearingRedeemFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3117,7 +3117,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3125,18 +3125,18 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             };
 
             await expect(
-              asset.connect(signer_A).operatorClearingRedeemByPartition(clearingOperationFromB, _AMOUNT),
+              asset.connect(signer_F).operatorClearingRedeemByPartition(clearingOperationFromB, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3148,19 +3148,19 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
         describe("clearingTransferByPartition", () => {
           it("GIVEN a recovered msgSender WHEN calling clearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+              asset.connect(signer_F).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered to address WHEN calling clearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             await expect(
-              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_B.address),
+              asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
         });
@@ -3169,7 +3169,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3178,7 +3178,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
 
             await expect(
               asset
-                .connect(signer_A)
+                .connect(signer_F)
                 .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
@@ -3186,7 +3186,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered to address WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3196,18 +3196,18 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             await expect(
               asset
                 .connect(signer_A)
-                .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
+                .clearingTransferFromByPartition(clearingOperationFromB, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling clearingTransferFromByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3222,7 +3222,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered msgSender WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3231,7 +3231,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
 
             await expect(
               asset
-                .connect(signer_A)
+                .connect(signer_F)
                 .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
@@ -3239,7 +3239,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           it("GIVEN a recovered to address WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
@@ -3249,18 +3249,18 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             await expect(
               asset
                 .connect(signer_A)
-                .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_C.address),
+                .operatorClearingTransferByPartition(clearingOperationFromB, _AMOUNT, signer_F.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered from address WHEN calling operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_B).authorizeOperator(signer_A.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+            await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
             const clearingOperationFromB = {
               ...clearingOperationFrom,
-              from: signer_B.address,
+              from: signer_F.address,
             };
 
             await expect(
@@ -3629,11 +3629,11 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
       describe("onlyUnrecoveredAddress modifier for protectedClearingCreateHoldByPartition", () => {
         it("GIVEN a recovered from address WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-          await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const protectedClearingOperation = {
             clearingOperation: clearingOperation,
-            from: signer_A.address,
+            from: signer_F.address,
             deadline: expirationTimestamp,
             nonce: 1,
           };
@@ -3647,8 +3647,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
 
         it("GIVEN a recovered hold.to address WHEN calling protectedClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-          // Recover the hold.to address (signer_C)
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const protectedClearingOperation = {
             clearingOperation: clearingOperation,
@@ -3658,7 +3657,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           };
 
           const signature = "0x1234"; // Dummy signature
-
+          hold.to = signer_F.address;
           await expect(
             asset.protectedClearingCreateHoldByPartition(protectedClearingOperation, hold, signature),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
@@ -4910,20 +4909,17 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           });
         });
 
-        // Recovery tests following hold.test.ts pattern
         it("GIVEN a from user recovering WHEN protectedClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
-          // Setup: Issue tokens to signer_A
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
 
-          // Recover signer_A's address (needs single-partition)
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
 
           const message = {
             _protectedClearingOperation: protectedClearingTransfer,
@@ -4931,8 +4927,8 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             _amount: _AMOUNT,
           };
 
-          const signature = await signer_A.signTypedData(domain, clearingTransferType, message);
-
+          const signature = await signer_F.signTypedData(domain, clearingTransferType, message);
+          protectedClearingTransfer.from = signer_F.address;
           await expect(
             asset
               .connect(signer_B)
@@ -4941,7 +4937,6 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN a to user recovering WHEN protectedClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
-          // Setup: Issue tokens to signer_A
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
@@ -4950,13 +4945,12 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             data: _DATA,
           });
 
-          // Recover signer_C's address (needs single-partition)
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const message = {
             _protectedClearingOperation: protectedClearingTransfer,
-            _to: signer_C.address,
+            _to: signer_F.address,
             _amount: _AMOUNT,
           };
 
@@ -4965,7 +4959,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           await expect(
             asset
               .connect(signer_B)
-              .protectedClearingTransferByPartition(protectedClearingTransfer, _AMOUNT, signer_C.address, signature),
+              .protectedClearingTransferByPartition(protectedClearingTransfer, _AMOUNT, signer_F.address, signature),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
@@ -4988,16 +4982,14 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN a from user recovering WHEN protectedClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
-          // Setup: Issue tokens to signer_A
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
 
-          // Grant partition-specific role to signer_B
           const packedData = ethers.AbiCoder.defaultAbiCoder().encode(
             ["bytes32", "bytes32"],
             [ATS_ROLES.ROLE_PROTECTED_PARTITIONS_PARTICIPANT, _DEFAULT_PARTITION],
@@ -5006,30 +4998,26 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           const protectedPartitionRole = ethers.keccak256("0x" + packedDataWithoutPrefix);
           await asset.grantRole(protectedPartitionRole, signer_B.address);
 
-          // Recover signer_A's address (needs single-partition)
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
-
-          // Try to call - should hit onlyUnrecoveredAddress before signature validation
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
+          protectedClearingRedeem.from = signer_F.address;
           await expect(
             asset.connect(signer_B).protectedClearingRedeemByPartition(protectedClearingRedeem, _AMOUNT, "0x1234"),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
         it("GIVEN a from user recovering WHEN protectedClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
-          // Setup: Issue tokens to signer_A
           await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
           await asset.issueByPartition({
             partition: _DEFAULT_PARTITION,
-            tokenHolder: signer_A.address,
+            tokenHolder: signer_F.address,
             value: _AMOUNT,
             data: _DATA,
           });
 
-          // Recover signer_A's address (needs single-partition)
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
-
+          await asset.recoveryAddress(signer_F.address, signer_B.address, ADDRESS_ZERO);
+          protectedClearingHoldCreation.from = signer_F.address;
           const holdForClearing = {
             amount: _AMOUNT,
             expirationTimestamp: expirationTimestamp,
@@ -5043,7 +5031,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             _hold: holdForClearing,
           };
 
-          const signature = await signer_A.signTypedData(domain, clearingHoldType, message);
+          const signature = await signer_F.signTypedData(domain, clearingHoldType, message);
 
           await expect(
             asset
@@ -5062,15 +5050,14 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
             data: _DATA,
           });
 
-          // Recover signer_C's address (needs single-partition)
           await asset.setMultiPartition(false);
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const holdForClearing = {
             amount: _AMOUNT,
             expirationTimestamp: expirationTimestamp,
             escrow: signer_D.address,
-            to: signer_C.address,
+            to: signer_F.address,
             data: _DATA,
           };
 

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -127,12 +127,15 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
       });
 
       it("GIVEN a recovered wallet WHEN fullRedeemAtMaturity THEN reverts with WalletRecovered", async () => {
-        await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+        const signers = await ethers.getSigners();
+        const recoveredSigner = signers[11];
 
-        await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_A.address)).to.be.revertedWithCustomError(
-          asset,
-          "WalletRecovered",
-        );
+        await asset.connect(signer_A).recoveryAddress(recoveredSigner.address, signer_B.address, ADDRESS_ZERO);
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_MATURITY_REDEEMER, recoveredSigner.address);
+
+        await expect(
+          asset.connect(recoveredSigner).fullRedeemAtMaturity(recoveredSigner.address),
+        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 
       it("GIVEN a non-recovered caller redeeming on behalf of a recovered token holder WHEN fullRedeemAtMaturity THEN reverts with WalletRecovered", async () => {

--- a/packages/ats/contracts/test/contracts/integration/maturityByPartition/maturityByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturityByPartition/maturityByPartition.test.ts
@@ -29,6 +29,7 @@ export function maturityByPartitionTests(getCtx: () => AssetMockCtx): void {
     let signer_B: HardhatEthersSigner;
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
+    let signer_E: HardhatEthersSigner;
 
     let maturityDate: number;
 
@@ -39,6 +40,7 @@ export function maturityByPartitionTests(getCtx: () => AssetMockCtx): void {
       signer_B = ctx.user1;
       signer_C = ctx.user2;
       signer_D = ctx.user3;
+      signer_E = ctx.user4;
 
       await executeRbac(asset, [
         { role: ATS_ROLES.ROLE_FREEZE_MANAGER, members: [signer_A.address] },
@@ -120,10 +122,10 @@ export function maturityByPartitionTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN a recovered wallet WHEN redeeming at maturity THEN transaction fails with WalletRecovered", async () => {
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_E.address, signer_B.address, ADDRESS_ZERO);
 
           await expect(
-            asset.connect(signer_A).redeemAtMaturityByPartition(signer_A.address, DEFAULT_PARTITION, amount),
+            asset.connect(signer_A).redeemAtMaturityByPartition(signer_E.address, DEFAULT_PARTITION, amount),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 

--- a/packages/ats/contracts/test/contracts/integration/mint/mint.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/mint/mint.test.ts
@@ -130,9 +130,9 @@ export function mintTests(getCtx: () => AssetMockCtx): void {
         expect(await asset.balanceOf(signer_E.address)).to.be.equal(AMOUNT / 2);
       });
 
-      it("GIVEN a recovered caller WHEN issue THEN reverts with WalletRecovered", async () => {
+      it("GIVEN a recovered tokenHolder WHEN issue THEN reverts with WalletRecovered", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_E.address, signer_B.address, ADDRESS_ZERO);
 
         await expect(asset.issue(signer_E.address, AMOUNT, DATA)).to.be.revertedWithCustomError(
           asset,
@@ -140,9 +140,9 @@ export function mintTests(getCtx: () => AssetMockCtx): void {
         );
       });
 
-      it("GIVEN a recovered caller WHEN mint THEN reverts with WalletRecovered", async () => {
+      it("GIVEN a recovered to WHEN mint THEN reverts with WalletRecovered", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-        await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+        await asset.recoveryAddress(signer_E.address, signer_B.address, ADDRESS_ZERO);
 
         await expect(asset.mint(signer_E.address, AMOUNT)).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });

--- a/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
@@ -125,7 +125,7 @@ export function mintByPartitionTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a recovered caller WHEN issueByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_C.address);
-        await asset.connect(signer_C).recoveryAddress(signer_A.address, signer_E.address, ethers.ZeroAddress);
+        await asset.connect(signer_C).recoveryAddress(signer_E.address, signer_D.address, ethers.ZeroAddress);
 
         await expect(
           asset.issueByPartition({

--- a/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorClearingByPartition/operatorClearingByPartition.test.ts
@@ -36,6 +36,7 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -69,6 +70,7 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       asset = ctx.asset;
 
       clearingOperation = {
@@ -164,6 +166,8 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
         describe("onlyUnrecoveredAddress modifier", () => {
           it("GIVEN a recovered msgSender WHEN operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_A).authorizeOperator(signer_B.address);
+            await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_B.address);
+            await asset.revokeRole(ATS_ROLES.ROLE_KYC, signer_B.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
             await asset.recoveryAddress(signer_B.address, signer_E.address, ADDRESS_ZERO);
 
@@ -177,8 +181,8 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
           it("GIVEN a recovered from address WHEN operatorClearingTransferByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_A).authorizeOperator(signer_B.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_E.address, ADDRESS_ZERO);
-
+            await asset.recoveryAddress(signer_F.address, signer_E.address, ADDRESS_ZERO);
+            clearingOperationFrom.from = signer_F.address;
             await expect(
               asset
                 .connect(signer_B)
@@ -245,6 +249,8 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
         describe("onlyUnrecoveredAddress modifier", () => {
           it("GIVEN a recovered msgSender WHEN operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_A).authorizeOperator(signer_B.address);
+            await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_B.address);
+            await asset.revokeRole(ATS_ROLES.ROLE_KYC, signer_B.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
             await asset.recoveryAddress(signer_B.address, signer_E.address, ADDRESS_ZERO);
 
@@ -256,8 +262,8 @@ export function operatorClearingByPartitionTests(getCtx: () => AssetMockCtx): vo
           it("GIVEN a recovered from address WHEN operatorClearingRedeemByPartition THEN transaction fails with WalletRecovered", async () => {
             await asset.connect(signer_A).authorizeOperator(signer_B.address);
             await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-            await asset.recoveryAddress(signer_A.address, signer_E.address, ADDRESS_ZERO);
-
+            await asset.recoveryAddress(signer_F.address, signer_E.address, ADDRESS_ZERO);
+            clearingOperationFrom.from = signer_F.address;
             await expect(
               asset.connect(signer_B).operatorClearingRedeemByPartition(clearingOperationFrom, _AMOUNT),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");

--- a/packages/ats/contracts/test/contracts/integration/operatorClearingHoldByPartition/operatorClearingHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorClearingHoldByPartition/operatorClearingHoldByPartition.test.ts
@@ -46,6 +46,7 @@ export function operatorClearingHoldByPartitionTests(getCtx: () => AssetMockCtx)
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -86,6 +87,7 @@ export function operatorClearingHoldByPartitionTests(getCtx: () => AssetMockCtx)
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       asset = ctx.asset;
 
       hold = {
@@ -176,11 +178,11 @@ export function operatorClearingHoldByPartitionTests(getCtx: () => AssetMockCtx)
         it("GIVEN a recovered msgSender WHEN calling operatorClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.connect(signer_B).authorizeOperator(signer_A.address);
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-          await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const clearingOperationFromB = {
             ...clearingOperationFrom,
-            from: signer_B.address,
+            from: signer_F.address,
           };
 
           await expect(
@@ -191,11 +193,11 @@ export function operatorClearingHoldByPartitionTests(getCtx: () => AssetMockCtx)
         it("GIVEN a recovered from address WHEN calling operatorClearingCreateHoldByPartition THEN transaction fails with WalletRecovered", async () => {
           await asset.connect(signer_B).authorizeOperator(signer_A.address);
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
-          await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const clearingOperationFromB = {
             ...clearingOperationFrom,
-            from: signer_B.address,
+            from: signer_F.address,
           };
 
           await expect(
@@ -215,13 +217,13 @@ export function operatorClearingHoldByPartitionTests(getCtx: () => AssetMockCtx)
           await asset.connect(signer_B).authorizeOperator(signer_A.address);
           await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
           // Recover the hold.to address (signer_C - the actual hold.to)
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
           const clearingOperationFromB = {
             ...clearingOperationFrom,
             from: signer_B.address,
           };
-
+          hold.to = signer_F.address;
           await expect(
             asset.connect(signer_A).operatorClearingCreateHoldByPartition(clearingOperationFromB, hold),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");

--- a/packages/ats/contracts/test/contracts/integration/operatorHoldByPartition/operatorHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/operatorHoldByPartition/operatorHoldByPartition.test.ts
@@ -39,6 +39,7 @@ export function operatorHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
     let signer_E: HardhatEthersSigner;
+    let signer_F: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -163,6 +164,7 @@ export function operatorHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
       signer_C = ctx.user2;
       signer_D = ctx.user3;
       signer_E = ctx.user4;
+      signer_F = ctx.user5;
       asset = ctx.asset;
 
       await executeRbac(asset, set_initRbacs());
@@ -210,34 +212,22 @@ export function operatorHoldByPartitionTests(getCtx: () => AssetMockCtx): void {
       ).to.be.revertedWithCustomError(asset, "Unauthorized");
     });
 
-    // --- modifier: onlyValidOperatorCreateHoldByPartition (recovered addresses) ---
-    it("GIVEN a recovered msgSender WHEN operatorCreateHoldByPartition THEN reverts with WalletRecovered", async () => {
-      await asset.connect(signer_A).authorizeOperator(signer_B.address);
-      await asset.recoveryAddress(signer_B.address, signer_D.address, ADDRESS_ZERO);
-
-      await expect(
-        asset
-          .connect(signer_B)
-          .operatorCreateHoldByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES),
-      ).to.be.revertedWithCustomError(asset, "WalletRecovered");
-    });
-
     it("GIVEN a recovered _from address WHEN operatorCreateHoldByPartition THEN reverts with WalletRecovered", async () => {
       await asset.connect(signer_A).authorizeOperator(signer_B.address);
-      await asset.recoveryAddress(signer_A.address, signer_D.address, ADDRESS_ZERO);
+      await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
 
       await expect(
         asset
           .connect(signer_B)
-          .operatorCreateHoldByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES),
+          .operatorCreateHoldByPartition(_DEFAULT_PARTITION, signer_F.address, hold, EMPTY_HEX_BYTES),
       ).to.be.revertedWithCustomError(asset, "WalletRecovered");
     });
 
     it("GIVEN a recovered hold.to address WHEN operatorCreateHoldByPartition THEN reverts with WalletRecovered", async () => {
       const holdWithTo = { ...hold, to: signer_C.address };
       await asset.connect(signer_A).authorizeOperator(signer_B.address);
-      await asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO);
-
+      await asset.recoveryAddress(signer_F.address, signer_D.address, ADDRESS_ZERO);
+      holdWithTo.to = signer_F.address;
       await expect(
         asset
           .connect(signer_B)

--- a/packages/ats/contracts/test/contracts/integration/protectedHoldByPartition/protectedHoldByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/protectedHoldByPartition/protectedHoldByPartition.test.ts
@@ -447,12 +447,12 @@ export function protectedHoldByPartitionTests(getCtx: () => AssetMockCtx): void 
           nonce: 1,
         };
 
-        await asset.connect(signer_A).recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+        await asset.connect(signer_A).recoveryAddress(signer_C.address, signer_B.address, ADDRESS_ZERO);
 
         await expect(
           asset
             .connect(signer_B)
-            .protectedCreateHoldByPartition(DEFAULT_PARTITION, signer_A.address, protectedHold, "0x1234"),
+            .protectedCreateHoldByPartition(DEFAULT_PARTITION, signer_C.address, protectedHold, "0x1234"),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 

--- a/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
@@ -199,6 +199,7 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN _lostWallet is already recovered WHEN recoveryAddress THEN transaction fails with WalletRecovered", async () => {
+          await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
           await asset.recoveryAddress(signer_C.address, signer_B.address, ADDRESS_ZERO);
           await expect(
             asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO),
@@ -206,6 +207,7 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN _newWallet is already recovered WHEN recoveryAddress THEN transaction fails with WalletRecovered", async () => {
+          await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
           await asset.recoveryAddress(signer_C.address, signer_B.address, ADDRESS_ZERO);
           await expect(
             asset.recoveryAddress(signer_B.address, signer_C.address, ADDRESS_ZERO),
@@ -223,6 +225,7 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
           await asset.connect(signer_A).authorizeOperator(signer_C.address);
           await asset.connect(signer_A).authorizeOperator(signer_A.address);
           const amount = 1000;
+          await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
           await asset.recoveryAddress(signer_C.address, signer_B.address, ADDRESS_ZERO);
           const basicTransferInfo = {
             to: signer_B.address,
@@ -677,25 +680,25 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
         });
 
         it("GIVEN a recovered wallet WHEN recoveryAddress THEN transaction fails with WalletRecovered", async () => {
-          await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+          await asset.recoveryAddress(signer_D.address, signer_B.address, ADDRESS_ZERO);
 
           await expect(
-            asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO),
+            asset.recoveryAddress(signer_D.address, signer_B.address, ADDRESS_ZERO),
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
         describe("Recovered wallets fail centralized role checks", () => {
           it("GIVEN a recovered wallet still holding ROLE_PAUSER WHEN it calls pause (onlyRole) THEN reverts WalletRecovered", async () => {
-            await asset.grantRole(ATS_ROLES.ROLE_PAUSER, signer_D.address);
             await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+            await asset.grantRole(ATS_ROLES.ROLE_PAUSER, signer_D.address);
 
             expect(await asset.hasRole(ATS_ROLES.ROLE_PAUSER, signer_D.address)).to.equal(true);
             await expect(asset.connect(signer_D).pause()).to.be.revertedWithCustomError(asset, "WalletRecovered");
           });
 
           it("GIVEN a recovered wallet still holding ROLE_FREEZE_MANAGER WHEN it freezes (onlyFreezeRoles → checkAnyRole) THEN reverts WalletRecovered", async () => {
-            await asset.grantRole(ATS_ROLES.ROLE_FREEZE_MANAGER, signer_D.address);
             await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+            await asset.grantRole(ATS_ROLES.ROLE_FREEZE_MANAGER, signer_D.address);
 
             expect(await asset.hasRole(ATS_ROLES.ROLE_FREEZE_MANAGER, signer_D.address)).to.equal(true);
             await expect(
@@ -704,13 +707,32 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
           });
 
           it("GIVEN a recovered wallet still holding DEFAULT_ADMIN_ROLE WHEN it calls applyRoles (direct checkRole) THEN reverts WalletRecovered", async () => {
-            await asset.grantRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_D.address);
             await asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO);
+            await asset.grantRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_D.address);
 
             expect(await asset.hasRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_D.address)).to.equal(true);
             await expect(
               asset.connect(signer_D).applyRoles([ATS_ROLES.ROLE_LOCKER], [true], signer_E.address),
             ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+          });
+
+          it("FIND-039 (TDD, expected red) GIVEN a sole DEFAULT_ADMIN_ROLE holder WHEN recoveryAddress is called on it before rotating the role THEN transaction fails instead of permanently bricking admin operations", async () => {
+            const roleCount = await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE);
+            expect(roleCount).to.equal(1);
+            expect(await asset.hasRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, signer_A.address)).to.equal(true);
+
+            await expect(
+              asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO),
+            ).to.be.revertedWithCustomError(asset, "CannotRecoverWallet");
+          });
+
+          it("FIND-039 GIVEN a role-bearing wallet that is not the sole holder of that role WHEN recoveryAddress is called THEN transaction fails with CannotRecoverWallet", async () => {
+            await asset.grantRole(ATS_ROLES.ROLE_LOCKER, signer_D.address);
+            await asset.grantRole(ATS_ROLES.ROLE_LOCKER, signer_E.address);
+
+            await expect(
+              asset.recoveryAddress(signer_D.address, signer_F.address, ADDRESS_ZERO),
+            ).to.be.revertedWithCustomError(asset, "CannotRecoverWallet");
           });
         });
       });
@@ -746,6 +768,7 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN a multi partition token WHEN recoveryAddress THEN transaction fails with NotAllowedInMultiPartitionMode", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
+        await asset.revokeRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
         await expect(
           asset.recoveryAddress(signer_C.address, signer_D.address, ADDRESS_ZERO),
         ).to.be.revertedWithCustomError(asset, "NotAllowedInMultiPartitionMode");

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -32,6 +32,12 @@ const TEST_CONFIG_IDS = {
 const RESOLVER_PROXY_VERSION_V2 = "0x0000000000000002"; // bytes8
 const PAUSE_SELECTOR = "0x8456cb59";
 
+enum VersionStatus {
+  NONE = 0,
+  ACTIVATED = 1,
+  DEACTIVATED = 2,
+}
+
 describe("DiamondCutManager", () => {
   function createFacetConfigurations(ids: string[], versions: number[]): IDiamondCutManager.FacetConfigurationStruct[] {
     return ids.map((id, index) => ({
@@ -610,6 +616,22 @@ describe("DiamondCutManager", () => {
         .connect(signer_A)
         .createBatchConfiguration(CONFIG_IDS.equity, facetConfigurations, false, "0x", { gasLimit: 60_000_000 }),
     ).to.be.revertedWithCustomError(diamondCutManager, "DuplicatedFacetInConfiguration");
+  });
+
+  it("FIND-033 (TDD, expected red) GIVEN a facet version marked DEACTIVATED WHEN createBatchConfiguration selects it THEN fails with DeactivatedVersionNotAllowed", async () => {
+    await businessLogicResolver
+      .connect(signer_A)
+      .setVersionStatus(equityFacetIdList[0], equityFacetVersionList[0], VersionStatus.DEACTIVATED);
+
+    const facetConfigurations = createFacetConfigurations(equityFacetIdList, equityFacetVersionList);
+
+    await expect(
+      diamondCutManager
+        .connect(signer_A)
+        .createBatchConfiguration(CONFIG_IDS.equity, facetConfigurations, false, "0x", { gasLimit: 60_000_000 }),
+    )
+      .to.be.revertedWithCustomError(diamondCutManager, "DeactivatedVersionNotAllowed")
+      .withArgs(equityFacetIdList[0], equityFacetVersionList[0]);
   });
 
   it("GIVEN a resolver WHEN a selector is blacklisted THEN transaction fails with SelectorBlacklisted", async () => {

--- a/packages/ats/contracts/test/contracts/integration/transfer/transfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/transfer/transfer.test.ts
@@ -433,8 +433,8 @@ export function transferTests(getCtx: () => AssetMockCtx): void {
 
         it("GIVEN a recovered msgSender WHEN transferFromWithData THEN transaction fails with WalletRecovered", async () => {
           await asset.connect(signer_E).approve(signer_C.address, amount / 2);
-          await asset.recoveryAddress(signer_C.address, signer_D.address, ethers.ZeroAddress);
-          expect(await asset.isAddressRecovered(signer_C.address)).to.be.true;
+          await asset.recoveryAddress(signer_D.address, signer_E.address, ethers.ZeroAddress);
+          expect(await asset.isAddressRecovered(signer_D.address)).to.be.true;
 
           await expect(
             asset.connect(signer_C).transferFromWithData(signer_E.address, signer_D.address, amount / 2, DATA),


### PR DESCRIPTION
## Description

This PR closes three findings from the external security audit (FIND-033, FIND-039, FIND-069), addressing two independent gaps in the diamond/facet registry's version and role-state handling.

**`VersionStatus.DEACTIVATED` was unimplemented, and `registerBusinessLogics()` did not guard against partial re-registration (FIND-033, FIND-069):**
- Adds an authorised `setVersionStatus()` function so a registered facet version can be explicitly marked `DEACTIVATED`.
- `createConfiguration()` / `createBatchConfiguration()` now reject selecting a `DEACTIVATED` version for a new configuration (`DeactivatedVersionNotAllowed`).
- Documents that each business logic key keeps its own independent version counter, that a registration call may omit previously-registered keys without reverting, and that `DEACTIVATED` is the supported way to retire a key going forward.

**A wallet could be recovered while still holding a privileged role, risking an unrecoverable `DEFAULT_ADMIN_ROLE` (FIND-039):**
- `canRecover()` now rejects recovering any wallet that currently holds at least one `AccessControl` role.

Fixes FIND-033, FIND-039, FIND-069.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- Result: 3749 passing, 0 failing; coverage 98% lines / 98% branches / 99% functions; 0 lint errors (93 warnings, unchanged vs. base branch)

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅