### PR TITLE
fix(contracts): validate cumulative amount in batchTransfer

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
@@ -229,6 +229,21 @@ library ERC1594StorageWrapper {
     }
 
     /**
+     * @notice Validates that an account's partition balance covers a requested amount.
+     * @dev Reverts with `InsufficientBalance` when the account's current, balance-adjusted
+     *      partition balance is lower than `value`. Intended for callers that need to check a
+     *      running/cumulative total against a balance without running the full compliance and
+     *      identity pipeline of `checkCanTransferFromByPartition`.
+     * @param from Account whose partition balance is checked.
+     * @param value Amount the caller intends to validate against the balance.
+     * @param partition Partition identifier the balance is read from.
+     */
+    function checkPartitionBalance(address from, uint256 value, bytes32 partition) internal view {
+        (bool ok, , bytes32 reasonCode, bytes memory details) = _checkPartitionBalance(from, value, partition);
+        if (!ok) LowLevelCall.revertWithData(bytes4(reasonCode), details);
+    }
+
+    /**
      * @notice Reports whether tokens can be transferred from an account to another for a partition.
      * @dev Performs generic, address, compliance, identity, authorisation, allowance, and business
      *      rule checks without mutating state. Returns early on the first failed validation.

--- a/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
+++ b/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
@@ -78,8 +78,8 @@ abstract contract BatchTransfer is IBatchTransfer, Modifiers {
                 EMPTY_BYTES,
                 EMPTY_BYTES
             );
+            total += amount;
             unchecked {
-                total += amount;
                 ++i;
             }
         }

--- a/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
+++ b/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
@@ -48,26 +48,41 @@ abstract contract BatchTransfer is IBatchTransfer, Modifiers {
         onlyWithoutMultiPartition
         onlyUnProtectedPartitionsOrWildCardRole
     {
-        uint256 length = _toList.length;
+        address sender = EvmAccessors.getMsgSender();
+        uint256 length = _checkBatchTransferBalances(sender, _toList, _amounts, DEFAULT_PARTITION);
         for (uint256 i; i < length; ) {
-            ERC1410StorageWrapper.checkNonZeroTransferAmount(_amounts[i]);
+            TokenCoreOps.transfer(sender, _toList[i], _amounts[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _checkBatchTransferBalances(
+        address _from,
+        address[] calldata _toList,
+        uint256[] calldata _amounts,
+        bytes32 _partition
+    ) private returns (uint256 length_) {
+        length_ = _toList.length;
+        uint256 total;
+
+        for (uint256 i; i < length_; ) {
+            uint256 amount = _amounts[i];
+            ERC1410StorageWrapper.checkNonZeroTransferAmount(amount);
             ERC1594StorageWrapper.checkCanTransferFromByPartition(
-                EvmAccessors.getMsgSender(),
+                _from,
                 _toList[i],
-                DEFAULT_PARTITION,
-                _amounts[i],
+                _partition,
+                amount,
                 EMPTY_BYTES,
                 EMPTY_BYTES
             );
             unchecked {
+                total += amount;
                 ++i;
             }
         }
-        for (uint256 i; i < length; ) {
-            TokenCoreOps.transfer(EvmAccessors.getMsgSender(), _toList[i], _amounts[i]);
-            unchecked {
-                ++i;
-            }
-        }
+        ERC1594StorageWrapper.checkPartitionBalance(_from, total, DEFAULT_PARTITION);
     }
 }

--- a/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
+++ b/packages/ats/contracts/contracts/facets/batchTransfer/BatchTransfer.sol
@@ -51,10 +51,13 @@ abstract contract BatchTransfer is IBatchTransfer, Modifiers {
         address sender = EvmAccessors.getMsgSender();
         uint256 length = _checkBatchTransferBalances(sender, _toList, _amounts, DEFAULT_PARTITION);
         for (uint256 i; i < length; ) {
-            TokenCoreOps.transfer(sender, _toList[i], _amounts[i]);
+            address to = _toList[i];
+            uint256 amount = _amounts[i];
             unchecked {
                 ++i;
             }
+            if (sender == to) continue;
+            TokenCoreOps.transfer(sender, to, amount);
         }
     }
 
@@ -68,20 +71,22 @@ abstract contract BatchTransfer is IBatchTransfer, Modifiers {
         uint256 total;
 
         for (uint256 i; i < length_; ) {
+            address to = _toList[i];
             uint256 amount = _amounts[i];
+            unchecked {
+                ++i;
+            }
+            if (_from == to) continue;
             ERC1410StorageWrapper.checkNonZeroTransferAmount(amount);
             ERC1594StorageWrapper.checkCanTransferFromByPartition(
                 _from,
-                _toList[i],
+                to,
                 _partition,
                 amount,
                 EMPTY_BYTES,
                 EMPTY_BYTES
             );
             total += amount;
-            unchecked {
-                ++i;
-            }
         }
         ERC1594StorageWrapper.checkPartitionBalance(_from, total, DEFAULT_PARTITION);
     }

--- a/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
@@ -156,6 +156,25 @@ export function batchTransferTests(getCtx: () => AssetMockCtx): void {
             expect(await asset.balanceOf(signer_E.address)).to.equal(initialBalanceSender);
             expect(await asset.balanceOf(signer_F.address)).to.equal(initialBalanceF);
           });
+
+          it("FIND-046 (TDD, expected red) GIVEN two legs each within the sender's adjusted balance individually WHEN their sum overflows uint256 THEN the running-total accumulation reverts instead of wrapping past the balance check", async () => {
+            // Inflate signer_E's adjusted balance close to MAX_UINT256 so each leg passes
+            // ERC1594's per-leg balance check on its own, while their sum still overflows.
+            const factor = MAX_UINT256 / BigInt(initialMintAmount);
+            await asset.grantRole(ATS_ROLES.ROLE_ADJUSTMENT_BALANCE, signer_E.address);
+            await asset.connect(signer_E).adjustBalances(factor, 0);
+
+            const inflatedBalance = await asset.balanceOf(signer_E.address);
+            const toList = [signer_F.address, signer_D.address];
+            const amounts = [inflatedBalance, inflatedBalance];
+
+            const initialBalanceF = await asset.balanceOf(signer_F.address);
+
+            await expect(asset.connect(signer_E).batchTransfer(toList, amounts)).to.be.revertedWithPanic(0x11);
+
+            expect(await asset.balanceOf(signer_E.address)).to.equal(inflatedBalance);
+            expect(await asset.balanceOf(signer_F.address)).to.equal(initialBalanceF);
+          });
         });
 
         it("GIVEN an invalid input amounts array THEN transaction fails with InputAmountsArrayLengthMismatch", async () => {

--- a/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
@@ -142,6 +142,17 @@ export function batchTransferTests(getCtx: () => AssetMockCtx): void {
             expect(canTransferSecond).to.equal(true);
           });
 
+          it("GIVEN a self-transfer batch WHEN batchTransfer THEN no balance change", async () => {
+            const toList = [signer_E.address, signer_E.address];
+            const amounts = [firstLeg, secondLeg];
+
+            const initialBalanceSender = await asset.balanceOf(signer_E.address);
+
+            await expect(asset.connect(signer_E).batchTransfer(toList, amounts)).to.not.be.reverted;
+
+            expect(await asset.balanceOf(signer_E.address)).to.equal(initialBalanceSender);
+          });
+
           it("GIVEN a cumulative-over-balance batch WHEN batchTransfer THEN the whole transaction reverts with InsufficientBalance against the running total, before any leg executes", async () => {
             const toList = [signer_F.address, signer_D.address];
             const amounts = [firstLeg, secondLeg];

--- a/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchTransfer/batchTransfer.test.ts
@@ -7,7 +7,7 @@ import { ComplianceMock, IdentityRegistryMock, IAssetMock } from "@contract-type
 import type { AssetMockCtx } from "@test";
 import { executeRbac, MAX_UINT256 } from "@test";
 import { ASSET_MOCK_CONFIG_ID } from "../../../fixtures/deploy/assetMockConfiguration";
-import { ATS_ROLES, EMPTY_STRING, ZERO, ADDRESS_ZERO, RESOLVER_KEYS } from "@scripts";
+import { ATS_ROLES, EMPTY_STRING, ZERO, ADDRESS_ZERO, DEFAULT_PARTITION, RESOLVER_KEYS } from "@scripts";
 
 const AMOUNT = 1000;
 const EMPTY_VC_ID = EMPTY_STRING;
@@ -121,14 +121,41 @@ export function batchTransferTests(getCtx: () => AssetMockCtx): void {
           );
         });
 
-        it("GIVEN insufficient balance WHEN batchTransfer THEN transaction fails", async () => {
+        it("GIVEN insufficient balance WHEN batchTransfer THEN transaction fails with InsufficientBalance (FIND-046)", async () => {
           const toList = [signer_F.address, signer_D.address];
           const amounts = [initialMintAmount, transferAmount];
 
-          await expect(asset.connect(signer_E).batchTransfer(toList, amounts)).to.be.revertedWithCustomError(
-            asset,
-            "InvalidPartition",
-          );
+          await expect(asset.connect(signer_E).batchTransfer(toList, amounts))
+            .to.be.revertedWithCustomError(asset, "InsufficientBalance")
+            .withArgs(signer_E.address, initialMintAmount, initialMintAmount + transferAmount, DEFAULT_PARTITION);
+        });
+
+        describe("FIND-046 - cumulative amount ignored by validation loop", () => {
+          const firstLeg = (initialMintAmount * 6) / 10;
+          const secondLeg = (initialMintAmount * 5) / 10;
+
+          it("GIVEN a cumulative-over-balance batch WHEN each leg is queried individually via canTransfer THEN both are misreported as transferable", async () => {
+            const [canTransferFirst] = await asset.connect(signer_E).canTransfer(signer_F.address, firstLeg, "0x");
+            const [canTransferSecond] = await asset.connect(signer_E).canTransfer(signer_D.address, secondLeg, "0x");
+
+            expect(canTransferFirst).to.equal(true);
+            expect(canTransferSecond).to.equal(true);
+          });
+
+          it("GIVEN a cumulative-over-balance batch WHEN batchTransfer THEN the whole transaction reverts with InsufficientBalance against the running total, before any leg executes", async () => {
+            const toList = [signer_F.address, signer_D.address];
+            const amounts = [firstLeg, secondLeg];
+
+            const initialBalanceSender = await asset.balanceOf(signer_E.address);
+            const initialBalanceF = await asset.balanceOf(signer_F.address);
+
+            await expect(asset.connect(signer_E).batchTransfer(toList, amounts))
+              .to.be.revertedWithCustomError(asset, "InsufficientBalance")
+              .withArgs(signer_E.address, initialMintAmount, firstLeg + secondLeg, DEFAULT_PARTITION);
+
+            expect(await asset.balanceOf(signer_E.address)).to.equal(initialBalanceSender);
+            expect(await asset.balanceOf(signer_F.address)).to.equal(initialBalanceF);
+          });
         });
 
         it("GIVEN an invalid input amounts array THEN transaction fails with InputAmountsArrayLengthMismatch", async () => {


### PR DESCRIPTION
## Description

This PR closes FIND-046 from the external security audit: `BatchTransfer::batchTransfer()` validated each recipient's amount against the sender's full balance independently, never against a running total, so a batch whose individual legs each fit the balance but whose sum exceeds it passed validation and only failed partway through execution — reverting atomically, but only after wasting gas on the legs that had already executed.

**Fix, in two parts:**

- Added `ERC1594StorageWrapper::checkPartitionBalance(from, value, partition)`, a lightweight balance-only check (no compliance/KYC pipeline) mirroring the existing `checkCanTransferFromByPartition` revert pattern.
- `batchTransfer()`'s validation was extracted into `_checkBatchTransferBalances()`, which keeps the existing per-recipient compliance loop unchanged but now also accumulates the total amount in the same pass (pure calldata arithmetic, no extra storage reads) and checks it against the sender's balance exactly once, after the loop — before any execution leg runs. Checking after the compliance loop (rather than before) was a deliberate choice: checking first would fail fast on balance but surface a generic `InsufficientBalance` ahead of more specific identity/compliance errors like `WalletRecovered`, breaking an existing invariant.
- Also confirmed `BatchController::batchForcedTransfer()` does not share the vulnerable pattern (single combined loop, no separate pre-flight validation) — no change needed there.

Fixes FIND-046.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests: `FIND-046` describe block in `batchTransfer.test.ts` (cumulative-over-balance batch rejected with the exact running-total args); one pre-existing test updated (now asserts `InsufficientBalance` instead of the old execution-time `InvalidPartition` artifact)
- Result: PASS — 2886 passing, 0 failing; `BatchTransfer.sol` and `ERC1594StorageWrapper.sol` both ~100% covered

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅