### PR TITLE
As2 3674 ats find 060 cancel batch configuration must clear facet id position or a reused batch version returns wrong facet data

### DIFF
--- a/packages/ats/contracts/contracts/infrastructure/README.md
+++ b/packages/ats/contracts/contracts/infrastructure/README.md
@@ -472,7 +472,7 @@ Typical upgrade process:
 1. **Deploy new facet versions**: New contracts with updated logic
 2. **Register with BLR**: `registerBusinessLogics([{key, newAddress}])` — advances that key's own version counter only; other keys are unaffected
 3. **Create a new configuration**: `createConfiguration()`/`createBatchConfiguration()`, explicitly selecting the new `(key, version)` pair alongside the existing versions of every other facet. A facet's version counter and a configuration's version are different things — bumping the former does not by itself change what any configuration resolves to
-4. **Point the proxy at it**: Call `proxy.updateConfigVersion(newConfigurationVersion)` to activate that configuration version
+4. **Update proxies**: Call `proxy.updateConfigVersion(newConfigurationVersion)` to activate that configuration version
 5. **New calls route to new facets**: Future calls use the new configuration
 
 ---

--- a/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
+++ b/packages/ats/contracts/contracts/infrastructure/diamond/DiamondCutManagerWrapper.sol
@@ -231,6 +231,7 @@ abstract contract DiamondCutManagerWrapper is IDiamondCutManager, Ownership, Bus
         for (uint256 index; index < facetIdsLength; ) {
             bytes32 configVersionFacetHash = _buildHash(_configurationId, batchVersion_, facetIds[index]);
             delete dcms.addr[configVersionFacetHash];
+            delete dcms.facetIdPosition[configVersionFacetHash];
             _cleanSelectors(dcms, _configurationId, batchVersion_, configVersionFacetHash);
             _cleanInterfacesIds(dcms, _configurationId, batchVersion_, configVersionFacetHash);
             unchecked {

--- a/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/resolver/diamondCutManager.test.ts
@@ -557,6 +557,32 @@ describe("DiamondCutManager", () => {
     expect(await diamondCutManager.getLatestVersionByConfiguration(testConfigId)).to.equal(0);
   });
 
+  it("FIND-060 (TDD, expected red) GIVEN a cancelled batch configuration WHEN a new batch reuses the same version and queries a facet from the cancelled batch THEN it reverts with FacetIdNotRegistered", async () => {
+    const testConfigId = "0x0000000000000000000000000000000000000000000000000000000000000060";
+
+    const cancelledBatchFacets: IDiamondCutManager.FacetConfigurationStruct[] = [
+      { id: equityFacetIdList[0], version: 1 },
+      { id: equityFacetIdList[1], version: 1 },
+      { id: equityFacetIdList[2], version: 1 },
+    ];
+
+    await diamondCutManager.connect(signer_A).createBatchConfiguration(testConfigId, cancelledBatchFacets, false, "0x");
+    await diamondCutManager.connect(signer_A).cancelBatchConfiguration(testConfigId);
+
+    const newBatchFacets: IDiamondCutManager.FacetConfigurationStruct[] = [{ id: equityFacetIdList[3], version: 1 }];
+
+    await diamondCutManager.connect(signer_A).createBatchConfiguration(testConfigId, newBatchFacets, true, "0x");
+    const newLatestVersion = Number(await diamondCutManager.getLatestVersionByConfiguration(testConfigId));
+
+    await expect(
+      diamondCutManager.getFacetVersionByConfigurationIdVersionAndFacetId(
+        testConfigId,
+        newLatestVersion,
+        equityFacetIdList[0],
+      ),
+    ).to.be.revertedWithCustomError(diamondCutManager, "FacetIdNotRegistered");
+  });
+
   it("GIVEN a resolver WHEN adding a new configuration with configId at 0 with createBatchConfiguration THEN fails with DefaultValueForConfigurationIdNotPermitted", async () => {
     const facetConfigurations: IDiamondCutManager.FacetConfigurationStruct[] = [];
     equityFacetIdList.forEach((id, index) =>


### PR DESCRIPTION
## Description

This PR closes FIND-060 from the external security audit, fixing a stale-state bug in `DiamondCutManagerWrapper::_cancelBatchConfiguration()`.

**Cancelling a batch configuration left a stale `facetIdPosition` entry behind, which a later batch reusing the same version number could collide with:**
- `_cancelBatchConfiguration()` cleared `addr`, selectors, interface ids, `facetVersions`, `facetIds` and `batchVersion` for the cancelled batch, but never deleted the corresponding `facetIdPosition` entries written by `_addFacetsToBatchConfiguration()`.
- Because cancellation never advances `latestVersion`, the next batch for the same `configurationId` reuses the exact same version number. The stale position entries from the cancelled batch then collided with the new batch under that same version, causing facet-version lookups to return the wrong facet's data or revert with an out-of-bounds panic instead of the expected `FacetIdNotRegistered`.
- Fix: delete `facetIdPosition[configVersionFacetHash]` inside the existing cleanup loop in `_cancelBatchConfiguration()`, alongside the other per-facet deletes.

Fixes FIND-060.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- Result: 3755 passing, 0 failing; coverage 98% lines / 98% branches / 99% functions; 0 lint errors

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅