### PR TITLE
fix(contracts): fail closed when the revocation registry reverts

### DIFF
--- a/packages/ats/contracts/contracts/domain/core/KycStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/KycStorageWrapper.sol
@@ -133,7 +133,7 @@ library KycStorageWrapper {
                     return IKyc.KycStatus.NOT_GRANTED;
                 }
             } catch {
-                // we consider that the kyc was not revoked
+                return IKyc.KycStatus.NOT_GRANTED;
             }
         }
 

--- a/packages/ats/contracts/test/contracts/integration/ssi/ssi.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/ssi/ssi.test.ts
@@ -192,12 +192,6 @@ export function ssiTests(getCtx: () => AssetMockCtx): void {
         revertingRegistry = await (await ethers.getContractFactory("RevertingRevocationRegistry")).deploy();
       });
 
-      it("GIVEN a reverting registry WHEN transfer THEN succeeds treating KYC credential as not revoked", async () => {
-        await equityAsset.setRevocationRegistryAddress(revertingRegistry.target);
-        await equityAsset.connect(signer_B).transfer(signer_C.address, AMOUNT);
-        expect(await equityAsset.balanceOf(signer_C.address)).to.equal(AMOUNT);
-      });
-
       it("GIVEN a working registry with revoked credential WHEN transfer THEN reverts with InvalidKycStatus", async () => {
         await equityAsset.setRevocationRegistryAddress(revocationList.target);
         await revocationList.revoke(VC_ID); // signer_A (the issuer) revokes the credential
@@ -211,6 +205,14 @@ export function ssiTests(getCtx: () => AssetMockCtx): void {
         await equityAsset.setRevocationRegistryAddress(revocationList.target);
         await equityAsset.connect(signer_B).transfer(signer_C.address, AMOUNT);
         expect(await equityAsset.balanceOf(signer_C.address)).to.equal(AMOUNT);
+      });
+
+      it("FIND-011 (TDD, expected red) GIVEN a reverting registry WHEN transfer THEN reverts with InvalidKycStatus instead of failing open", async () => {
+        await equityAsset.setRevocationRegistryAddress(revertingRegistry.target);
+        await expect(equityAsset.connect(signer_B).transfer(signer_C.address, AMOUNT)).to.be.revertedWithCustomError(
+          equityAsset,
+          "InvalidKycStatus",
+        );
       });
     });
 


### PR DESCRIPTION
## Description

This PR closes FIND-011 from the external security audit: `KycStorageWrapper::getKycStatusFor()` treated a reverting or unreachable SSI revocation registry as "not revoked," so a credential actually revoked on that registry was still read as `GRANTED` for as long as the registry kept failing — failing open on exactly the check meant to catch out-of-band revocations (compromised key, legal action, issuer-detected fraud).

**Root cause:** the `try IRevocationList(...).revoked(issuer, vcId) catch { ... }` around the registry call had an empty `catch` block, so any revert (paused registry, self-destructed contract, out-of-gas, malformed return data) fell through silently to `return kycFor.status` — the stored `GRANTED` value.

**Decision:** discussed internally whether fail-open was defensible given we control which registry address is configured; concluded it isn't — "no explicit revoked signal" on failure means *unknown*, not *not revoked*, and defaulting to permit under that uncertainty is exactly the fail-open anti-pattern the fail-safe-defaults principle warns against. Adopted the auditor's original recommendation as-is.

**Fix:** the `catch` block now returns `IKyc.KycStatus.NOT_GRANTED`, so an unreachable or reverting revocation registry closes the gate instead of opening it, on every KYC-gated path (`transfer`, `transferFrom`, `redeem`, clearing, etc. — anywhere `getKycStatusFor` is consulted).

Fixes FIND-011.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage) — pending final run
- New test: `ssi.test.ts` — reverting-registry scenario now asserts `transfer` reverts with `InvalidKycStatus`, TDD red→green
- Removed the pre-existing sibling test that asserted the old fail-open behaviour (now redundant with, and contradictory to, the new test)

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [ ] **Linters** - No New Warnings ⚠️ — pending run
- [ ] Local Tests Pass ✅ — pending run
- [x] Effective Tests Added ✔️
- [ ] No reduction of **Coverage** ✅ — pending run