### PR TITLE
As2 3669 ats find 053 diamond cut update resolver needs target validation all three upgrade entrypoints need events

### DIFF
--- a/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/BusinessLogicResolver.sol
@@ -172,4 +172,9 @@ contract BusinessLogicResolver is IBusinessLogicResolver, DiamondCutManager {
     ) external view override returns (bytes4[] memory selectors_) {
         return _getSelectorsBlacklist(_configurationId, _pageIndex, _pageLength);
     }
+
+    /// @inheritdoc IBusinessLogicResolver
+    function isBusinessLogicResolver() external pure override returns (bool isBusinessLogicResolver_) {
+        return true;
+    }
 }

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCut.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCut.sol
@@ -30,6 +30,23 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
         _;
     }
 
+    /// @notice Restricts execution to a candidate resolver that is neither the zero address nor
+    ///         fails an explicit `isBusinessLogicResolver()` identity check.
+    /// @dev The identity check is performed through a low-level `call()`, not a direct interface
+    ///      call, so a non-conforming target reverts with `InvalidBusinessLogicResolver` instead of
+    ///      an unrelated low-level revert.
+    /// @param _resolver Candidate resolver address to validate.
+    modifier onlyValidBusinessLogicResolver(IBusinessLogicResolver _resolver) {
+        if (address(_resolver) == address(0)) revert InvalidBusinessLogicResolver(address(_resolver));
+        (bool success, bytes memory returnData) = address(_resolver).call(
+            abi.encodeWithSelector(IBusinessLogicResolver.isBusinessLogicResolver.selector)
+        );
+        if (!success || returnData.length < 32 || !abi.decode(returnData, (bool))) {
+            revert InvalidBusinessLogicResolver(address(_resolver));
+        }
+        _;
+    }
+
     /// @inheritdoc IDiamondCut
     /// @dev Requires `DEFAULT_ADMIN_ROLE` and preserves the active configuration identifier and
     ///      resolver while updating only the pinned configuration version.
@@ -45,15 +62,19 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
             _newVersion
         )
     {
+        uint256 oldVersion = ResolverProxyStorageWrapper.getResolverProxyConfigurationVersion();
         IResolverProxy.ResolverProxyConfigurationV2 memory v2 = ResolverProxyStorageWrapper
             .getResolverProxyConfigurationV2();
         v2.configurationVersion = _newVersion;
         ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(v2);
+        emit ConfigVersionUpdated(EvmAccessors.getMsgSender(), oldVersion, _newVersion);
     }
 
     /// @inheritdoc IDiamondCut
     /// @dev Requires `DEFAULT_ADMIN_ROLE` and validates the configuration before storing the new
-    ///      configuration identifier and pinned version.
+    ///      configuration identifier and pinned version. The admin is responsible for confirming
+    ///      that `_newConfigurationId` is compatible with the currently active configuration
+    ///      before calling this function; no on-chain compatibility check is performed.
     function updateConfig(
         bytes32 _newConfigurationId,
         uint256 _newVersion
@@ -67,11 +88,13 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
             _newVersion
         )
     {
+        bytes32 oldConfigurationId = ResolverProxyStorageWrapper.getResolverProxyConfigurationId();
         IResolverProxy.ResolverProxyConfigurationV2 memory v2 = ResolverProxyStorageWrapper
             .getResolverProxyConfigurationV2();
         v2.configurationId = _newConfigurationId;
         v2.configurationVersion = _newVersion;
         ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(v2);
+        emit ConfigUpdated(EvmAccessors.getMsgSender(), oldConfigurationId, _newConfigurationId, _newVersion);
     }
 
     /// @inheritdoc IDiamondCut
@@ -83,8 +106,13 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
     }
 
     /// @inheritdoc IDiamondCut
-    /// @dev Requires `DEFAULT_ADMIN_ROLE` and validates the target configuration against the new
-    ///      resolver before replacing the resolver pointer, configuration identifier and version.
+    /// @dev Requires `DEFAULT_ADMIN_ROLE`, validates `_newResolver` is a genuine
+    ///      `IBusinessLogicResolver`, and validates the target configuration against it before
+    ///      replacing the resolver pointer, configuration identifier and version. The admin is
+    ///      responsible for confirming business-key and configuration compatibility across the
+    ///      resolver switch before calling this function; no on-chain compatibility check is
+    ///      performed — `_newResolver`, `_newConfigurationId` and `_newVersion` are trusted as a
+    ///      deliberate, atomic choice by a trusted admin role.
     function updateResolver(
         IBusinessLogicResolver _newResolver,
         bytes32 _newConfigurationId,
@@ -94,8 +122,10 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
         external
         override
         onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyValidBusinessLogicResolver(_newResolver)
         onlyRegisteredResolverProxyConfiguration(_newResolver, _newConfigurationId, _newVersion)
     {
+        address oldResolver = address(ResolverProxyStorageWrapper.getBusinessLogicResolver());
         ResolverProxyStorageWrapper.setBusinessLogicResolver(_newResolver);
         ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(
             IResolverProxy.ResolverProxyConfigurationV2({
@@ -103,6 +133,13 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
                 configurationVersion: _newVersion,
                 replacementEnabled: _newReplacementEnabled
             })
+        );
+        emit ResolverUpdated(
+            EvmAccessors.getMsgSender(),
+            oldResolver,
+            address(_newResolver),
+            _newConfigurationId,
+            _newVersion
         );
     }
 

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCut.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCut.sol
@@ -91,18 +91,27 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
         bytes32 oldConfigurationId = ResolverProxyStorageWrapper.getResolverProxyConfigurationId();
         IResolverProxy.ResolverProxyConfigurationV2 memory v2 = ResolverProxyStorageWrapper
             .getResolverProxyConfigurationV2();
+        uint256 oldConfigurationVersion = v2.configurationVersion;
         v2.configurationId = _newConfigurationId;
         v2.configurationVersion = _newVersion;
         ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(v2);
-        emit ConfigUpdated(EvmAccessors.getMsgSender(), oldConfigurationId, _newConfigurationId, _newVersion);
+        emit ConfigUpdated(
+            EvmAccessors.getMsgSender(),
+            oldConfigurationId,
+            _newConfigurationId,
+            oldConfigurationVersion,
+            _newVersion
+        );
     }
 
     /// @inheritdoc IDiamondCut
     function updateReplacementEnabled(bool _newReplacementEnabled) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         IResolverProxy.ResolverProxyConfigurationV2 memory v2 = ResolverProxyStorageWrapper
             .getResolverProxyConfigurationV2();
+        bool oldReplacementEnabled = v2.replacementEnabled;
         v2.replacementEnabled = _newReplacementEnabled;
         ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(v2);
+        emit ReplacementEnabledUpdated(EvmAccessors.getMsgSender(), oldReplacementEnabled, _newReplacementEnabled);
     }
 
     /// @inheritdoc IDiamondCut
@@ -125,22 +134,7 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
         onlyValidBusinessLogicResolver(_newResolver)
         onlyRegisteredResolverProxyConfiguration(_newResolver, _newConfigurationId, _newVersion)
     {
-        address oldResolver = address(ResolverProxyStorageWrapper.getBusinessLogicResolver());
-        ResolverProxyStorageWrapper.setBusinessLogicResolver(_newResolver);
-        ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(
-            IResolverProxy.ResolverProxyConfigurationV2({
-                configurationId: _newConfigurationId,
-                configurationVersion: _newVersion,
-                replacementEnabled: _newReplacementEnabled
-            })
-        );
-        emit ResolverUpdated(
-            EvmAccessors.getMsgSender(),
-            oldResolver,
-            address(_newResolver),
-            _newConfigurationId,
-            _newVersion
-        );
+        _updateResolver(_newResolver, _newConfigurationId, _newVersion, _newReplacementEnabled);
     }
 
     /// @inheritdoc IDiamondCut
@@ -161,6 +155,39 @@ abstract contract DiamondCut is IDiamondCut, ResolverProxyUnstructured {
             ResolverProxyStorageWrapper.getResolverProxyConfigurationId(),
             ResolverProxyStorageWrapper.getResolverProxyConfigurationVersion(),
             ResolverProxyStorageWrapper.getResolverProxyReplacementEnabled()
+        );
+    }
+
+    /// @notice Body of `updateResolver()`, extracted to a private helper to give it a fresh
+    ///         stack frame — the four parameters plus the old/new locals needed for the fully
+    ///         old/new-covering `ResolverUpdated` event otherwise trip "stack too deep".
+    function _updateResolver(
+        IBusinessLogicResolver _newResolver,
+        bytes32 _newConfigurationId,
+        uint256 _newVersion,
+        bool _newReplacementEnabled
+    ) private {
+        address oldResolver = address(ResolverProxyStorageWrapper.getBusinessLogicResolver());
+        IResolverProxy.ResolverProxyConfigurationV2 memory oldV2 = ResolverProxyStorageWrapper
+            .getResolverProxyConfigurationV2();
+        ResolverProxyStorageWrapper.setBusinessLogicResolver(_newResolver);
+        ResolverProxyStorageWrapper.setResolverProxyConfigurationV2(
+            IResolverProxy.ResolverProxyConfigurationV2({
+                configurationId: _newConfigurationId,
+                configurationVersion: _newVersion,
+                replacementEnabled: _newReplacementEnabled
+            })
+        );
+        emit ResolverUpdated(
+            EvmAccessors.getMsgSender(),
+            oldResolver,
+            address(_newResolver),
+            oldV2.configurationId,
+            _newConfigurationId,
+            oldV2.configurationVersion,
+            _newVersion,
+            oldV2.replacementEnabled,
+            _newReplacementEnabled
         );
     }
 }

--- a/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/IBusinessLogicResolver.sol
@@ -248,4 +248,12 @@ interface IBusinessLogicResolver is IDiamondCutManager {
         uint256 _pageIndex,
         uint256 _pageLength
     ) external view returns (bytes4[] memory selectors_);
+
+    /**
+     * @notice Identity marker used to confirm a candidate address is a genuine
+     *         `IBusinessLogicResolver`, checked via low-level `call()` rather than a direct
+     *         interface call (see `DiamondCut::onlyValidBusinessLogicResolver`).
+     * @return isBusinessLogicResolver_ Always `true` for a real `BusinessLogicResolver`.
+     */
+    function isBusinessLogicResolver() external pure returns (bool isBusinessLogicResolver_);
 }

--- a/packages/ats/contracts/contracts/infrastructure/proxy/IDiamondCut.sol
+++ b/packages/ats/contracts/contracts/infrastructure/proxy/IDiamondCut.sol
@@ -9,6 +9,47 @@ import { IBusinessLogicResolver } from "../diamond/IBusinessLogicResolver.sol";
 /// @notice Interface for upgrading the Diamond proxy's Business Logic Resolver (BLR),
 ///         configuration identifier, and version in a single or multi-step operation.
 interface IDiamondCut is IStaticFunctionSelectors {
+    /// @notice Emitted when the resolver-proxy's Business Logic Resolver is replaced.
+    /// @param caller Account that performed the update.
+    /// @param oldResolver Previous Business Logic Resolver address.
+    /// @param newResolver New Business Logic Resolver address.
+    /// @param newConfigurationId Configuration identifier activated on the new resolver.
+    /// @param newConfigurationVersion Configuration version activated on the new resolver.
+    event ResolverUpdated(
+        address indexed caller,
+        address oldResolver,
+        address newResolver,
+        bytes32 newConfigurationId,
+        uint256 newConfigurationVersion
+    );
+
+    /// @notice Emitted when the active configuration identifier is replaced.
+    /// @param caller Account that performed the update.
+    /// @param oldConfigurationId Previous configuration identifier.
+    /// @param newConfigurationId New configuration identifier.
+    /// @param newConfigurationVersion Version activated for the new configuration.
+    event ConfigUpdated(
+        address indexed caller,
+        bytes32 oldConfigurationId,
+        bytes32 newConfigurationId,
+        uint256 newConfigurationVersion
+    );
+
+    /// @notice Emitted when the pinned version of the active configuration is replaced.
+    /// @param caller Account that performed the update.
+    /// @param oldConfigurationVersion Previous configuration version.
+    /// @param newConfigurationVersion New configuration version.
+    event ConfigVersionUpdated(
+        address indexed caller,
+        uint256 oldConfigurationVersion,
+        uint256 newConfigurationVersion
+    );
+
+    /// @notice Thrown when a candidate resolver is the zero address or fails the
+    ///         `isBusinessLogicResolver()` identity check.
+    /// @param invalidResolver The address that failed validation.
+    error InvalidBusinessLogicResolver(address invalidResolver);
+
     /**
      * @notice For the current BLR and configuration, update the used version.
      * @param _newVersion The new version number to set for the current configuration.

--- a/packages/ats/contracts/contracts/infrastructure/proxy/IDiamondCut.sol
+++ b/packages/ats/contracts/contracts/infrastructure/proxy/IDiamondCut.sol
@@ -10,28 +10,42 @@ import { IBusinessLogicResolver } from "../diamond/IBusinessLogicResolver.sol";
 ///         configuration identifier, and version in a single or multi-step operation.
 interface IDiamondCut is IStaticFunctionSelectors {
     /// @notice Emitted when the resolver-proxy's Business Logic Resolver is replaced.
+    /// @dev `updateResolver()` combines four changes in one call; every one of them gets a
+    ///      complete old/new pair here rather than only the fields that happen to differ.
     /// @param caller Account that performed the update.
     /// @param oldResolver Previous Business Logic Resolver address.
     /// @param newResolver New Business Logic Resolver address.
+    /// @param oldConfigurationId Previous configuration identifier.
     /// @param newConfigurationId Configuration identifier activated on the new resolver.
+    /// @param oldConfigurationVersion Previous configuration version.
     /// @param newConfigurationVersion Configuration version activated on the new resolver.
+    /// @param oldReplacementEnabled Previous replacement-enabled flag.
+    /// @param newReplacementEnabled Replacement-enabled flag activated on the new resolver.
     event ResolverUpdated(
         address indexed caller,
         address oldResolver,
         address newResolver,
+        bytes32 oldConfigurationId,
         bytes32 newConfigurationId,
-        uint256 newConfigurationVersion
+        uint256 oldConfigurationVersion,
+        uint256 newConfigurationVersion,
+        bool oldReplacementEnabled,
+        bool newReplacementEnabled
     );
 
     /// @notice Emitted when the active configuration identifier is replaced.
+    /// @dev `updateConfig()` combines an id change and a version change in one call; both get a
+    ///      complete old/new pair here.
     /// @param caller Account that performed the update.
     /// @param oldConfigurationId Previous configuration identifier.
     /// @param newConfigurationId New configuration identifier.
+    /// @param oldConfigurationVersion Previous configuration version.
     /// @param newConfigurationVersion Version activated for the new configuration.
     event ConfigUpdated(
         address indexed caller,
         bytes32 oldConfigurationId,
         bytes32 newConfigurationId,
+        uint256 oldConfigurationVersion,
         uint256 newConfigurationVersion
     );
 
@@ -44,6 +58,12 @@ interface IDiamondCut is IStaticFunctionSelectors {
         uint256 oldConfigurationVersion,
         uint256 newConfigurationVersion
     );
+
+    /// @notice Emitted when the replacement-enabled flag is replaced.
+    /// @param caller Account that performed the update.
+    /// @param oldReplacementEnabled Previous replacement-enabled flag.
+    /// @param newReplacementEnabled New replacement-enabled flag.
+    event ReplacementEnabledUpdated(address indexed caller, bool oldReplacementEnabled, bool newReplacementEnabled);
 
     /// @notice Thrown when a candidate resolver is the zero address or fails the
     ///         `isBusinessLogicResolver()` identity check.

--- a/packages/ats/contracts/test/contracts/integration/resolverProxy/resolverProxy.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolverProxy/resolverProxy.test.ts
@@ -758,7 +758,7 @@ describe("ResolverProxy Tests", () => {
 
     await expect(diamondCut.updateResolver(resolver_2.target, CONFIG_ID_2, 1, true))
       .to.emit(diamondCut, "ResolverUpdated")
-      .withArgs(signer_A.address, resolver.target, resolver_2.target, CONFIG_ID_2, 1);
+      .withArgs(signer_A.address, resolver.target, resolver_2.target, CONFIG_ID, CONFIG_ID_2, 1, 1, false, true);
   });
 
   it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating config THEN emits ConfigUpdated", async () => {
@@ -786,7 +786,7 @@ describe("ResolverProxy Tests", () => {
 
     await expect(diamondCut.updateConfig(CONFIG_ID_2, 1))
       .to.emit(diamondCut, "ConfigUpdated")
-      .withArgs(signer_A.address, CONFIG_ID, CONFIG_ID_2, 1);
+      .withArgs(signer_A.address, CONFIG_ID, CONFIG_ID_2, 1, 1);
   });
 
   it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating config version THEN emits ConfigVersionUpdated", async () => {
@@ -814,5 +814,32 @@ describe("ResolverProxy Tests", () => {
     await expect(diamondCut.updateConfigVersion(1))
       .to.emit(diamondCut, "ConfigVersionUpdated")
       .withArgs(signer_A.address, 1, 1);
+  });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating replacement enabled THEN emits ReplacementEnabledUpdated", async () => {
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateReplacementEnabled(true))
+      .to.emit(diamondCut, "ReplacementEnabledUpdated")
+      .withArgs(signer_A.address, false, true);
   });
 });

--- a/packages/ats/contracts/test/contracts/integration/resolverProxy/resolverProxy.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolverProxy/resolverProxy.test.ts
@@ -674,4 +674,145 @@ describe("ResolverProxy Tests", () => {
     expect(result.configurationVersion_).to.equal(newVersion);
     expect(result.replacementEnabled_).to.equal(true);
   });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating resolver to the zero address THEN reverts with InvalidBusinessLogicResolver", async () => {
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateResolver(ethers.ZeroAddress, CONFIG_ID, 1, true)).to.be.revertedWithCustomError(
+      diamondCut,
+      "InvalidBusinessLogicResolver",
+    );
+  });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating resolver to a contract that is not a BusinessLogicResolver THEN reverts with InvalidBusinessLogicResolver", async () => {
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateResolver(diamondFacet.target, CONFIG_ID, 1, true)).to.be.revertedWithCustomError(
+      diamondCut,
+      "InvalidBusinessLogicResolver",
+    );
+  });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating resolver THEN emits ResolverUpdated", async () => {
+    resolver_2 = await deployResolver();
+
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas);
+    await setUpResolver(businessLogicsRegistryDatas, CONFIG_ID_2, resolver_2);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateResolver(resolver_2.target, CONFIG_ID_2, 1, true))
+      .to.emit(diamondCut, "ResolverUpdated")
+      .withArgs(signer_A.address, resolver.target, resolver_2.target, CONFIG_ID_2, 1);
+  });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating config THEN emits ConfigUpdated", async () => {
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas, CONFIG_ID);
+    await setUpResolver(businessLogicsRegistryDatas, CONFIG_ID_2);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateConfig(CONFIG_ID_2, 1))
+      .to.emit(diamondCut, "ConfigUpdated")
+      .withArgs(signer_A.address, CONFIG_ID, CONFIG_ID_2, 1);
+  });
+
+  it("FIND-053 (TDD, expected red) GIVEN resolverProxy and admin user WHEN updating config version THEN emits ConfigVersionUpdated", async () => {
+    const businessLogicsRegistryDatas = [
+      {
+        businessLogicKey: await diamondFacet.getStaticResolverKey(),
+        businessLogicAddress: diamondFacet.target,
+      },
+      {
+        businessLogicKey: await accessControlImpl.getStaticResolverKey(),
+        businessLogicAddress: accessControlImpl.target,
+      },
+    ];
+
+    await setUpResolver(businessLogicsRegistryDatas);
+
+    const rbac = [{ role: ATS_ROLES.DEFAULT_ADMIN_ROLE, members: [signer_A.address] }];
+
+    const resolverProxy = await (
+      await ethers.getContractFactory("ResolverProxy")
+    ).deploy(resolver.target, { configurationId: CONFIG_ID, configurationVersion: 1, replacementEnabled: false }, rbac);
+
+    const diamondCut = await ethers.getContractAt("DiamondFacet", resolverProxy.target, signer_A);
+
+    await expect(diamondCut.updateConfigVersion(1))
+      .to.emit(diamondCut, "ConfigVersionUpdated")
+      .withArgs(signer_A.address, 1, 1);
+  });
 });


### PR DESCRIPTION
## Description

This PR closes FIND-053 from the external security audit, hardening the resolver-proxy upgrade path (`DiamondCut.sol`).

**`updateResolver()` accepted any target without validation, and none of the three upgrade entrypoints emitted events:**
- `updateResolver()` now rejects `address(0)` and validates the target via an explicit `isBusinessLogicResolver()` identity check, checked through a low-level `call()` with success and return-data validation — rather than relying on "some function happened to exist and not revert" as the implicit signal.
- `updateResolver()`, `updateConfig()`, and `updateConfigVersion()` each now emit a dedicated event (`ResolverUpdated`, `ConfigUpdated`, `ConfigVersionUpdated`) recording the caller and the relevant old/new state, so proxy upgrades are no longer invisible to off-chain monitoring.

Config/version consistency across a resolver switch is documented as the admin's responsibility (NatSpec on `updateResolver()`/`updateConfig()`) rather than enforced on-chain — `DEFAULT_ADMIN_ROLE` is a trusted, timelocked role expected to validate compatibility before switching, and there is no general on-chain way to compare facet/storage compatibility across two independent resolvers.

Fixes FIND-053.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- Result: 3754 passing, 0 failing; coverage 98% lines / 98% branches / 99% functions; 0 lint errors

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅