### PR TITLE
fix(contracts): enforce compliance checks on transferAndLock recipients

### DIFF
--- a/packages/ats/contracts/contracts/facets/transferAndLock/TransferAndLock.sol
+++ b/packages/ats/contracts/contracts/facets/transferAndLock/TransferAndLock.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import { DEFAULT_PARTITION } from "../../constants/values.sol";
+import { DEFAULT_PARTITION, EMPTY_BYTES } from "../../constants/values.sol";
 import { ROLE_LOCKER } from "../../constants/roles.sol";
 import { ITransferAndLock } from "./ITransferAndLock.sol";
 import { IERC1410Types } from "../commonTypes/IERC1410Types.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
 import { LockStorageWrapper } from "../../domain/asset/LockStorageWrapper.sol";
+import { ERC1594StorageWrapper } from "../../domain/asset/ERC1594StorageWrapper.sol";
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
 import { DEFAULT_ADMIN_ROLE } from "../../constants/roles.sol";
@@ -51,6 +52,16 @@ abstract contract TransferAndLock is ITransferAndLock, Modifiers {
         onlyPositiveTransferAmount(_amount)
         returns (uint256 lockId_)
     {
+        {
+            ERC1594StorageWrapper.checkCanTransferFromByPartition(
+                EvmAccessors.getMsgSender(),
+                _to,
+                DEFAULT_PARTITION,
+                _amount,
+                EMPTY_BYTES,
+                EMPTY_BYTES
+            );
+        }
         TokenCoreOps.transferByPartition(
             EvmAccessors.getMsgSender(),
             IERC1410Types.BasicTransferInfo(_to, _amount),

--- a/packages/ats/contracts/contracts/facets/transferAndLockByPartition/TransferAndLockByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/transferAndLockByPartition/TransferAndLockByPartition.sol
@@ -5,13 +5,14 @@ import {
     ITransferAndLockByPartition,
     RESOLVER_KEY_TRANSFER_AND_LOCK_BY_PARTITION
 } from "./ITransferAndLockByPartition.sol";
-import { ROLE_LOCKER } from "../../constants/roles.sol";
+import { ROLE_LOCKER, DEFAULT_ADMIN_ROLE } from "../../constants/roles.sol";
+import { EMPTY_BYTES } from "../../constants/values.sol";
 import { IERC1410Types } from "../commonTypes/IERC1410Types.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
 import { LockStorageWrapper } from "../../domain/asset/LockStorageWrapper.sol";
+import { ERC1594StorageWrapper } from "../../domain/asset/ERC1594StorageWrapper.sol";
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
-import { DEFAULT_ADMIN_ROLE } from "../../constants/roles.sol";
 import { InitializerStorageWrapper } from "../../domain/core/InitializerStorageWrapper.sol";
 
 /**
@@ -58,6 +59,16 @@ abstract contract TransferAndLockByPartition is ITransferAndLockByPartition, Mod
         onlyPositiveTransferAmount(_amount)
         returns (uint256 lockId_)
     {
+        {
+            ERC1594StorageWrapper.checkCanTransferFromByPartition(
+                EvmAccessors.getMsgSender(),
+                _to,
+                _partition,
+                _amount,
+                EMPTY_BYTES,
+                EMPTY_BYTES
+            );
+        }
         TokenCoreOps.transferByPartition(
             EvmAccessors.getMsgSender(),
             IERC1410Types.BasicTransferInfo(_to, _amount),

--- a/packages/ats/contracts/test/contracts/integration/compliance/compliance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/compliance/compliance.test.ts
@@ -8,6 +8,7 @@ import type { AssetMockCtx } from "@test";
 import { executeRbac, MAX_UINT256 } from "@test";
 import {
   ATS_ROLES,
+  DEFAULT_PARTITION,
   EIP1066_CODES,
   EMPTY_HEX_BYTES,
   EMPTY_STRING,
@@ -320,6 +321,40 @@ export function complianceTests(getCtx: () => AssetMockCtx): void {
           asset,
           "IsPaused",
         );
+      });
+
+      it("GIVEN a compliance module that rejects the transfer WHEN transferAndLock or transferAndLockByPartition THEN both transactions fail with ComplianceNotAllowed (FIND-065)", async () => {
+        const amount = 1000;
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_LOCKER, signer_A.address);
+
+        await asset.connect(signer_A).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: amount * 4,
+          data: EMPTY_HEX_BYTES,
+        });
+
+        await complianceMock.setFlags(false, false);
+
+        const latestBlock = await ethers.provider.getBlock("latest");
+        const expirationTimestamp = latestBlock!.timestamp + 365 * 24 * 60 * 60;
+
+        await expect(
+          asset.connect(signer_A).transferAndLock(signer_C.address, amount, EMPTY_HEX_BYTES, expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "ComplianceNotAllowed");
+
+        await expect(
+          asset
+            .connect(signer_A)
+            .transferAndLockByPartition(
+              DEFAULT_PARTITION,
+              signer_C.address,
+              amount,
+              EMPTY_HEX_BYTES,
+              expirationTimestamp,
+            ),
+        ).to.be.revertedWithCustomError(asset, "ComplianceNotAllowed");
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/transferAndLock/transferAndLock.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/transferAndLock/transferAndLock.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect } from "chai";
+import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { IAssetMock } from "@contract-types";
+import { IAssetMock, ComplianceMock } from "@contract-types";
 import type { AssetMockCtx } from "@test";
 import { ZERO, EMPTY_STRING, ATS_ROLES, ADDRESS_ZERO, RESOLVER_KEYS } from "@scripts";
 import { getDltTimestamp, MAX_UINT256 } from "@test";
@@ -18,6 +19,7 @@ export function transferAndLockTests(getCtx: () => AssetMockCtx): void {
     let signer_B: HardhatEthersSigner;
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
+    let signer_E: HardhatEthersSigner;
     let unknownSigner: HardhatEthersSigner;
 
     let asset: IAssetMock;
@@ -63,6 +65,7 @@ export function transferAndLockTests(getCtx: () => AssetMockCtx): void {
       signer_B = ctx.user2;
       signer_C = ctx.user3;
       signer_D = ctx.user4;
+      signer_E = ctx.user1;
       unknownSigner = ctx.unknownSigner;
       asset = ctx.asset;
 
@@ -203,6 +206,61 @@ export function transferAndLockTests(getCtx: () => AssetMockCtx): void {
           asset,
           "AssetNotOperational",
         );
+      });
+    });
+
+    describe("FIND-065 - recipient compliance checks", () => {
+      it("GIVEN a recipient without KYC WHEN transferAndLock THEN transaction fails with InvalidKycStatus", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_INTERNAL_KYC_MANAGER, signer_A.address);
+        await asset.connect(signer_A).activateInternalKyc();
+
+        await asset.connect(signer_B).issueByPartition({
+          partition: _DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        await expect(
+          asset.connect(signer_C).transferAndLock(signer_D.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "InvalidKycStatus");
+      });
+
+      it("GIVEN a compliance module that rejects the transfer WHEN transferAndLock THEN transaction fails with ComplianceNotAllowed", async () => {
+        await asset.connect(signer_B).issueByPartition({
+          partition: _DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        const complianceMock: ComplianceMock = await (
+          await ethers.getContractFactory("ComplianceMock", signer_A)
+        ).deploy(false, false);
+        await complianceMock.waitForDeployment();
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_TREX_OWNER, signer_A.address);
+        await asset.connect(signer_A).setCompliance(complianceMock.target as string);
+
+        await expect(
+          asset.connect(signer_C).transferAndLock(signer_A.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "ComplianceNotAllowed");
+      });
+
+      it("GIVEN a recovered-wallet recipient WHEN transferAndLock THEN transaction fails with WalletRecovered", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
+        const strangerWallet = ethers.Wallet.createRandom().address;
+        await asset.connect(signer_A).recoveryAddress(signer_E.address, strangerWallet, ADDRESS_ZERO);
+
+        await asset.connect(signer_B).issueByPartition({
+          partition: _DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        await expect(
+          asset.connect(signer_C).transferAndLock(signer_E.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
     });
   });

--- a/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/recovery/recovery.test.ts
@@ -684,6 +684,37 @@ export function recoveryTests(getCtx: () => AssetMockCtx): void {
           ).to.be.revertedWithCustomError(asset, "WalletRecovered");
         });
 
+        it("GIVEN a recovered-wallet recipient WHEN transferAndLock or transferAndLockByPartition THEN both transactions fail with WalletRecovered (FIND-065)", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_LOCKER, signer_A.address);
+          const amount = 1000;
+          await asset.connect(signer_C).issueByPartition({
+            partition: DEFAULT_PARTITION,
+            tokenHolder: signer_A.address,
+            value: amount * 4,
+            data: EMPTY_HEX_BYTES,
+          });
+          await asset.recoveryAddress(signer_F.address, signer_E.address, ADDRESS_ZERO);
+
+          const latestBlock = await ethers.provider.getBlock("latest");
+          const expirationTimestamp = latestBlock!.timestamp + 365 * 24 * 60 * 60;
+
+          await expect(
+            asset.connect(signer_A).transferAndLock(signer_F.address, amount, EMPTY_HEX_BYTES, expirationTimestamp),
+          ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+
+          await expect(
+            asset
+              .connect(signer_A)
+              .transferAndLockByPartition(
+                DEFAULT_PARTITION,
+                signer_F.address,
+                amount,
+                EMPTY_HEX_BYTES,
+                expirationTimestamp,
+              ),
+          ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+        });
+
         describe("Recovered wallets fail centralized role checks", () => {
           it("GIVEN a recovered wallet still holding ROLE_PAUSER WHEN it calls pause (onlyRole) THEN reverts WalletRecovered", async () => {
             await asset.grantRole(ATS_ROLES.ROLE_PAUSER, signer_D.address);

--- a/packages/ats/contracts/test/contracts/integration/transferAndLockByPartition/transferAndLockByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/transferAndLockByPartition/transferAndLockByPartition.test.ts
@@ -3,7 +3,7 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
-import { IAssetMock } from "@contract-types";
+import { IAssetMock, ComplianceMock } from "@contract-types";
 import { ATS_ROLES, RESOLVER_KEYS } from "@scripts";
 import { ASSET_MOCK_CONFIG_ID } from "../../../fixtures/deploy/assetMockConfiguration";
 import { executeRbac, getDltTimestamp, grantKycToHolders, NON_DEFAULT_PARTITION, DEFAULT_PARTITION } from "@test";
@@ -17,6 +17,7 @@ export function transferAndLockByPartitionTests(getCtx: () => AssetMockCtx): voi
     let signer_B: HardhatEthersSigner;
     let signer_C: HardhatEthersSigner;
     let signer_D: HardhatEthersSigner;
+    let signer_E: HardhatEthersSigner;
 
     let asset: IAssetMock;
 
@@ -61,6 +62,7 @@ export function transferAndLockByPartitionTests(getCtx: () => AssetMockCtx): voi
       signer_B = ctx.user2;
       signer_C = ctx.user3;
       signer_D = ctx.user4;
+      signer_E = ctx.user1;
       await executeRbac(asset, set_initRbacs());
       await setFacets(asset);
       currentTimestamp = await getDltTimestamp();
@@ -253,6 +255,67 @@ export function transferAndLockByPartitionTests(getCtx: () => AssetMockCtx): voi
         await expect(asset.transferAndLockByPartition(ethers.ZeroHash, ethers.ZeroAddress, 0n, "0x", 0n))
           .to.be.revertedWithCustomError(asset, "AssetNotOperational")
           .withArgs(ASSET_MOCK_CONFIG_ID, 1);
+      });
+    });
+
+    describe("FIND-065 - recipient compliance checks", () => {
+      it("GIVEN a recipient without KYC WHEN transferAndLockByPartition THEN transaction fails with InvalidKycStatus", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_INTERNAL_KYC_MANAGER, signer_A.address);
+        await asset.connect(signer_A).activateInternalKyc();
+
+        await asset.connect(signer_B).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        await expect(
+          asset
+            .connect(signer_C)
+            .transferAndLockByPartition(DEFAULT_PARTITION, signer_D.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "InvalidKycStatus");
+      });
+
+      it("GIVEN a compliance module that rejects the transfer WHEN transferAndLockByPartition THEN transaction fails with ComplianceNotAllowed", async () => {
+        await asset.connect(signer_B).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        const complianceMock: ComplianceMock = await (
+          await ethers.getContractFactory("ComplianceMock", signer_A)
+        ).deploy(false, false);
+        await complianceMock.waitForDeployment();
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_TREX_OWNER, signer_A.address);
+        await asset.connect(signer_A).setCompliance(complianceMock.target as string);
+
+        await expect(
+          asset
+            .connect(signer_C)
+            .transferAndLockByPartition(DEFAULT_PARTITION, signer_A.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "ComplianceNotAllowed");
+      });
+
+      it("GIVEN a recovered-wallet recipient WHEN transferAndLockByPartition THEN transaction fails with WalletRecovered", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_A.address);
+        const strangerWallet = ethers.Wallet.createRandom().address;
+        await asset.connect(signer_A).recoveryAddress(signer_E.address, strangerWallet, ethers.ZeroAddress);
+
+        await asset.connect(signer_B).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_C.address,
+          value: _AMOUNT * 2,
+          data: "0x",
+        });
+
+        await expect(
+          asset
+            .connect(signer_C)
+            .transferAndLockByPartition(DEFAULT_PARTITION, signer_E.address, _AMOUNT, "0x", expirationTimestamp),
+        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
     });
   });


### PR DESCRIPTION
## Description

This PR closes FIND-065 from the external security audit: `transferAndLock` and `transferAndLockByPartition` transferred and locked tokens without validating the recipient against KYC, the compliance module, or the recovered-wallet list.

**Both entrypoints called `TokenCoreOps.transferByPartition` directly, bypassing the same recipient-compliance check every other transfer entrypoint (`transferByPartition`) already enforces:**

- `TransferAndLockByPartition.transferAndLockByPartition()` and `TransferAndLock.transferAndLock()` never called `ERC1594StorageWrapper.checkCanTransferFromByPartition()` before transferring and locking tokens, so a recipient without KYC, blocked by the active compliance module, or already recovered could still receive locked tokens.
- Fix: both entrypoints now call `ERC1594StorageWrapper.checkCanTransferFromByPartition(...)` before the transfer — the same check `transferByPartition` already performs. On `TransferAndLock.transferAndLock()`, adding it as a modifier hit the EVM's stack-too-deep limit given the existing modifier chain, so the check is inlined in its own block instead; both entrypoints now use that same form for consistency. No ABI/selector change.

Fixes FIND-065.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests: `FIND-065` describe block in `transferAndLock.test.ts` / `transferAndLockByPartition.test.ts` (KYC failure, compliance-module rejection, recovered-wallet recipient — TDD red→green), plus one extended case each in `compliance.test.ts` and `recovery.test.ts`
- Result: PASS — coverage 98% lines / 98% branches / 99% functions; 0 lint errors

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅