### PR TITLE
fix(contracts): break same-timestamp ties in scheduled tasks by type …

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ScheduledTasksStorageWrapper.sol
@@ -161,10 +161,10 @@ library ScheduledTasksStorageWrapper {
      * @param _taskType Encoded task type identifier for the sub-queue to coordinate.
      */
     function addScheduledCrossOrderedTask(uint256 _newScheduledTimestamp, bytes32 _taskType) internal {
-        ScheduledTasksLib.addScheduledTask(
+        ScheduledTasksLib.addScheduledCrossOrderedTaskWithPriority(
             _scheduledCrossOrderedTaskStorage(),
             _newScheduledTimestamp,
-            abi.encode(_taskType)
+            _taskType
         );
     }
 

--- a/packages/ats/contracts/contracts/facets/scheduledTasksLib/ScheduledTasksLib.sol
+++ b/packages/ats/contracts/contracts/facets/scheduledTasksLib/ScheduledTasksLib.sol
@@ -5,6 +5,7 @@ import { Pagination } from "../../infrastructure/utils/Pagination.sol";
 import { ScheduledTask } from "../scheduledTasksCommon/IScheduledTasksCommon.sol";
 import { ScheduledTasksDataStorage } from "../../domain/asset/ScheduledTasksStorageWrapper.sol";
 import { SCHEDULED_TASK_POP_EMPTY } from "../../constants/values.sol";
+import { SCHEDULED_TASK_TYPE_BALANCE_ADJUSTMENT } from "../../constants/dispatchTypes.sol";
 import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 
 /// @title ScheduledTasksLib
@@ -57,14 +58,54 @@ library ScheduledTasksLib {
         }
     }
 
-    /// @notice Removes the tail entry from the queue.
-    /// @dev Reverts with `UnexpectedError(SCHEDULED_TASK_POP_EMPTY)` when the queue is empty —
-    ///      every legitimate caller checks `getScheduledTaskCount` before popping, so an empty
-    ///      queue here indicates a caller-side invariant violation rather than a valid state.
-    ///      Otherwise clears the last slot and decrements `scheduledTaskCount`. Callers must
-    ///      pop in order (typically after executing the head entry and rotating it to the tail
-    ///      upstream).
-    /// @param _scheduledTasks The storage struct whose tail entry is discarded.
+    /**
+     * @notice Inserts a new task into the shared cross-ordered queue, breaking same-timestamp
+     *         ties by task-type priority instead of insertion order.
+     * @dev Identical walk-and-insert logic to `addScheduledTask`, except that when the new
+     *      task's timestamp exactly matches an existing entry's timestamp, the tie is broken by
+     *      comparing `_crossOrderedTaskPriority` of both task types (decoded from `data`, which
+     *      for this queue is always `abi.encode(taskType)` — see
+     *      `ScheduledTasksStorageWrapper::addScheduledCrossOrderedTask`) instead of always
+     *      placing the new entry so it executes before the existing one (FIND-015: this used to
+     *      let a same-timestamp balance adjustment execute before a governance snapshot).
+     * @param _scheduledTasks Cross-ordered queue storage.
+     * @param _newScheduledTimestamp Timestamp at which the new task may be triggered.
+     * @param _newTaskType Task type being scheduled; only ever a `SCHEDULED_TASK_TYPE_*` constant.
+     */
+    function addScheduledCrossOrderedTaskWithPriority(
+        ScheduledTasksDataStorage storage _scheduledTasks,
+        uint256 _newScheduledTimestamp,
+        bytes32 _newTaskType
+    ) internal {
+        uint256 newPriority = _crossOrderedTaskPriority(_newTaskType);
+
+        for (uint256 pos = getScheduledTaskCount(_scheduledTasks); pos > 0; ) {
+            unchecked {
+                --pos;
+            }
+
+            ScheduledTask storage existingTask = _scheduledTasks.scheduledTasks[pos];
+            uint256 existingTimestamp = existingTask.scheduledTimestamp;
+
+            if (
+                existingTimestamp > _newScheduledTimestamp ||
+                (existingTimestamp == _newScheduledTimestamp &&
+                    _crossOrderedTaskPriority(abi.decode(existingTask.data, (bytes32))) >= newPriority)
+            ) {
+                _insertScheduledTask(
+                    _scheduledTasks,
+                    pos + 1,
+                    ScheduledTask(_newScheduledTimestamp, abi.encode(_newTaskType))
+                );
+                return;
+            }
+
+            _slideScheduledTasks(_scheduledTasks, pos);
+        }
+
+        _insertScheduledTask(_scheduledTasks, 0, ScheduledTask(_newScheduledTimestamp, abi.encode(_newTaskType)));
+    }
+
     function popScheduledTask(ScheduledTasksDataStorage storage _scheduledTasks) internal {
         uint256 scheduledTasksLength = getScheduledTaskCount(_scheduledTasks);
         _checkUnexpectedError(scheduledTasksLength == 0, SCHEDULED_TASK_POP_EMPTY);
@@ -148,5 +189,17 @@ library ScheduledTasksLib {
         unchecked {
             ++_scheduledTasks.scheduledTaskCount;
         }
+    }
+
+    /**
+     * @notice Priority used to break same-timestamp ties in the cross-ordered queue: lower
+     *         executes first. Balance adjustments must never execute before a same-timestamp
+     *         governance snapshot or coupon listing, since the latter would otherwise capture
+     *         post-adjustment balances instead of the balances at the intended record date.
+     * @param _taskType Task type to look up.
+     * @return priority_ Ordering priority; strictly lower values execute first on a tie.
+     */
+    function _crossOrderedTaskPriority(bytes32 _taskType) private pure returns (uint256 priority_) {
+        priority_ = _taskType == SCHEDULED_TASK_TYPE_BALANCE_ADJUSTMENT ? 1 : 0;
     }
 }

--- a/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/coupon/coupon.test.ts
@@ -852,6 +852,53 @@ export function couponTests(getCtx: () => AssetMockCtx): void {
       );
     });
 
+    it("GIVEN a coupon snapshot and a balance adjustment scheduled for the SAME record-date timestamp WHEN the cross-ordered queue is triggered THEN the coupon entitlement is unaffected (FIND-015)", async () => {
+      const TotalAmount = 1000;
+
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
+
+      await asset.connect(signer_A).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        value: TotalAmount,
+        data: "0x",
+      });
+
+      couponRecordDateInSeconds = (await getDltTimestamp()) + 10000;
+      couponExecutionDateInSeconds = (await getDltTimestamp()) + 20000;
+
+      const localCouponData = {
+        recordDate: couponRecordDateInSeconds.toString(),
+        executionDate: couponExecutionDateInSeconds.toString(),
+        rate: couponRate,
+        rateDecimals: couponRateDecimals,
+        startDate: couponStartDateInSeconds.toString(),
+        endDate: couponEndDateInSeconds.toString(),
+        fixingDate: couponFixingDateInSeconds.toString(),
+        rateStatus: couponRateStatus,
+      };
+
+      const balanceAdjustmentData = {
+        executionDate: BigInt(localCouponData.recordDate),
+        factor: 20,
+        decimals: 1,
+      };
+
+      await asset.connect(signer_A).setCoupon(localCouponData);
+      await asset.connect(signer_A).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+      await asset.changeSystemTimestamp(couponRecordDateInSeconds + 1);
+      await asset.connect(signer_A).triggerPendingScheduledCrossOrderedTasks();
+
+      const registered = (await asset.getCoupon(1)).registeredCoupon_;
+      expect(registered.snapshotId).to.be.greaterThan(0);
+
+      const couponFor = await asset.getCouponFor(1, signer_A.address);
+      expect(couponFor.recordDateReached).to.equal(true);
+      expect(couponFor.tokenBalance).to.equal(TotalAmount);
+    });
+
     it("GIVEN a coupon WHEN getCoupon is called THEN decodes coupon data", async () => {
       await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
       couponRecordDateInSeconds = (await getDltTimestamp()) + 1000;

--- a/packages/ats/contracts/test/contracts/integration/layer_1/dividend/dividend.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/dividend/dividend.test.ts
@@ -442,6 +442,52 @@ export function dividendTests(getCtx: () => AssetMockCtx): void {
       expect(dividendAmountFor.denominator).to.equal(10n ** BigInt(dividendFor.amountDecimals));
     });
 
+    it("GIVEN a dividend snapshot and a balance adjustment scheduled for the SAME record-date timestamp WHEN the cross-ordered queue is triggered THEN the snapshot executes before the balance adjustment and the dividend entitlement uses the pre-adjustment balance (FIND-015)", async () => {
+      await asset.grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_C.address);
+      await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
+
+      const TotalAmount = number_Of_Shares;
+
+      await asset.connect(signer_C).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        value: TotalAmount,
+        data: "0x",
+      });
+
+      await asset.connect(signer_C).setDividend(dividendData);
+      await asset.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+      await asset.changeSystemTimestamp((dividendsRecordDateInSeconds + 1).toString());
+
+      const tx = await asset.connect(signer_C).triggerPendingScheduledCrossOrderedTasks();
+      const receipt = await tx.wait();
+
+      const adjustmentTopic = asset.interface.getEvent("AdjustmentBalanceSet")!.topicHash;
+      const snapshotTopic = asset.interface.getEvent("SnapshotTriggered")!.topicHash;
+
+      const adjustmentIndex = receipt!.logs.findIndex((l) => l.topics[0] === adjustmentTopic);
+      const snapshotIndex = receipt!.logs.findIndex((l) => l.topics[0] === snapshotTopic);
+
+      expect(adjustmentIndex).to.not.equal(-1);
+      expect(snapshotIndex).to.not.equal(-1);
+
+      expect(snapshotIndex).to.be.lessThan(adjustmentIndex);
+
+      const dividendFor = await asset.getDividendFor(1, signer_A.address);
+      const dividendAmountFor = await asset.getDividendAmountFor(1, signer_A.address);
+
+      expect(dividendFor.tokenBalance).to.equal(TotalAmount);
+      expect(dividendFor.recordDateReached).to.equal(true);
+      expect(dividendFor.amount).to.equal(dividendsAmountPerEquity);
+      expect(dividendFor.amountDecimals).to.equal(dividendsAmountDecimalsPerEquity);
+      expect(dividendAmountFor.recordDateReached).to.equal(dividendFor.recordDateReached);
+      expect(dividendAmountFor.numerator).to.equal(
+        (dividendFor.tokenBalance * dividendFor.amount) / 10n ** BigInt(dividendFor.decimals),
+      );
+      expect(dividendAmountFor.denominator).to.equal(10n ** BigInt(dividendFor.amountDecimals));
+    });
+
     it("GIVEN frozen tokens WHEN calculating dividends without snapshot THEN frozen tokens are included in dividend calculation", async () => {
       await asset.grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
       await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);

--- a/packages/ats/contracts/test/contracts/integration/voting/voting.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/voting/voting.test.ts
@@ -250,6 +250,36 @@ export function votingTests(getCtx: () => AssetMockCtx): void {
       expect([...votingHolders]).to.have.members([signer_A.address]);
     });
 
+    it("GIVEN a voting-rights snapshot and a balance adjustment scheduled for the SAME record-date timestamp WHEN the cross-ordered queue is triggered THEN the voting entitlement is unaffected (FIND-015)", async () => {
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_C.address);
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
+
+      const TotalAmount = 100000n;
+
+      await asset.connect(signer_C).issueByPartition({
+        partition: DEFAULT_PARTITION,
+        tokenHolder: signer_A.address,
+        value: TotalAmount,
+        data: "0x",
+      });
+
+      const balanceAdjustmentData = {
+        executionDate: votingRecordDateInSeconds,
+        factor: 20,
+        decimals: 1,
+      };
+
+      await asset.connect(signer_C).setVoting(votingData);
+      await asset.connect(signer_C).setScheduledBalanceAdjustment(balanceAdjustmentData);
+
+      await asset.changeSystemTimestamp(votingRecordDateInSeconds + 1n);
+      await asset.connect(signer_C).triggerPendingScheduledCrossOrderedTasks();
+
+      const votingFor = await asset.getVotingFor(1, signer_A.address);
+      expect(votingFor.recordDateReached).to.equal(true);
+      expect(votingFor.tokenBalance).to.equal(TotalAmount);
+    });
+
     describe("Cancel Voting", () => {
       it("GIVEN an account without corporateActions role WHEN cancelVoting THEN transaction fails with AccountHasNoRole", async () => {
         await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_B.address);


### PR DESCRIPTION
## Description

This PR closes FIND-015 from the external security audit, fixing a same-timestamp ordering bug that inflated holder entitlements.

**A balance adjustment scheduled for the same record-date timestamp as a governance snapshot could execute before it, inflating every affected holder's entitlement:**
- `ScheduledTasksLib::addScheduledTask()` broke same-timestamp ties by insertion order (LIFO), so whichever task was scheduled last for a given timestamp executed first — commonly a balance adjustment scheduled after a dividend, coupon, or voting-rights snapshot for the same record date.
- The snapshot then captured the post-adjustment balance with no compensating rescale: a holder with 100,000 shares subject to a 356× balance adjustment tied to the same record date was reported with a dividend `tokenBalance` of 35,600,000.
- Fix: the shared cross-ordered queue now breaks same-timestamp ties by task-type priority instead of insertion order — a governance snapshot or coupon listing always executes before a same-timestamp balance adjustment, regardless of scheduling order. Scoped to a new `ScheduledTasksLib` function used only by the cross-ordered queue; the three single-purpose queues (snapshot, coupon listing, balance adjustment) are untouched.

Fixes FIND-015.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- Result: 98% lines / 98% branches / 99% functions coverage; 0 lint errors
- Same-timestamp tie coverage added for all three affected task types: dividend snapshot, coupon listing, and voting-rights snapshot, each verified against a same-timestamp balance adjustment

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅