### PR TITLE
fix(contracts): use full lookback window for early KPI fixing dates

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/KpiLinkedRateLib.sol
+++ b/packages/ats/contracts/contracts/domain/asset/KpiLinkedRateLib.sol
@@ -114,7 +114,7 @@ library KpiLinkedRateLib {
     ) private view returns (uint256 impactData_, bool reportFound_) {
         uint256 windowStart;
         unchecked {
-            windowStart = fixingDate > reportPeriod ? fixingDate - reportPeriod : fixingDate;
+            windowStart = fixingDate > reportPeriod ? fixingDate - reportPeriod : 0;
         }
         uint256 projectCount = ProceedRecipientsStorageWrapper.getProceedRecipientsCount();
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/interestRates/kpiLinkedRate/kpiLinkedRate.test.ts
@@ -742,6 +742,74 @@ export function kpiLinkedRateTests(getCtx: () => AssetMockCtx): void {
           const [registeredCoupon] = await asset.getCoupon(1);
           expect(registeredCoupon.coupon.rate).to.equal(TEST_BOND_KPI_LINKED_RATE.maxRate);
         });
+
+        describe("FIND-021 - wrong KPI window start when fixingDate is at or before reportPeriod", () => {
+          const kpiDate = 1;
+          const impactData = 600;
+          const expectedRate = 60n;
+
+          it("GIVEN fixingDate equal to reportPeriod WHEN getCoupon THEN rate reflects the KPI impact instead of the missed-report penalty", async () => {
+            const currentTimestamp = await getDltTimestamp();
+            const fixingDate = currentTimestamp + TIME_PERIODS_S.DAY;
+
+            await kpiRate.setKpiLinkedRateInterestRate({
+              maxRate: TEST_BOND_KPI_LINKED_RATE.maxRate,
+              baseRate: TEST_BOND_KPI_LINKED_RATE.baseRate,
+              minRate: TEST_BOND_KPI_LINKED_RATE.minRate,
+              startPeriod: TEST_BOND_KPI_LINKED_RATE.startPeriod,
+              startRate: TEST_BOND_KPI_LINKED_RATE.startRate,
+              missedPenalty: TEST_BOND_KPI_LINKED_RATE.missedPenalty,
+              reportPeriod: fixingDate,
+              rateDecimals: TEST_BOND_KPI_LINKED_RATE.rateDecimals,
+            });
+            await kpis.addKpiData(kpiDate, impactData, signer_A.address);
+            await asset.connect(signer_A).setCoupon({
+              recordDate: fixingDate.toString(),
+              executionDate: (fixingDate + TIME_PERIODS_S.DAY).toString(),
+              rate: 0,
+              rateDecimals: 0,
+              startDate: currentTimestamp.toString(),
+              endDate: fixingDate.toString(),
+              fixingDate: fixingDate.toString(),
+              rateStatus: 0,
+            });
+            await asset.changeSystemTimestamp(fixingDate + 1);
+
+            const [registeredCoupon] = await asset.getCoupon(1);
+            expect(registeredCoupon.coupon.rate).to.equal(expectedRate);
+          });
+
+          it("GIVEN fixingDate lower than reportPeriod WHEN getCoupon THEN rate reflects the KPI impact instead of the missed-report penalty", async () => {
+            const currentTimestamp = await getDltTimestamp();
+            const fixingDate = currentTimestamp + TIME_PERIODS_S.DAY;
+
+            await kpiRate.setKpiLinkedRateInterestRate({
+              maxRate: TEST_BOND_KPI_LINKED_RATE.maxRate,
+              baseRate: TEST_BOND_KPI_LINKED_RATE.baseRate,
+              minRate: TEST_BOND_KPI_LINKED_RATE.minRate,
+              startPeriod: TEST_BOND_KPI_LINKED_RATE.startPeriod,
+              startRate: TEST_BOND_KPI_LINKED_RATE.startRate,
+              missedPenalty: TEST_BOND_KPI_LINKED_RATE.missedPenalty,
+              reportPeriod: fixingDate + 500,
+              rateDecimals: TEST_BOND_KPI_LINKED_RATE.rateDecimals,
+            });
+            await kpis.addKpiData(kpiDate, impactData, signer_A.address);
+            await asset.connect(signer_A).setCoupon({
+              recordDate: fixingDate.toString(),
+              executionDate: (fixingDate + TIME_PERIODS_S.DAY).toString(),
+              rate: 0,
+              rateDecimals: 0,
+              startDate: currentTimestamp.toString(),
+              endDate: fixingDate.toString(),
+              fixingDate: fixingDate.toString(),
+              rateStatus: 0,
+            });
+            await asset.changeSystemTimestamp(fixingDate + 1);
+
+            const [registeredCoupon] = await asset.getCoupon(1);
+            expect(registeredCoupon.coupon.rate).to.equal(expectedRate);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## Description

This PR closes FIND-021 from the external security audit: `KpiLinkedRateLib::_collectImpactData()` computed the KPI lookback window start incorrectly whenever a coupon's `fixingDate` was at or before the configured `reportPeriod`, making a valid, pre-existing KPI report unfindable and wrongly forcing the missed-report penalty rate.

**Root cause:** the window-start ternary set `windowStart = fixingDate` (the end of the window, not its start) in that branch, degenerating the lookup into `getLatestKpiData(fixingDate, fixingDate, project)`. Since `getLatestKpiData` implements an exclusive-lower-bound window `(from, to]`, that call can never return a match, however recent or valid the underlying report is.

**Fix:** `windowStart = 0` in that branch instead, so the lookback covers the full `[0, fixingDate]` period and any valid, pre-existing report is found. One-line change; the per-recipient aggregation loop that follows is unchanged.

Fixes FIND-021.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests: `FIND-021` describe block in `kpiLinkedRate.test.ts` (`fixingDate == reportPeriod`, `fixingDate < reportPeriod`), TDD red→green
- Result: PASS — full `kpiLinkedRate.test.ts` file green (37 passing), 0 lint errors

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅