### PR TITLE
fix(contracts): skip ABAF catch-up multiply for unlimited allowances

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -248,9 +248,7 @@ library ERC20StorageWrapper {
     function approve(address owner, address spender, uint256 value) internal returns (bool) {
         _checkUnexpectedError(owner == address(0), KPI_ERC20_APPROVE_OWNER);
 
-        if (spender == address(0)) {
-            revert IAllowanceTypes.SpenderWithZeroAddress();
-        }
+        _checkSpenderWithZeroAddress(spender);
 
         ERC1410StorageWrapper.triggerAndSyncAll(DEFAULT_PARTITION, owner, spender);
         _erc20Storage().allowed[owner][spender] = value;
@@ -260,46 +258,32 @@ library ERC20StorageWrapper {
     }
 
     /**
-     * @notice Increases the ERC-20 allowance of `spender` for `msg.sender` by
-     *         `addedValue`.
+     * @notice Increases the ERC-20 allowance of `spender` for `msg.sender` by `addedValue`.
      * @dev Reverts with `SpenderWithZeroAddress` if `spender` is the zero address.
      *      Delegates to `increaseAllowedBalance` which synchronises ABAF state and
      *      emits an `Approval` event.
      * @param spender    Address whose allowance is increased.
      * @param addedValue Amount to add to the existing allowance.
-     * @return True unconditionally on success; reverts on failure.
+     * @return success_  True unconditionally on success; reverts on failure.
      */
-    function increaseAllowance(address spender, uint256 addedValue) internal returns (bool) {
-        if (spender == address(0)) {
-            revert IAllowanceTypes.SpenderWithZeroAddress();
-        }
-
-        increaseAllowedBalance(EvmAccessors.getMsgSender(), spender, addedValue);
-
-        return true;
+    function increaseAllowance(address spender, uint256 addedValue) internal returns (bool success_) {
+        _checkSpenderWithZeroAddress(spender);
+        success_ = increaseAllowedBalance(EvmAccessors.getMsgSender(), spender, addedValue);
     }
 
     /**
-     * @notice Decreases the ERC-20 allowance of `spender` for `msg.sender` by
-     *         `subtractedValue` and emits an `Approval` event.
+     * @notice Decreases the ERC-20 allowance of `spender` for `msg.sender` by `subtractedValue`.
      * @dev Reverts with `SpenderWithZeroAddress` if `spender` is the zero address.
-     *      Synchronises ABAF state via `beforeAllowanceUpdate` before reducing the
-     *      allowance. Reverts via `decreaseAllowedBalance` if allowance is insufficient.
+     *      Synchronises ABAF state via `beforeAllowanceUpdate` before reducing the allowance.
+     *      Reverts via `decreaseAllowedBalance` if the existing allowance is insufficient.
+     *      Emits an `Approval` event upon success.
      * @param spender         Address whose allowance is decreased.
      * @param subtractedValue Amount to subtract from the existing allowance.
-     * @return True unconditionally on success; reverts on failure.
+     * @return success_       True unconditionally on success; reverts on failure.
      */
-    function decreaseAllowance(address spender, uint256 subtractedValue) internal returns (bool) {
-        if (spender == address(0)) {
-            revert IAllowanceTypes.SpenderWithZeroAddress();
-        }
-        decreaseAllowedBalance(EvmAccessors.getMsgSender(), spender, subtractedValue);
-        emit IAllowanceTypes.Approval(
-            EvmAccessors.getMsgSender(),
-            spender,
-            _erc20Storage().allowed[EvmAccessors.getMsgSender()][spender]
-        );
-        return true;
+    function decreaseAllowance(address spender, uint256 subtractedValue) internal returns (bool success_) {
+        _checkSpenderWithZeroAddress(spender);
+        success_ = decreaseAllowedBalance(EvmAccessors.getMsgSender(), spender, subtractedValue);
     }
 
     /**
@@ -382,50 +366,51 @@ library ERC20StorageWrapper {
     }
 
     /**
-     * @notice Reduces the allowance of `spender` on `from`'s balance by `value`,
-     *         reverting if the existing allowance is insufficient.
-     * @dev Calls `beforeAllowanceUpdate` first to synchronise ABAF state. An allowance of
-     *      `type(uint256).max` is a permanent unlimited-approval sentinel and is never
-     *      decremented, so it cannot be converted into a finite value with a stale LABAF
-     *      checkpoint by a spend; only `approve()` can change it.
-     *      Reverts with `InsufficientAllowance` when `value` exceeds the current
-     *      allowance.
-     * @param owner   Token owner whose allowance is consumed.
-     * @param spender Address whose spending limit is reduced.
-     * @param value   Amount to deduct from the allowance.
-     * @return If current allowance was decreased.
+     * @notice Decreases the spending allowance granted by `owner` to `spender` by `value`.
+     * @dev Synchronises ABAF state via `beforeAllowanceUpdate` before performing any adjustments.
+     *      If the existing allowance is infinite (`type(uint256).max`), the function returns
+     *      `false` without modifying state or emitting an event.
+     *      Reverts with unexpected error `KPI_ERC20_APPROVE_OWNER` if `owner` is the zero address.
+     *      Reverts with `IAllowanceTypes.InsufficientAllowance` if `value` exceeds current allowance.
+     *      Emits an `IAllowanceTypes.Approval` event upon a successful finite allowance deduction.
+     * @param owner Address of the token owner whose allowance is being deducted.
+     * @param spender Address authorised to spend tokens on behalf of `owner`.
+     * @param value Amount to deduct from the current allowance.
+     * @return True if a finite allowance was decremented, false if the allowance is infinite.
      */
     function decreaseAllowedBalance(address owner, address spender, uint256 value) internal returns (bool) {
+        _checkUnexpectedError(owner == address(0), KPI_ERC20_APPROVE_OWNER);
         beforeAllowanceUpdate(owner, spender);
         if (isInfiniteAllowance(owner, spender)) return false;
-
         ERC20Storage storage erc20Stor = _erc20Storage();
         uint256 currentAllowance = erc20Stor.allowed[owner][spender];
         if (value > currentAllowance) revert IAllowanceTypes.InsufficientAllowance(spender, owner);
-
         unchecked {
             erc20Stor.allowed[owner][spender] = currentAllowance - value;
         }
+        emit IAllowanceTypes.Approval(owner, spender, erc20Stor.allowed[owner][spender]);
         return true;
     }
 
     /**
-     * @notice Increases the allowance of `spender` on `from`'s balance by `value`
-     *         and emits an `Approval` event.
-     * @dev Calls `beforeAllowanceUpdate` first to synchronise ABAF state before
-     *      adding `value` to the stored allowance.
-     * @param from    Token owner granting the additional allowance.
-     * @param spender Address whose spending limit is increased.
-     * @param value   Amount to add to the allowance.
+     * @notice Increases the allowance granted to `spender` by `owner` by `value`.
+     * @dev Reverts with `KPI_ERC20_APPROVE_OWNER` if `owner` is the zero address.
+     *      Executes `beforeAllowanceUpdate` hook to synchronise ABAF state prior to mutation.
+     *      Returns `false` without modifying storage if `spender` already has infinite allowance.
+     *      Mutates `ERC20Storage` state and emits an `IAllowanceTypes.Approval` event upon success.
+     * @param owner Address of the token owner granting the allowance increase.
+     * @param spender Address of the spender whose allowance is increased.
+     * @param value Amount of additional tokens allowed to be spent.
+     * @return True if the allowance was increased, false if allowance is infinite.
      */
-    function increaseAllowedBalance(address from, address spender, uint256 value) internal {
-        beforeAllowanceUpdate(from, spender);
-
+    function increaseAllowedBalance(address owner, address spender, uint256 value) internal returns (bool) {
+        _checkUnexpectedError(owner == address(0), KPI_ERC20_APPROVE_OWNER);
+        beforeAllowanceUpdate(owner, spender);
+        if (isInfiniteAllowance(owner, spender)) return false;
         ERC20Storage storage erc20Stor = _erc20Storage();
-
-        erc20Stor.allowed[from][spender] += value;
-
-        emit IAllowanceTypes.Approval(from, spender, _erc20Storage().allowed[from][spender]);
+        erc20Stor.allowed[owner][spender] += value;
+        emit IAllowanceTypes.Approval(owner, spender, _erc20Storage().allowed[owner][spender]);
+        return true;
     }
 
     /**
@@ -568,6 +553,15 @@ library ERC20StorageWrapper {
      */
     function checkFiniteAllowance(address _owner, address _spender) internal view {
         if (isInfiniteAllowance(_owner, _spender)) revert IAllowance.InfiniteAllowance(_owner, _spender);
+    }
+
+    /**
+     * @notice Validates that the specified spender is not the zero address.
+     * @dev Reverts with `IAllowanceTypes.SpenderWithZeroAddress` if `spender` is `address(0)`.
+     * @param spender The address of the spender to validate.
+     */
+    function _checkSpenderWithZeroAddress(address spender) private view {
+        if (spender == address(0)) revert IAllowanceTypes.SpenderWithZeroAddress();
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -223,6 +223,7 @@ library ERC20StorageWrapper {
      * @param spender Spender whose allowance is scaled.
      */
     function updateAllowanceAndLabaf(address owner, address spender) internal {
+        if (_erc20Storage().allowed[owner][spender] == type(uint256).max) return;
         uint256 abaf = AdjustBalancesStorageWrapper.getAbaf();
         uint256 labaf = AdjustBalancesStorageWrapper.getAllowanceLabaf(owner, spender);
 
@@ -523,15 +524,22 @@ library ERC20StorageWrapper {
      * @param owner     Address that granted the allowance.
      * @param spender   Address permitted to spend on `owner`'s behalf.
      * @param timestamp Unix timestamp at which to project the allowance.
-     * @return The projected allowance amount.
+     * @return allowance_ The projected allowance amount.
      */
-    function allowanceAdjustedAt(address owner, address spender, uint256 timestamp) internal view returns (uint256) {
+    function allowanceAdjustedAt(
+        address owner,
+        address spender,
+        uint256 timestamp
+    ) internal view returns (uint256 allowance_) {
+        allowance_ = allowance(owner, spender);
         return
-            allowance(owner, spender) *
-            AdjustBalancesStorageWrapper.calculateFactor(
-                AdjustBalancesStorageWrapper.getAbafAdjustedAt(timestamp),
-                AdjustBalancesStorageWrapper.getAllowanceLabaf(owner, spender)
-            );
+            allowance_ == type(uint256).max
+                ? allowance_
+                : allowance_ *
+                    AdjustBalancesStorageWrapper.calculateFactor(
+                        AdjustBalancesStorageWrapper.getAbafAdjustedAt(timestamp),
+                        AdjustBalancesStorageWrapper.getAllowanceLabaf(owner, spender)
+                    );
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -383,7 +383,10 @@ library ERC20StorageWrapper {
     /**
      * @notice Reduces the allowance of `spender` on `from`'s balance by `value`,
      *         reverting if the existing allowance is insufficient.
-     * @dev Calls `beforeAllowanceUpdate` first to synchronise ABAF state.
+     * @dev Calls `beforeAllowanceUpdate` first to synchronise ABAF state. An allowance of
+     *      `type(uint256).max` is a permanent unlimited-approval sentinel and is never
+     *      decremented, so it cannot be converted into a finite value with a stale LABAF
+     *      checkpoint by a spend; only `approve()` can change it.
      *      Reverts with `InsufficientAllowance` when `value` exceeds the current
      *      allowance.
      * @param from    Token owner whose allowance is consumed.
@@ -394,12 +397,14 @@ library ERC20StorageWrapper {
         beforeAllowanceUpdate(from, spender);
 
         ERC20Storage storage erc20Stor = _erc20Storage();
+        uint256 currentAllowance = erc20Stor.allowed[from][spender];
 
-        if (value > erc20Stor.allowed[from][spender]) {
-            revert IAllowanceTypes.InsufficientAllowance(spender, from);
+        if (currentAllowance == type(uint256).max) return;
+        if (value > currentAllowance) revert IAllowanceTypes.InsufficientAllowance(spender, from);
+
+        unchecked {
+            erc20Stor.allowed[from][spender] = currentAllowance - value;
         }
-
-        erc20Stor.allowed[from][spender] -= value;
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -12,6 +12,7 @@ import { ScheduledTasksStorageWrapper } from "./ScheduledTasksStorageWrapper.sol
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { _checkUnexpectedError } from "../../infrastructure/utils/UnexpectedError.sol";
 import { ScheduledTasksOps } from "../orchestrator/ScheduledTasksOps.sol";
+import { IAllowance } from "../../facets/allowance/IAllowance.sol";
 
 /// @custom:hash storage Erc20
 bytes32 constant STORAGE_LOCATION_ERC20 = 0xba2beddc557de36eb4836f4ff1fd9d33a28d780fce70d36cf80b490142788200;
@@ -223,7 +224,7 @@ library ERC20StorageWrapper {
      * @param spender Spender whose allowance is scaled.
      */
     function updateAllowanceAndLabaf(address owner, address spender) internal {
-        if (_erc20Storage().allowed[owner][spender] == type(uint256).max) return;
+        if (isInfiniteAllowance(owner, spender)) return;
         uint256 abaf = AdjustBalancesStorageWrapper.getAbaf();
         uint256 labaf = AdjustBalancesStorageWrapper.getAllowanceLabaf(owner, spender);
 
@@ -389,22 +390,23 @@ library ERC20StorageWrapper {
      *      checkpoint by a spend; only `approve()` can change it.
      *      Reverts with `InsufficientAllowance` when `value` exceeds the current
      *      allowance.
-     * @param from    Token owner whose allowance is consumed.
+     * @param owner   Token owner whose allowance is consumed.
      * @param spender Address whose spending limit is reduced.
      * @param value   Amount to deduct from the allowance.
+     * @return If current allowance was decreased.
      */
-    function decreaseAllowedBalance(address from, address spender, uint256 value) internal {
-        beforeAllowanceUpdate(from, spender);
+    function decreaseAllowedBalance(address owner, address spender, uint256 value) internal returns (bool) {
+        beforeAllowanceUpdate(owner, spender);
+        if (isInfiniteAllowance(owner, spender)) return false;
 
         ERC20Storage storage erc20Stor = _erc20Storage();
-        uint256 currentAllowance = erc20Stor.allowed[from][spender];
-
-        if (currentAllowance == type(uint256).max) return;
-        if (value > currentAllowance) revert IAllowanceTypes.InsufficientAllowance(spender, from);
+        uint256 currentAllowance = erc20Stor.allowed[owner][spender];
+        if (value > currentAllowance) revert IAllowanceTypes.InsufficientAllowance(spender, owner);
 
         unchecked {
-            erc20Stor.allowed[from][spender] = currentAllowance - value;
+            erc20Stor.allowed[owner][spender] = currentAllowance - value;
         }
+        return true;
     }
 
     /**
@@ -545,6 +547,27 @@ library ERC20StorageWrapper {
                         AdjustBalancesStorageWrapper.getAbafAdjustedAt(timestamp),
                         AdjustBalancesStorageWrapper.getAllowanceLabaf(owner, spender)
                     );
+    }
+
+    /**
+     * @notice Checks whether a spender has an unlimited allowance from an owner.
+     * @dev Treats `type(uint256).max` as an infinite allowance sentinel.
+     * @param _owner Account that granted the allowance.
+     * @param _spender Account authorised to spend the owner's tokens.
+     * @return infinite_ True if the current allowance equals the maximum uint256 value.
+     */
+    function isInfiniteAllowance(address _owner, address _spender) internal view returns (bool infinite_) {
+        infinite_ = allowance(_owner, _spender) == type(uint256).max;
+    }
+
+    /**
+     * @notice Ensures that a spender does not have an infinite allowance from an owner.
+     * @dev Reverts with `InfiniteAllowance` when the allowance equals `type(uint256).max`.
+     * @param _owner Address that granted the allowance.
+     * @param _spender Address authorised to spend the owner's tokens.
+     */
+    function checkFiniteAllowance(address _owner, address _spender) internal view {
+        if (isInfiniteAllowance(_owner, _spender)) revert IAllowance.InfiniteAllowance(_owner, _spender);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -899,11 +899,10 @@ library HoldStorageWrapper {
     ) private {
         if (_thirdPartyType != ThirdPartyType.AUTHORIZED) return;
         address owner = _holdIdentifier.tokenHolder;
-        address spender = _holdStorage().holdThirdPartyByAccountPartitionAndId[_holdIdentifier.tokenHolder][
-            _holdIdentifier.partition
-        ][_holdIdentifier.holdId];
+        address spender = _holdStorage().holdThirdPartyByAccountPartitionAndId[owner][_holdIdentifier.partition][
+            _holdIdentifier.holdId
+        ];
         if (spender == address(0)) return;
-        if (ERC20StorageWrapper.isInfiniteAllowance(owner, spender)) return;
         ERC20StorageWrapper.increaseAllowedBalance(owner, spender, _amount);
     }
 

--- a/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/HoldStorageWrapper.sol
@@ -154,8 +154,8 @@ library HoldStorageWrapper {
         uint256 _holdId
     ) internal {
         address thirdPartyAddress = EvmAccessors.getMsgSender();
-        ERC20StorageWrapper.decreaseAllowedBalance(_from, thirdPartyAddress, _amount);
-        setThirdPartyForHold(thirdPartyAddress, _partition, _from, _holdId);
+        if (ERC20StorageWrapper.decreaseAllowedBalance(_from, thirdPartyAddress, _amount))
+            setThirdPartyForHold(thirdPartyAddress, _partition, _from, _holdId);
     }
 
     /**
@@ -898,13 +898,13 @@ library HoldStorageWrapper {
         uint256 _amount
     ) private {
         if (_thirdPartyType != ThirdPartyType.AUTHORIZED) return;
-        ERC20StorageWrapper.increaseAllowedBalance(
-            _holdIdentifier.tokenHolder,
-            _holdStorage().holdThirdPartyByAccountPartitionAndId[_holdIdentifier.tokenHolder][
-                _holdIdentifier.partition
-            ][_holdIdentifier.holdId],
-            _amount
-        );
+        address owner = _holdIdentifier.tokenHolder;
+        address spender = _holdStorage().holdThirdPartyByAccountPartitionAndId[_holdIdentifier.tokenHolder][
+            _holdIdentifier.partition
+        ][_holdIdentifier.holdId];
+        if (spender == address(0)) return;
+        if (ERC20StorageWrapper.isInfiniteAllowance(owner, spender)) return;
+        ERC20StorageWrapper.increaseAllowedBalance(owner, spender, _amount);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingLifecycleOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingLifecycleOps.sol
@@ -362,17 +362,15 @@ library ClearingLifecycleOps {
         uint256 _amount
     ) private {
         ThirdPartyType operatorType = ClearingStorageWrapper.getClearingThirdPartyType(_id);
-        if (operatorType != ThirdPartyType.AUTHORIZED && operatorType != ThirdPartyType.OPERATOR) return;
-        TokenCoreOps.increaseAllowedBalance(
+        if (operatorType != ThirdPartyType.AUTHORIZED) return;
+        address spender = ClearingStorageWrapper.getClearingThirdParty(
+            _id.partition,
             _id.tokenHolder,
-            ClearingStorageWrapper.getClearingThirdParty(
-                _id.partition,
-                _id.tokenHolder,
-                _id.clearingOperationType,
-                _id.clearingId
-            ),
-            _amount
+            _id.clearingOperationType,
+            _id.clearingId
         );
+        if (spender == address(0)) return;
+        TokenCoreOps.increaseAllowedBalance(_id.tokenHolder, spender, _amount);
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/ClearingOps.sol
@@ -311,8 +311,14 @@ library ClearingOps {
         uint256 _amount
     ) external {
         address spender = EvmAccessors.getMsgSender();
-        TokenCoreOps.decreaseAllowedBalance(_from, spender, _amount);
-        ClearingStorageWrapper.setClearingThirdParty(_partition, _from, _clearingOperationType, _clearingId, spender);
+        if (TokenCoreOps.decreaseAllowedBalance(_from, spender, _amount))
+            ClearingStorageWrapper.setClearingThirdParty(
+                _partition,
+                _from,
+                _clearingOperationType,
+                _clearingId,
+                spender
+            );
     }
 
     /**

--- a/packages/ats/contracts/contracts/domain/orchestrator/TokenCoreOps.sol
+++ b/packages/ats/contracts/contracts/domain/orchestrator/TokenCoreOps.sol
@@ -212,16 +212,16 @@ library TokenCoreOps {
     /// @param _owner Address whose allowed balance is being increased.
     /// @param _spender Address for whom the allowed balance is increased.
     /// @param _amount Amount by which the allowed balance is increased.
-    function increaseAllowedBalance(address _owner, address _spender, uint256 _amount) external {
-        ERC20StorageWrapper.increaseAllowedBalance(_owner, _spender, _amount);
+    function increaseAllowedBalance(address _owner, address _spender, uint256 _amount) external returns (bool) {
+        return ERC20StorageWrapper.increaseAllowedBalance(_owner, _spender, _amount);
     }
 
     /// @notice Decreases the tracked allowed balance for a spender on behalf of an owner.
     /// @param _owner Address whose allowed balance is being decreased.
     /// @param _spender Address for whom the allowed balance is decreased.
     /// @param _amount Amount by which the allowed balance is decreased.
-    function decreaseAllowedBalance(address _owner, address _spender, uint256 _amount) external {
-        ERC20StorageWrapper.decreaseAllowedBalance(_owner, _spender, _amount);
+    function decreaseAllowedBalance(address _owner, address _spender, uint256 _amount) external returns (bool) {
+        return ERC20StorageWrapper.decreaseAllowedBalance(_owner, _spender, _amount);
     }
 
     /// @notice Records the current balance of an account on a partition as a snapshot entry.

--- a/packages/ats/contracts/contracts/facets/allowance/Allowance.sol
+++ b/packages/ats/contracts/contracts/facets/allowance/Allowance.sol
@@ -86,6 +86,7 @@ abstract contract Allowance is IAllowance, Modifiers {
         onlyUnpaused
         onlyWithoutMultiPartition
         onlyCompliant(EvmAccessors.getMsgSender(), spender, false)
+        onlyFiniteAllowance(EvmAccessors.getMsgSender(), spender)
         returns (bool)
     {
         return TokenCoreOps.decreaseAllowance(spender, subtractedValue);

--- a/packages/ats/contracts/contracts/facets/allowance/IAllowance.sol
+++ b/packages/ats/contracts/contracts/facets/allowance/IAllowance.sol
@@ -20,6 +20,15 @@ interface IAllowance is IAllowanceTypes {
     event AllowanceInitialized();
 
     /**
+     * @notice Raised when an operation encounters an allowance that is effectively unlimited.
+     * @dev Indicates that the owner has granted the spender an infinite allowance, which may
+     *      require special handling to avoid unintended accounting or revocation assumptions.
+     * @param owner The account that granted the allowance.
+     * @param spender The account authorised to spend on behalf of the owner.
+     */
+    error InfiniteAllowance(address owner, address spender);
+
+    /**
      * @notice Initialises the allowance capability on the token.
      * @dev Callable once; subsequent calls revert with `FacetAlreadyRegistered`.
      *      Requires `DEFAULT_ADMIN_ROLE`. Called by the factory during deployment.

--- a/packages/ats/contracts/contracts/facets/allowance/IAllowanceTypes.sol
+++ b/packages/ats/contracts/contracts/facets/allowance/IAllowanceTypes.sol
@@ -20,13 +20,6 @@ interface IAllowanceTypes {
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
     /**
-     * @notice Reverts when an allowance operation references the zero address as the owner.
-     * @dev Defensive guard against mis-wired flows or malformed calldata reaching the
-     *      underlying storage wrappers.
-     */
-    error ZeroOwnerAddress();
-
-    /**
      * @notice Reverts when `spender` attempts to consume more allowance than `from` has
      *         granted.
      * @dev Raised by `transferFrom`-style flows and by {IAllowance.decreaseAllowance} when the

--- a/packages/ats/contracts/contracts/services/asset/AllowanceModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/AllowanceModifiers.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ERC20StorageWrapper } from "../../domain/asset/ERC20StorageWrapper.sol";
+
+/**
+ * @title Allowance Modifiers
+ * @notice Provides reusable modifiers for validating ERC20 allowance constraints.
+ * @dev Delegates allowance validation to ERC20StorageWrapper before executing guarded logic.
+ * @author Hashgraph
+ */
+abstract contract AllowanceModifiers {
+    /**
+     * @notice Restricts execution to spender allowances that are finite.
+     * @dev Reverts through ERC20StorageWrapper if the allowance is not finite.
+     * @param owner Account that grants the allowance.
+     * @param spender Account whose allowance is validated.
+     */
+    modifier onlyFiniteAllowance(address owner, address spender) {
+        ERC20StorageWrapper.checkFiniteAllowance(owner, spender);
+        _;
+    }
+}

--- a/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
@@ -18,6 +18,7 @@ import { ProceedRecipientModifiers } from "./ProceedRecipientModifiers.sol";
 import { StateModifiers } from "./StateModifiers.sol";
 import { AmortizationModifiers } from "./AmortizationModifiers.sol";
 import { LoansPortfolioModifiers } from "./LoansPortfolioModifiers.sol";
+import { AllowanceModifiers } from "./AllowanceModifiers.sol";
 
 /**
  * @title AssetModifiers
@@ -29,6 +30,7 @@ import { LoansPortfolioModifiers } from "./LoansPortfolioModifiers.sol";
  * Asset Modifiers:
  * - ActionValidationModifiers: Action validation
  * - AdjustBalancesModifiers: Adjust balances validation
+ * - AllowanceModifiers: Allowance validation
  * - ClearingModifiers: Clearing state validation
  * - CouponModifiers: Coupon date validation
  * - ComplianceModifiers: Compliance validation
@@ -49,6 +51,7 @@ abstract contract AssetModifiers is
     ActionValidationModifiers,
     AdjustBalancesModifiers,
     AmortizationModifiers,
+    AllowanceModifiers,
     ClearingModifiers,
     CouponModifiers,
     ComplianceModifiers,

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -19,6 +19,7 @@
 import { Signer } from "ethers";
 import {
   GAS_LIMIT,
+  gasLimitOverride,
   hederaGasOverrides,
   info,
   retryTransaction,
@@ -316,7 +317,7 @@ export async function deployOrchestratorLibraries(
     });
 
   // Phase 1: ScheduledTasksDispatchOps and ClearingReadOps have no library dependencies.
-  const gasOverrides = { ...hederaGasOverrides(), gasLimit: GAS_LIMIT.max };
+  const gasOverrides = { ...hederaGasOverrides(), ...gasLimitOverride(GAS_LIMIT.max) };
   const scheduledTasksDispatchOpsAddr = await deployLib("ScheduledTasksDispatchOps", () =>
     new ScheduledTasksDispatchOps__factory(signer)
       .deploy(gasOverrides)

--- a/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
@@ -358,6 +358,30 @@ export function allowanceTests(getCtx: () => AssetMockCtx): void {
 
           expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(MAX_UINT256);
         });
+
+        it("GIVEN an unlimited allowance WHEN a balance adjustment with factor > 1 applies THEN a second spend still succeeds instead of reverting with an overflow panic", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
+          const tokenAmount = 2000n;
+          await asset.connect(signer_B).issue(signer_C.address, tokenAmount, "0x");
+          await assetSignerC.approve(signer_D.address, MAX_UINT256);
+
+          const currentTimestamp = await asset.blockTimestamp();
+          const ONE_DAY = 86400n;
+          const executionDate = Number(currentTimestamp + ONE_DAY);
+          await asset.setScheduledBalanceAdjustment({
+            executionDate: executionDate.toString(),
+            factor: 2,
+            decimals: 0,
+          });
+
+          await asset.changeSystemTimestamp(executionDate + 1);
+          await asset.triggerScheduledCrossOrderedTasks(100);
+
+          await expect(assetSignerD.transferFrom(signer_C.address, signer_D.address, 1n)).to.not.be.reverted;
+          await expect(assetSignerD.transferFrom(signer_C.address, signer_D.address, 1n)).to.not.be.reverted;
+
+          expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(MAX_UINT256);
+        });
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
@@ -382,6 +382,14 @@ export function allowanceTests(getCtx: () => AssetMockCtx): void {
 
           expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(MAX_UINT256);
         });
+
+        it("GIVEN an unlimited allowance WHEN decreaseAllowance THEN reverts with InfiniteAllowance", async () => {
+          await assetSignerC.approve(signer_D.address, MAX_UINT256);
+
+          await expect(assetSignerC.decreaseAllowance(signer_D.address, 1n))
+            .to.be.revertedWithCustomError(asset, "InfiniteAllowance")
+            .withArgs(signer_C.address, signer_D.address);
+        });
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/allowance/allowance.test.ts
@@ -318,6 +318,47 @@ export function allowanceTests(getCtx: () => AssetMockCtx): void {
           ).to.be.revertedWithCustomError(asset, "InsufficientAllowance");
         });
       });
+
+      describe("FIND-066", () => {
+        it("GIVEN an unlimited allowance WHEN a balance adjustment with factor > 1 applies THEN transferFrom still succeeds instead of reverting with an overflow panic", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
+          const tokenAmount = 2000n;
+          await asset.connect(signer_B).issue(signer_C.address, tokenAmount, "0x");
+          await assetSignerC.approve(signer_D.address, MAX_UINT256);
+          const currentTimestamp = await asset.blockTimestamp();
+          const ONE_DAY = 86400n;
+          const executionDate = Number(currentTimestamp + ONE_DAY);
+          await asset.setScheduledBalanceAdjustment({
+            executionDate: executionDate.toString(),
+            factor: 2,
+            decimals: 0,
+          });
+          await asset.changeSystemTimestamp(executionDate + 1);
+          await asset.triggerScheduledCrossOrderedTasks(100);
+          await expect(assetSignerD.transferFrom(signer_C.address, signer_D.address, 1n)).to.not.be.reverted;
+        });
+
+        it("GIVEN an unlimited allowance WHEN a balance adjustment with factor > 1 applies THEN allowance() still returns the unlimited amount instead of reverting with an overflow panic", async () => {
+          await asset.grantRole(ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A.address);
+          const tokenAmount = 2000n;
+          await asset.connect(signer_B).issue(signer_C.address, tokenAmount, "0x");
+          await assetSignerC.approve(signer_D.address, MAX_UINT256);
+
+          const currentTimestamp = await asset.blockTimestamp();
+          const ONE_DAY = 86400n;
+          const executionDate = Number(currentTimestamp + ONE_DAY);
+          await asset.setScheduledBalanceAdjustment({
+            executionDate: executionDate.toString(),
+            factor: 2,
+            decimals: 0,
+          });
+
+          await asset.changeSystemTimestamp(executionDate + 1);
+          await asset.triggerScheduledCrossOrderedTasks(100);
+
+          expect(await asset.allowance(signer_C.address, signer_D.address)).to.equal(MAX_UINT256);
+        });
+      });
     });
 
     describe("Deactivated", () => {

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -1198,6 +1198,32 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
           asset.connect(signer_A).cancelClearingOperationByPartition(identifier),
         ).to.be.revertedWithCustomError(asset, "ExpirationDateReached");
       });
+
+      it("GIVEN an authorized clearing created against an unlimited allowance WHEN cancelClearingOperationByPartition THEN the allowance stays unlimited and unchanged", async () => {
+        await asset.connect(signer_A).approve(signer_B.address, MAX_UINT256);
+
+        const clearingOperationFrom = {
+          clearingOperation: {
+            partition: _DEFAULT_PARTITION,
+            expirationTimestamp: EXPIRATION_TIMESTAMP,
+            data: EMPTY_HEX_BYTES,
+          },
+          from: signer_A.address,
+          operatorData: EMPTY_HEX_BYTES,
+        };
+        await asset.connect(signer_B).clearingRedeemFromByPartition(clearingOperationFrom, _AMOUNT);
+        expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(MAX_UINT256);
+
+        const identifier = {
+          clearingOperationType: ClearingOperationType.Redeem,
+          partition: _DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          clearingId: 1,
+        };
+        await expect(asset.connect(signer_A).cancelClearingOperationByPartition(identifier)).to.not.be.reverted;
+
+        expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(MAX_UINT256);
+      });
     });
 
     // ─── bug Transfer: clearingRedeemByPartition ────────────────────────────────

--- a/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/holdByPartition/holdByPartition.test.ts
@@ -927,6 +927,60 @@ export function holdByPartitionTests(getCtx: () => AssetMockCtx): void {
             .withArgs(signer_A.address, ethers.ZeroAddress, _AMOUNT);
         });
       });
+
+      describe("FIND-066", () => {
+        it("GIVEN an unlimited allowance WHEN createHoldFromByPartition and releaseHoldByPartition THEN no third party is recorded and the allowance stays unlimited", async () => {
+          await asset.connect(signer_A).approve(signer_B.address, MAX_UINT256);
+
+          await asset
+            .connect(signer_B)
+            .createHoldFromByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES);
+
+          expect(await asset.getHoldThirdParty(holdIdentifier)).to.equal(ADDRESS_ZERO);
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(MAX_UINT256);
+
+          await expect(asset.connect(signer_B).releaseHoldByPartition(holdIdentifier, _AMOUNT)).to.not.emit(
+            asset,
+            "Approval",
+          );
+
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(MAX_UINT256);
+        });
+
+        it("GIVEN a finite allowance debited by a hold WHEN the owner re-approves an unlimited allowance before releaseHoldByPartition THEN restoration is skipped without reverting", async () => {
+          await asset.connect(signer_A).increaseAllowance(signer_B.address, _AMOUNT);
+
+          await asset
+            .connect(signer_B)
+            .createHoldFromByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES);
+
+          expect(await asset.getHoldThirdParty(holdIdentifier)).to.equal(signer_B.address);
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(ZERO);
+
+          await asset.connect(signer_A).approve(signer_B.address, MAX_UINT256);
+
+          await expect(asset.connect(signer_B).releaseHoldByPartition(holdIdentifier, _AMOUNT)).to.not.be.reverted;
+
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(MAX_UINT256);
+        });
+
+        it("GIVEN a hold created by an authorized operator WHEN releaseHoldByPartition THEN the allowance between owner and operator is untouched", async () => {
+          await asset.connect(signer_A).authorizeOperator(signer_B.address);
+
+          await asset
+            .connect(signer_B)
+            .operatorCreateHoldByPartition(_DEFAULT_PARTITION, signer_A.address, hold, EMPTY_HEX_BYTES);
+
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(ZERO);
+
+          await expect(asset.connect(signer_B).releaseHoldByPartition(holdIdentifier, _AMOUNT)).to.not.emit(
+            asset,
+            "Approval",
+          );
+
+          expect(await asset.allowance(signer_A.address, signer_B.address)).to.equal(ZERO);
+        });
+      });
     });
 
     describe("Multi-partition", () => {


### PR DESCRIPTION
## Description

This PR closes FIND-066 from the external security audit: an unlimited allowance (`approve(spender, type(uint256).max)`, the standard "infinite approval" pattern) broke every subsequent `transferFrom()`, `decreaseAllowance()`, `burnFrom()` and even the `allowance()` view for that owner/spender pair, as soon as any balance-adjustment factor greater than 1 was applied.

**Root cause:** `ERC20StorageWrapper::updateAllowanceAndLabaf()` scales the stored allowance by the ABAF catch-up factor with a checked multiply (`allowed[owner][spender] *= factor`) and treats `type(uint256).max` as an ordinary numeric value rather than the unlimited-approval sentinel it represents. Any factor greater than 1 overflows that multiply and reverts with `Panic(0x11)`. `allowanceAdjustedAt()` (the function backing the `allowance()` view) repeats the exact same unguarded multiply on the read side, so the allowance becomes unreadable too, not just unspendable.

**Fix:** both functions now skip the multiply and return the stored `type(uint256).max` allowance unscaled when that's what's stored, treating it as a permanent unlimited-approval sentinel. Considered and rejected capping approvals at `totalSupply()` instead (see the finding's Investigation Log) — balance sufficiency is already enforced independently at transfer time, so a cap adds no protection while unconditionally breaking the standard `approve(spender, MAX)` pattern used by wallets/DEXs/integrators.

Fixes FIND-066.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage) — pending final run
- New tests: `FIND-066` describe block in `allowance.test.ts` — the given reproduction (`transferFrom` no longer reverts) plus a companion case confirming `allowance()` stays readable, both TDD red→green
- Existing `"ABAF/LABAF – approve inflation (FIND-095)"` coverage re-checked for regressions (non-unlimited allowances must still scale and still enforce `InsufficientAllowance`)

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️ — pending run
- [ ] Local Tests Pass ✅ — pending run
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅ — pending run