### PR TITLE
fix: guard revokeRole and applyRoles against removing the sole admin

### DIFF
--- a/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/AccessControlStorageWrapper.sol
@@ -64,10 +64,7 @@ library AccessControlStorageWrapper {
      * @return success_ True when both directions of the index were updated.
      */
     function grantRole(bytes32 _role, address _account) internal returns (bool success_) {
-        RoleDataStorage storage roleDataStorage = _rolesStorage();
-        success_ =
-            roleDataStorage.roles[_role].roleMembers.add(_account) &&
-            roleDataStorage.memberRoles[_account].add(_role);
+        success_ = _grantRole(_rolesStorage(), _role, _account);
     }
 
     /**
@@ -80,10 +77,7 @@ library AccessControlStorageWrapper {
      * @return success_ True when both directions of the index were updated.
      */
     function revokeRole(bytes32 _role, address _account) internal returns (bool success_) {
-        RoleDataStorage storage roleDataStorage = _rolesStorage();
-        success_ =
-            roleDataStorage.roles[_role].roleMembers.remove(_account) &&
-            roleDataStorage.memberRoles[_account].remove(_role);
+        success_ = _revokeRole(_rolesStorage(), _role, _account);
     }
 
     /**
@@ -131,12 +125,10 @@ library AccessControlStorageWrapper {
             }
 
             if (active) {
-                roleDataStorage.roles[role].roleMembers.add(_account);
-                roleDataStorage.memberRoles[_account].add(role);
+                _grantRole(roleDataStorage, role, _account);
                 continue;
             }
-            roleDataStorage.roles[role].roleMembers.remove(_account);
-            roleDataStorage.memberRoles[_account].remove(role);
+            _revokeRole(roleDataStorage, role, _account);
         }
 
         // Shrink the dynamic-array length slot in memory to `count` —
@@ -296,6 +288,46 @@ library AccessControlStorageWrapper {
      */
     function checkConsistentRoles(bytes32[] calldata _roles, bool[] calldata _actives) internal pure {
         ArrayValidation.checkUniqueValues(_roles, _actives);
+    }
+
+    /**
+     * @notice Grants a role to an account within the role data storage.
+     * @dev Mutates both role-to-member and member-to-role indexes atomically at expression
+     *      level. Returns false if either association already exists or cannot be added.
+     * @param _roleDataStorage Storage reference containing role membership indexes.
+     * @param _role Role identifier to grant.
+     * @param _account Account receiving the role.
+     * @return success_ True if both membership indexes are updated successfully.
+     */
+    function _grantRole(
+        RoleDataStorage storage _roleDataStorage,
+        bytes32 _role,
+        address _account
+    ) private returns (bool success_) {
+        success_ =
+            _roleDataStorage.roles[_role].roleMembers.add(_account) &&
+            _roleDataStorage.memberRoles[_account].add(_role);
+    }
+
+    /**
+     * @notice Revokes a role from an account when doing so preserves admin availability.
+     * @dev Reverts if the role is the sole admin role according to `checkNotSoleAdmin`.
+     *      Mutates both role-to-member and member-to-role indexes only when both removals
+     *      succeed.
+     * @param roleDataStorage Storage pointer containing role membership and reverse indexes.
+     * @param _role Role identifier to revoke from the account.
+     * @param _account Account from which the role is revoked.
+     * @return success_ True when the account is removed from both role indexes.
+     */
+    function _revokeRole(
+        RoleDataStorage storage roleDataStorage,
+        bytes32 _role,
+        address _account
+    ) private returns (bool success_) {
+        checkNotSoleAdmin(_role);
+        success_ =
+            roleDataStorage.roles[_role].roleMembers.remove(_account) &&
+            roleDataStorage.memberRoles[_account].remove(_role);
     }
 
     /**

--- a/packages/ats/contracts/contracts/facets/accessControl/AccessControlBase.sol
+++ b/packages/ats/contracts/contracts/facets/accessControl/AccessControlBase.sol
@@ -78,7 +78,6 @@ abstract contract AccessControlBase is AccessControlRead {
      */
     function _renounceRole(bytes32 _role) internal returns (bool success_) {
         address account = EvmAccessors.getMsgSender();
-        AccessControlStorageWrapper.checkNotSoleAdmin(_role);
         success_ = AccessControlStorageWrapper.revokeRole(_role, account);
         if (!success_) {
             revert AccountNotAssignedToRole(_role, account);

--- a/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/accessControl/accessControl.test.ts
@@ -378,6 +378,38 @@ export function accessControlTests(getCtx: () => AssetMockCtx): void {
       expect(await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE)).to.equal(1);
     });
 
+    it("FIND-003 (TDD, expected red) GIVEN the sole DEFAULT_ADMIN_ROLE holder WHEN revokeRole targets itself THEN transaction fails with CannotRenounceSoleAdmin instead of bricking the token", async () => {
+      const memberCount = await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE);
+      expect(memberCount).to.equal(1);
+
+      await expect(
+        asset.connect(deployer).revokeRole(ATS_ROLES.DEFAULT_ADMIN_ROLE, deployer.address),
+      ).to.be.revertedWithCustomError(asset, "CannotRenounceSoleAdmin");
+    });
+
+    it("FIND-003 (TDD, expected red) GIVEN the sole DEFAULT_ADMIN_ROLE holder WHEN applyRoles revokes it THEN transaction fails with CannotRenounceSoleAdmin instead of bricking the token", async () => {
+      const memberCount = await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE);
+      expect(memberCount).to.equal(1);
+
+      await expect(
+        asset.connect(deployer).applyRoles([ATS_ROLES.DEFAULT_ADMIN_ROLE], [false], deployer.address),
+      ).to.be.revertedWithCustomError(asset, "CannotRenounceSoleAdmin");
+    });
+
+    it("FIND-003 GIVEN the sole DEFAULT_ADMIN_ROLE holder WHEN applyRoles bundles an unrelated role grant ahead of the sole-admin revocation in the same batch THEN the whole call reverts atomically with CannotRenounceSoleAdmin and the unrelated grant is not applied", async () => {
+      expect(await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE)).to.equal(1);
+      expect(await asset.hasRole(ATS_ROLES.ROLE_PAUSER, deployer.address)).to.equal(false);
+
+      await expect(
+        asset
+          .connect(deployer)
+          .applyRoles([ATS_ROLES.ROLE_PAUSER, ATS_ROLES.DEFAULT_ADMIN_ROLE], [true, false], deployer.address),
+      ).to.be.revertedWithCustomError(asset, "CannotRenounceSoleAdmin");
+
+      expect(await asset.hasRole(ATS_ROLES.ROLE_PAUSER, deployer.address)).to.equal(false);
+      expect(await asset.getRoleMemberCount(ATS_ROLES.DEFAULT_ADMIN_ROLE)).to.equal(1);
+    });
+
     describe("initializeAccessControl", () => {
       it("GIVEN a caller without DEFAULT_ADMIN_ROLE WHEN initializeAccessControl is called THEN it reverts with AccountHasNoRole", async () => {
         await expect(asset.connect(unknownSigner).initializeAccessControl())


### PR DESCRIPTION
## Description

This PR closes FIND-003 from the external security audit: the sole `DEFAULT_ADMIN_ROLE` holder could remove their own admin role via `revokeRole()` or `applyRoles()`, permanently bricking the proxy at the access-control layer — every admin-gated operation becomes unreachable with no recovery path. The existing `checkNotSoleAdmin()` guard was only wired into `renounceRole()`.

**Fix:**

- Extracted `grantRole`/`revokeRole`'s membership-index writes into private `_grantRole`/`_revokeRole` helpers in `AccessControlStorageWrapper.sol`, shared by the public functions **and** `applyRoles()`'s per-role loop (which previously reimplemented the same writes inline).
- Moved `checkNotSoleAdmin(_role)` inside `_revokeRole()` itself — now every revocation path (`revokeRole`, `renounceRole` via `revokeRole`, and `applyRoles`) enforces the "at least one admin" invariant from one place, instead of relying on each call site remembering to check it separately.
- Removed the now-redundant explicit `checkNotSoleAdmin` call in `AccessControlBase._renounceRole()`.

Fixes FIND-003. Does **not** include FIND-039 (`recoveryAddress()` rejecting a role-bearing lost wallet) — related finding, same failure class, different entry point, tracked separately per the ticket's own coordination note.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests in `accessControl.test.ts`: direct `revokeRole` self-targeting by the sole admin, single-role `applyRoles` revocation, and a mixed-batch `applyRoles` case (an unrelated role grant ordered before the sole-admin revocation) proving the revert is atomic — none of the batch is applied.
- Result: PASS.

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅