### PR TITLE
feat: add paginated redemption entry point for multi-partition maturi…

### DIFF
--- a/packages/ats/contracts/contracts/facets/maturity/IMaturity.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/IMaturity.sol
@@ -32,6 +32,28 @@ interface IMaturity {
         uint256 indexed previousMaturityDate
     );
 
+    /**
+     * @notice Emitted once after `fullRedeemAtMaturity` has redeemed every partition held by
+     *         `tokenHolder`.
+     * @param tokenHolder Token holder whose full partition list was redeemed.
+     */
+    event FullyRedeemedAtMaturity(address indexed tokenHolder);
+
+    /**
+     * @notice Emitted once after `redeemAtMaturityByPartitionRange` has redeemed the requested
+     *         page of partitions held by `tokenHolder`.
+     * @param tokenHolder Token holder whose partitions were redeemed.
+     * @param pageIndex   Zero-based index of the page that was redeemed.
+     * @param pageLength  Number of partitions per page, as requested by the caller.
+     */
+    event RedeemedAtMaturityByPartitionRange(address indexed tokenHolder, uint256 pageIndex, uint256 pageLength);
+
+    /**
+     * @notice Thrown when a maturity date fails validation.
+     * @dev Reverts when a proposed maturity date is not strictly in the future at the time it
+     *      is set, or when a maturity-gated action is attempted before the stored maturity
+     *      date has been reached.
+     */
     error MaturityDateInvalid();
 
     /**
@@ -53,11 +75,33 @@ interface IMaturity {
      *         status, must not be recovered, and the current timestamp must be at or past the
      *         maturity date. Iterates every partition owned by `_tokenHolder` and redeems each
      *         balance in full. Reverts with an unexpected error if any partition balance is zero.
-     * @dev    Emits {RedeemedByPartition} for each redeemed partition via
-     *         `ERC1410StorageWrapper.redeemByPartition`.
+     * @dev    Emits {TransferByPartition} and {RedeemedByPartition} for each redeemed partition
+     *         via `ERC1410StorageWrapper.redeemByPartition`, then {FullyRedeemedAtMaturity} once
+     *         after every partition has been processed.
      * @param  _tokenHolder Address of the token holder whose partitions are to be redeemed.
      */
     function fullRedeemAtMaturity(address _tokenHolder) external;
+
+    /**
+     * @notice Redeems a bounded page of the token partitions held by a token holder at maturity.
+     * @dev    Caller must hold `ROLE_MATURITY_REDEEMER`. Contract must be unpaused and clearing
+     *         must be disabled. `_tokenHolder` must be on the allowed list, hold granted KYC
+     *         status, must not be recovered, and the current timestamp must be at or past the
+     *         maturity date. Iterates only the partitions in the `[_pageIndex * _pageLength,
+     *         _pageIndex * _pageLength + _pageLength)` range of `_tokenHolder`'s partition list,
+     *         clamped to the actual partition count, and redeems each balance in full. Reverts
+     *         with an unexpected error if any partition in that range has a zero balance. Exists
+     *         so a holder with more partitions than fit in one block's gas limit can still be
+     *         fully redeemed across multiple calls; `fullRedeemAtMaturity` remains available
+     *         unchanged for holders within the existing gas budget.
+     * @dev    Emits {TransferByPartition} and {RedeemedByPartition} for each redeemed partition
+     *         via `ERC1410StorageWrapper.redeemByPartition`, then
+     *         {RedeemedAtMaturityByPartitionRange} once after the page has been processed.
+     * @param  _tokenHolder Address of the token holder whose partitions are to be redeemed.
+     * @param  _pageIndex   Zero-based index of the page of partitions to redeem.
+     * @param  _pageLength  Number of partitions per page.
+     */
+    function redeemAtMaturityByPartitionRange(address _tokenHolder, uint256 _pageIndex, uint256 _pageLength) external;
 
     /**
      * @notice Updates the token maturity date to a new timestamp.

--- a/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
@@ -18,9 +18,10 @@ import { MATURITY_ZERO_BALANCE_PARTITION } from "../../constants/values.sol";
  * @title  Maturity
  * @author Asset Tokenization Studio Team
  * @notice Maturity facet for token redemption and maturity date management.
- * @dev    `fullRedeemAtMaturity` and `updateMaturityDate` manage the token maturity lifecycle,
- *         registered under `RESOLVER_KEY_MATURITY`.
- *         Events: `MaturityDateUpdated`. Errors: `MaturityDateInvalid`.
+ * @dev    `fullRedeemAtMaturity`, `redeemAtMaturityByPartitionRange` and `updateMaturityDate`
+ *         manage the token maturity lifecycle, registered under `RESOLVER_KEY_MATURITY`.
+ *         Events: `MaturityInitialized`, `MaturityDateUpdated`, `FullyRedeemedAtMaturity`,
+ *         `RedeemedAtMaturityByPartitionRange`. Errors: `MaturityDateInvalid`.
  */
 abstract contract Maturity is IMaturity, Modifiers {
     /// @inheritdoc IMaturity
@@ -56,17 +57,31 @@ abstract contract Maturity is IMaturity, Modifiers {
         onlyMaturityReached
     {
         bytes32[] memory partitions = ERC1410StorageWrapper.partitionsOf(_tokenHolder);
-        uint256 length = partitions.length;
-        address sender = EvmAccessors.getMsgSender();
-        for (uint256 i; i < length; ) {
-            bytes32 partition = partitions[i];
-            uint256 balance = ERC1410StorageWrapper.balanceOfByPartition(partition, _tokenHolder);
-            _checkUnexpectedError(balance == 0, MATURITY_ZERO_BALANCE_PARTITION);
-            _redeemByPartition(partition, _tokenHolder, sender, balance);
-            unchecked {
-                ++i;
-            }
-        }
+        _redeemPartitionsInRange(_tokenHolder, partitions, 0, partitions.length);
+        emit FullyRedeemedAtMaturity(_tokenHolder);
+    }
+
+    /// @inheritdoc IMaturity
+    function redeemAtMaturityByPartitionRange(
+        address _tokenHolder,
+        uint256 _pageIndex,
+        uint256 _pageLength
+    )
+        external
+        override
+        onlyOperational
+        onlyActivated
+        onlyUnpaused
+        onlyClearingDisabled
+        onlyRole(ROLE_MATURITY_REDEEMER)
+        validateAddressNotZero(_tokenHolder)
+        onlyUnrecoveredAddress(_tokenHolder)
+        onlyListedAllowed(_tokenHolder)
+        onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)
+        onlyMaturityReached
+    {
+        _redeemAtMaturityByPartitionRange(_tokenHolder, _pageIndex, _pageLength);
+        emit RedeemedAtMaturityByPartitionRange(_tokenHolder, _pageIndex, _pageLength);
     }
 
     /// @inheritdoc IMaturity
@@ -105,5 +120,51 @@ abstract contract Maturity is IMaturity, Modifiers {
      */
     function _redeemByPartition(bytes32 _partition, address _holder, address _sender, uint256 _amount) private {
         TokenCoreOps.redeemByPartition(_partition, _holder, _sender, _amount, "", "");
+    }
+
+    /**
+     * @notice Resolves a caller-supplied page into a partition-index range and redeems it.
+     * @dev Computes `_start = _pageIndex * _pageLength` and `_end = _start + _pageLength`,
+     *      clamped to `partitions.length`, then delegates to `_redeemPartitionsInRange`. When
+     *      `_start` falls at or beyond `partitions.length`, clamping makes `_end <= _start` and
+     *      the range redeems nothing rather than reverting.
+     * @param _tokenHolder Token holder whose partitions are being redeemed.
+     * @param _pageIndex   Zero-based index of the page of partitions to redeem.
+     * @param _pageLength  Number of partitions per page.
+     */
+    function _redeemAtMaturityByPartitionRange(address _tokenHolder, uint256 _pageIndex, uint256 _pageLength) private {
+        bytes32[] memory partitions = ERC1410StorageWrapper.partitionsOf(_tokenHolder);
+        uint256 start = _pageIndex * _pageLength;
+        uint256 end = start + _pageLength;
+        _redeemPartitionsInRange(_tokenHolder, partitions, start, end > partitions.length ? partitions.length : end);
+    }
+
+    /**
+     * @notice Redeems every partition in `[_start, _end)` of `_partitions` for `_tokenHolder`.
+     * @dev Shared by `fullRedeemAtMaturity` (full range) and `_redeemAtMaturityByPartitionRange`
+     *      (a caller-supplied page), so both entry points redeem through the same loop instead
+     *      of duplicating it. Reverts with an unexpected error if any partition in range has a
+     *      zero balance.
+     * @param _tokenHolder Token holder whose balances are being redeemed.
+     * @param _partitions  Full partition list to index into; only `[_start, _end)` is processed.
+     * @param _start       Inclusive index of the first partition to redeem.
+     * @param _end         Exclusive index one past the last partition to redeem.
+     */
+    function _redeemPartitionsInRange(
+        address _tokenHolder,
+        bytes32[] memory _partitions,
+        uint256 _start,
+        uint256 _end
+    ) private {
+        address sender = EvmAccessors.getMsgSender();
+        for (uint256 i = _start; i < _end; ) {
+            bytes32 partition = _partitions[i];
+            uint256 balance = ERC1410StorageWrapper.balanceOfByPartition(partition, _tokenHolder);
+            _checkUnexpectedError(balance == 0, MATURITY_ZERO_BALANCE_PARTITION);
+            _redeemByPartition(partition, _tokenHolder, sender, balance);
+            unchecked {
+                ++i;
+            }
+        }
     }
 }

--- a/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
@@ -7,6 +7,7 @@ import { ROLE_MATURITY_MANAGER, ROLE_MATURITY_REDEEMER } from "../../constants/r
 import { Modifiers } from "../../services/Modifiers.sol";
 import { MaturityDateStorageWrapper } from "../../domain/asset/MaturityDateStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { Pagination } from "../../infrastructure/utils/Pagination.sol";
 import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 import { TokenCoreOps } from "../../domain/orchestrator/TokenCoreOps.sol";
 import { DEFAULT_ADMIN_ROLE } from "../../constants/roles.sol";
@@ -56,8 +57,7 @@ abstract contract Maturity is IMaturity, Modifiers {
         onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)
         onlyMaturityReached
     {
-        bytes32[] memory partitions = ERC1410StorageWrapper.partitionsOf(_tokenHolder);
-        _redeemPartitionsInRange(_tokenHolder, partitions, 0, partitions.length);
+        _redeemPartitionsInRange(_tokenHolder, 0, ERC1410StorageWrapper.partitionsLength(_tokenHolder));
         emit FullyRedeemedAtMaturity(_tokenHolder);
     }
 
@@ -124,47 +124,51 @@ abstract contract Maturity is IMaturity, Modifiers {
 
     /**
      * @notice Resolves a caller-supplied page into a partition-index range and redeems it.
-     * @dev Computes `_start = _pageIndex * _pageLength` and `_end = _start + _pageLength`,
-     *      clamped to `partitions.length`, then delegates to `_redeemPartitionsInRange`. When
-     *      `_start` falls at or beyond `partitions.length`, clamping makes `_end <= _start` and
-     *      the range redeems nothing rather than reverting.
+     * @dev Delegates the page-to-range math to `Pagination`, the same helper already used for
+     *      every other paginated getter in this codebase: `getStartAndEnd` turns the page into
+     *      a `[start, end)` pair, and `getSize` clamps it against the holder's partition count —
+     *      handling a page whose start falls at or beyond that count, or whose end overruns it,
+     *      as a smaller (possibly zero) size rather than reverting or underflowing.
+     *      `ERC1410StorageWrapper.partitionsLength` is a single storage-slot read, so resolving
+     *      the page never copies the holder's full partition list into memory.
      * @param _tokenHolder Token holder whose partitions are being redeemed.
      * @param _pageIndex   Zero-based index of the page of partitions to redeem.
      * @param _pageLength  Number of partitions per page.
      */
     function _redeemAtMaturityByPartitionRange(address _tokenHolder, uint256 _pageIndex, uint256 _pageLength) private {
-        bytes32[] memory partitions = ERC1410StorageWrapper.partitionsOf(_tokenHolder);
-        uint256 start = _pageIndex * _pageLength;
-        uint256 end = start + _pageLength;
-        _redeemPartitionsInRange(_tokenHolder, partitions, start, end > partitions.length ? partitions.length : end);
+        (uint256 start, uint256 end) = Pagination.getStartAndEnd(_pageIndex, _pageLength);
+        uint256 size = Pagination.getSize(start, end, ERC1410StorageWrapper.partitionsLength(_tokenHolder));
+        _redeemPartitionsInRange(_tokenHolder, start, size);
     }
 
     /**
-     * @notice Redeems every partition in `[_start, _end)` of `_partitions` for `_tokenHolder`.
+     * @notice Redeems the `_size` partitions of `_tokenHolder` starting at index `_start`.
      * @dev Shared by `fullRedeemAtMaturity` (full range) and `_redeemAtMaturityByPartitionRange`
      *      (a caller-supplied page), so both entry points redeem through the same loop instead
-     *      of duplicating it. Reverts with an unexpected error if any partition in range has a
-     *      zero balance.
+     *      of duplicating it. Reads each partition individually via
+     *      `ERC1410StorageWrapper.partitionAt` — never the holder's full partition list — so a
+     *      page never costs more gas than its own length regardless of how many partitions the
+     *      holder has in total. Walks the range from its highest index down to `_start` rather
+     *      than snapshotting it first: redeeming a partition always drains it to zero balance,
+     *      which removes it via swap-and-pop (the holder's current last partition is moved into
+     *      the freed slot, then the array shrinks by one). That move only ever touches the slot
+     *      just emptied and the array's tail — both at or beyond the index just processed —
+     *      so it never disturbs the lower indices still left to visit. Reverts with an
+     *      unexpected error if any partition in range has a zero balance.
      * @param _tokenHolder Token holder whose balances are being redeemed.
-     * @param _partitions  Full partition list to index into; only `[_start, _end)` is processed.
-     * @param _start       Inclusive index of the first partition to redeem.
-     * @param _end         Exclusive index one past the last partition to redeem.
+     * @param _start       Index of the first partition to redeem.
+     * @param _size        Number of partitions to redeem, starting at `_start`.
      */
-    function _redeemPartitionsInRange(
-        address _tokenHolder,
-        bytes32[] memory _partitions,
-        uint256 _start,
-        uint256 _end
-    ) private {
+    function _redeemPartitionsInRange(address _tokenHolder, uint256 _start, uint256 _size) private {
         address sender = EvmAccessors.getMsgSender();
-        for (uint256 i = _start; i < _end; ) {
-            bytes32 partition = _partitions[i];
+        for (uint256 i = _size; i > 0; ) {
+            unchecked {
+                --i;
+            }
+            bytes32 partition = ERC1410StorageWrapper.partitionAt(_tokenHolder, _start + i);
             uint256 balance = ERC1410StorageWrapper.balanceOfByPartition(partition, _tokenHolder);
             _checkUnexpectedError(balance == 0, MATURITY_ZERO_BALANCE_PARTITION);
             _redeemByPartition(partition, _tokenHolder, sender, balance);
-            unchecked {
-                ++i;
-            }
         }
     }
 }

--- a/packages/ats/contracts/contracts/facets/maturity/MaturityFacet.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/MaturityFacet.sol
@@ -26,6 +26,7 @@ contract MaturityFacet is Maturity, IStaticFunctionSelectors {
             Bytes4Builder.build(
                 this.initializeMaturity.selector,
                 this.fullRedeemAtMaturity.selector,
+                this.redeemAtMaturityByPartitionRange.selector,
                 this.updateMaturityDate.selector,
                 this.getMaturityDate.selector
             );

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -428,6 +428,60 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
             .withArgs(signer_A.address, ZERO, 5);
         });
       });
+
+      describe("bounded storage read regardless of total partition count (FIND-012 follow-up)", () => {
+        beforeEach(async () => {
+          await asset.setMultiPartition(true);
+        });
+
+        it("GIVEN holders with very different total partition counts WHEN redeemAtMaturityByPartitionRange requests the same one-partition page THEN gas cost does not scale with the holder's total partition count", async () => {
+          const manyPartitionsHolder = signer_A;
+          const signers = await ethers.getSigners();
+          const fewPartitionsHolder = signers[10];
+
+          const TOTAL_MANY_PARTITIONS = 25;
+          for (let i = 0; i < TOTAL_MANY_PARTITIONS; i++) {
+            await asset.connect(signer_A).issueByPartition({
+              partition: ethers.zeroPadValue(ethers.toBeHex(i + 10), 32),
+              tokenHolder: manyPartitionsHolder.address,
+              value: amount,
+              data: "0x",
+            });
+          }
+
+          await asset
+            .connect(signer_B)
+            .grantKyc(fewPartitionsHolder.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+          await asset.connect(signer_A).issueByPartition({
+            partition: DEFAULT_PARTITION,
+            tokenHolder: fewPartitionsHolder.address,
+            value: amount,
+            data: "0x",
+          });
+          await asset.connect(signer_A).issueByPartition({
+            partition: _PARTITION_ID,
+            tokenHolder: fewPartitionsHolder.address,
+            value: amount,
+            data: "0x",
+          });
+
+          await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
+
+          const txMany = await asset
+            .connect(signer_A)
+            .redeemAtMaturityByPartitionRange(manyPartitionsHolder.address, ZERO, 1);
+          const receiptMany = await txMany.wait();
+
+          const txFew = await asset
+            .connect(signer_A)
+            .redeemAtMaturityByPartitionRange(fewPartitionsHolder.address, ZERO, 1);
+          const receiptFew = await txFew.wait();
+
+          const gasDelta = receiptMany!.gasUsed - receiptFew!.gasUsed;
+
+          expect(gasDelta < 5_000n).to.equal(true);
+        });
+      });
     });
 
     describe("updateMaturityDate", () => {

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -161,7 +161,9 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
 
         await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_A.address))
           .to.emit(asset, "RedeemedByPartition")
-          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x");
+          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+          .to.emit(asset, "FullyRedeemedAtMaturity")
+          .withArgs(signer_A.address);
       });
 
       it("GIVEN a token holder with zero balance WHEN fullRedeemAtMaturity THEN succeeds without redeeming", async () => {
@@ -220,7 +222,211 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
           .to.emit(asset, "RedeemedByPartition")
           .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
           .to.emit(asset, "RedeemedByPartition")
-          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x");
+          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+          .to.emit(asset, "FullyRedeemedAtMaturity")
+          .withArgs(signer_A.address);
+      });
+    });
+
+    describe("redeemAtMaturityByPartitionRange", () => {
+      it("GIVEN a zero address as token holder WHEN redeemAtMaturityByPartitionRange THEN reverts with ZeroAddressNotAllowed", async () => {
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(ADDRESS_ZERO, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+      });
+
+      it("GIVEN the token holder account is blocked WHEN redeemAtMaturityByPartitionRange THEN reverts with AccountIsBlocked", async () => {
+        await asset.connect(signer_D).addToControlList(signer_B.address);
+
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_B.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "AccountIsBlocked");
+      });
+
+      it("GIVEN the caller lacks ROLE_MATURITY_REDEEMER WHEN redeemAtMaturityByPartitionRange THEN reverts with AccountHasNoRole", async () => {
+        await expect(
+          asset.connect(signer_B).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "AccountHasNoRole");
+      });
+
+      it("GIVEN clearing is activated WHEN redeemAtMaturityByPartitionRange THEN reverts with ClearingIsActivated", async () => {
+        await asset.connect(signer_A).activateClearing();
+
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "ClearingIsActivated");
+      });
+
+      it("GIVEN the token is paused WHEN redeemAtMaturityByPartitionRange THEN reverts with IsPaused", async () => {
+        await grantRoleAndPauseToken(asset, ATS_ROLES.ROLE_CORPORATE_ACTION, signer_A, signer_B, signer_C.address);
+
+        await expect(
+          asset.connect(signer_C).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "IsPaused");
+      });
+
+      it("GIVEN the token holder lacks valid KYC status WHEN redeemAtMaturityByPartitionRange THEN reverts with InvalidKycStatus", async () => {
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "InvalidKycStatus");
+      });
+
+      it("GIVEN the current date is before maturity WHEN redeemAtMaturityByPartitionRange THEN reverts with MaturityDateInvalid", async () => {
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "MaturityDateInvalid");
+      });
+
+      it("GIVEN a recovered wallet WHEN redeemAtMaturityByPartitionRange THEN reverts with WalletRecovered", async () => {
+        await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+      });
+
+      it("GIVEN a non-recovered caller redeeming on behalf of a recovered token holder WHEN redeemAtMaturityByPartitionRange THEN reverts with WalletRecovered", async () => {
+        const signers = await ethers.getSigners();
+        const newWallet = signers[11];
+
+        await asset.connect(signer_A).recoveryAddress(signer_C.address, newWallet.address, ADDRESS_ZERO);
+
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
+        ).to.be.revertedWithCustomError(asset, "WalletRecovered");
+      });
+
+      it("GIVEN all conditions are met and the page covers the holder's only partition WHEN redeemAtMaturityByPartitionRange THEN emits RedeemedByPartition and RedeemedAtMaturityByPartitionRange", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
+        await asset.connect(signer_C).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
+        await asset.changeSystemTimestamp(maturityDate + 1);
+
+        await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 1))
+          .to.emit(asset, "RedeemedByPartition")
+          .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+          .to.emit(asset, "RedeemedAtMaturityByPartitionRange")
+          .withArgs(signer_A.address, ZERO, 1);
+      });
+
+      it("GIVEN a token holder with no partitions WHEN redeemAtMaturityByPartitionRange THEN succeeds without redeeming but still emits RedeemedAtMaturityByPartitionRange", async () => {
+        const signers = await ethers.getSigners();
+        const newUser = signers[10];
+
+        await asset.connect(signer_B).grantKyc(newUser.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+        await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
+
+        const tx = asset.connect(signer_A).redeemAtMaturityByPartitionRange(newUser.address, ZERO, 10);
+
+        await expect(tx).to.not.emit(asset, "RedeemedByPartition");
+        await expect(tx).to.emit(asset, "RedeemedAtMaturityByPartitionRange").withArgs(newUser.address, ZERO, 10);
+      });
+
+      it("GIVEN a page length of zero WHEN redeemAtMaturityByPartitionRange THEN succeeds without redeeming regardless of the page index", async () => {
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
+        await asset.connect(signer_C).issueByPartition({
+          partition: DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          value: amount,
+          data: "0x",
+        });
+        await asset.changeSystemTimestamp(maturityDate + 1);
+
+        const tx = asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, 3, ZERO);
+
+        await expect(tx).to.not.emit(asset, "RedeemedByPartition");
+        await expect(tx).to.emit(asset, "RedeemedAtMaturityByPartitionRange").withArgs(signer_A.address, 3, ZERO);
+
+        expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(amount);
+      });
+
+      describe("multi-partition pagination", () => {
+        beforeEach(async () => {
+          await asset.setMultiPartition(true);
+          await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_ISSUER, signer_C.address);
+          await asset.connect(signer_C).issueByPartition({
+            partition: _PARTITION_ID,
+            tokenHolder: signer_A.address,
+            value: amount,
+            data: "0x",
+          });
+          await asset.connect(signer_C).issueByPartition({
+            partition: DEFAULT_PARTITION,
+            tokenHolder: signer_A.address,
+            value: amount,
+            data: "0x",
+          });
+          await asset.changeSystemTimestamp(maturityDate + 1);
+        });
+
+        it("GIVEN a single page covering both partitions WHEN redeemAtMaturityByPartitionRange THEN emits RedeemedByPartition for each partition and the completion event with the exact caller-supplied arguments", async () => {
+          await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 2))
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedAtMaturityByPartitionRange")
+            .withArgs(signer_A.address, ZERO, 2);
+        });
+
+        it("GIVEN page 0 with a page length smaller than the partition count WHEN redeemAtMaturityByPartitionRange THEN only the partitions in that page are redeemed", async () => {
+          await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 1))
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedAtMaturityByPartitionRange")
+            .withArgs(signer_A.address, ZERO, 1);
+
+          expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(amount);
+        });
+
+        it("GIVEN page 1 is requested directly WHEN redeemAtMaturityByPartitionRange THEN the second partition is redeemed without needing page 0 first", async () => {
+          await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, 1, 1))
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedAtMaturityByPartitionRange")
+            .withArgs(signer_A.address, 1, 1);
+
+          expect(await asset.balanceOfByPartition(_PARTITION_ID, signer_A.address)).to.equal(amount);
+        });
+
+        it("GIVEN a holder whose redeemed partitions are removed from the list via swap-and-pop, shifting the remaining partition down to index 0 WHEN redeemAtMaturityByPartitionRange is called twice for page 0 THEN both partitions end up fully redeemed", async () => {
+          await asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 1);
+          await asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 1);
+
+          expect(await asset.balanceOfByPartition(_PARTITION_ID, signer_A.address)).to.equal(ZERO);
+          expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(ZERO);
+        });
+
+        it("GIVEN a page whose start lands exactly on the partition count WHEN redeemAtMaturityByPartitionRange THEN succeeds without redeeming or reverting", async () => {
+          const tx = asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, 2, 1);
+
+          await expect(tx).to.not.emit(asset, "RedeemedByPartition");
+          await expect(tx).to.emit(asset, "RedeemedAtMaturityByPartitionRange").withArgs(signer_A.address, 2, 1);
+
+          expect(await asset.balanceOfByPartition(_PARTITION_ID, signer_A.address)).to.equal(amount);
+          expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_A.address)).to.equal(amount);
+        });
+
+        it("GIVEN a page whose start is well beyond the partition count WHEN redeemAtMaturityByPartitionRange THEN succeeds without redeeming or reverting", async () => {
+          const tx = asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, 5, 3);
+
+          await expect(tx).to.not.emit(asset, "RedeemedByPartition");
+          await expect(tx).to.emit(asset, "RedeemedAtMaturityByPartitionRange").withArgs(signer_A.address, 5, 3);
+        });
+
+        it("GIVEN a page length larger than the remaining partitions WHEN redeemAtMaturityByPartitionRange THEN the range is clamped and only the remaining partitions are redeemed", async () => {
+          await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 5))
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(_PARTITION_ID, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedByPartition")
+            .withArgs(DEFAULT_PARTITION, signer_A.address, signer_A.address, amount, "0x", "0x")
+            .to.emit(asset, "RedeemedAtMaturityByPartitionRange")
+            .withArgs(signer_A.address, ZERO, 5);
+        });
       });
     });
 
@@ -312,6 +518,12 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
       it("GIVEN a deactivated asset WHEN updateMaturityDate THEN transaction fails with Deactivated", async () => {
         await expect(asset.connect(signer_A).updateMaturityDate(0)).to.be.revertedWithCustomError(asset, "Deactivated");
       });
+
+      it("GIVEN a deactivated asset WHEN redeemAtMaturityByPartitionRange THEN transaction fails with Deactivated", async () => {
+        await expect(
+          asset.connect(signer_A).redeemAtMaturityByPartitionRange(ethers.ZeroAddress, 0, 0),
+        ).to.be.revertedWithCustomError(asset, "Deactivated");
+      });
     });
 
     describe("initializeMaturity", () => {
@@ -359,6 +571,13 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
 
       it("GIVEN non-operational asset WHEN updateMaturityDate THEN reverts with AssetNotOperational", async () => {
         await expect(asset.updateMaturityDate(0)).to.be.revertedWithCustomError(asset, "AssetNotOperational");
+      });
+
+      it("GIVEN non-operational asset WHEN redeemAtMaturityByPartitionRange THEN reverts with AssetNotOperational", async () => {
+        await expect(asset.redeemAtMaturityByPartitionRange(ADDRESS_ZERO, 0, 0)).to.be.revertedWithCustomError(
+          asset,
+          "AssetNotOperational",
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

This PR closes FIND-012 from the external security audit: `Maturity::fullRedeemAtMaturity()` reads a holder's full partition list and redeems every partition in one unbounded loop, so a holder with enough partitions makes the call exceed the block gas limit — the transaction can never succeed, and there was no paginated alternative.

**Fix:**

- Added `redeemAtMaturityByPartitionRange(address _tokenHolder, uint256 _pageIndex, uint256 _pageLength)` to `Maturity.sol`/`IMaturity.sol`, gated by the same modifiers as `fullRedeemAtMaturity` (`ROLE_MATURITY_REDEEMER`, unpaused, clearing disabled, KYC granted, not recovered, maturity reached).
- Redeems the `[pageIndex * pageLength, pageIndex * pageLength + pageLength)` slice of the holder's partitions, clamped to the actual partition count.
- Extracted the shared per-partition redemption loop into a private helper (`_redeemPartitionsInRange`), reused by both `fullRedeemAtMaturity` and the new function — no duplicated logic.
- Two new completion events, each mirroring its own function's inputs: `FullyRedeemedAtMaturity(tokenHolder)` and `RedeemedAtMaturityByPartitionRange(tokenHolder, pageIndex, pageLength)`.
- New selector registered in `MaturityFacet.sol`.
- Zero-balance-partition behaviour is unchanged and consistent across both entry points (reverts — see ticket for the design rationale).
- `fullRedeemAtMaturity()` is unchanged in behaviour for holders within the existing gas budget — no regression, no breaking change.

Fixes FIND-012.

## Type of change

- [ ] Bug fix 🐞
- [x] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests: `redeemAtMaturityByPartitionRange` describe block in `maturity.test.ts` covering every modifier-gate revert path mirrored from `fullRedeemAtMaturity`, plus pagination-specific edge cases — single-page happy path, page 1 requested directly (regression test for a `Pagination.getSize` misuse caught during implementation, before it reached review), draining a holder across sequential page-0 calls, page boundary exactly at the partition count, page beyond the partition count, zero page length, and a page length exceeding the remaining partitions (clamped range). `FullyRedeemedAtMaturity` event assertions added to the existing `fullRedeemAtMaturity` happy-path tests.
- Result: PASS. `Maturity.sol` 100% lines/branches/functions; `MaturityFacet.sol` 100% lines/functions.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅