### PR TITLE
fix(maturity): allow mandatory maturity redemption regardless of holder KYC or control-list status

### DIFF
--- a/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
+++ b/packages/ats/contracts/contracts/facets/maturity/Maturity.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 import { IMaturity, RESOLVER_KEY_MATURITY } from "./IMaturity.sol";
-import { IKyc } from "../kyc/IKyc.sol";
 import { ROLE_MATURITY_MANAGER, ROLE_MATURITY_REDEEMER } from "../../constants/roles.sol";
 import { Modifiers } from "../../services/Modifiers.sol";
 import { MaturityDateStorageWrapper } from "../../domain/asset/MaturityDateStorageWrapper.sol";
@@ -41,6 +40,9 @@ abstract contract Maturity is IMaturity, Modifiers {
     }
 
     /// @inheritdoc IMaturity
+    /// @dev Intentionally does not enforce onlyListedAllowed or onlyValidKycStatus on
+    ///      _tokenHolder: this is an issuer-driven mandatory settlement, and the holder's
+    ///      own compliance status must not be able to block redemption of what they are owed.
     function fullRedeemAtMaturity(
         address _tokenHolder
     )
@@ -53,8 +55,6 @@ abstract contract Maturity is IMaturity, Modifiers {
         onlyRole(ROLE_MATURITY_REDEEMER)
         validateAddressNotZero(_tokenHolder)
         onlyUnrecoveredAddress(_tokenHolder)
-        onlyListedAllowed(_tokenHolder)
-        onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)
         onlyMaturityReached
     {
         _redeemPartitionsInRange(_tokenHolder, 0, ERC1410StorageWrapper.partitionsLength(_tokenHolder));
@@ -62,6 +62,9 @@ abstract contract Maturity is IMaturity, Modifiers {
     }
 
     /// @inheritdoc IMaturity
+    /// @dev Intentionally does not enforce onlyListedAllowed or onlyValidKycStatus on
+    ///      _tokenHolder: this is an issuer-driven mandatory settlement, and the holder's
+    ///      own compliance status must not be able to block redemption of what they are owed.
     function redeemAtMaturityByPartitionRange(
         address _tokenHolder,
         uint256 _pageIndex,
@@ -76,8 +79,6 @@ abstract contract Maturity is IMaturity, Modifiers {
         onlyRole(ROLE_MATURITY_REDEEMER)
         validateAddressNotZero(_tokenHolder)
         onlyUnrecoveredAddress(_tokenHolder)
-        onlyListedAllowed(_tokenHolder)
-        onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)
         onlyMaturityReached
     {
         _redeemAtMaturityByPartitionRange(_tokenHolder, _pageIndex, _pageLength);

--- a/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/maturity/maturity.test.ts
@@ -78,13 +78,12 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
         );
       });
 
-      it("GIVEN the token holder account is blocked WHEN fullRedeemAtMaturity THEN reverts with AccountIsBlocked", async () => {
-        await asset.connect(signer_D).addToControlList(signer_B.address);
+      it("GIVEN the token holder account is blocked WHEN fullRedeemAtMaturity THEN it succeeds instead of reverting with AccountIsBlocked", async () => {
+        await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+        await asset.connect(signer_D).addToControlList(signer_C.address);
+        await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
 
-        await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_B.address)).to.be.revertedWithCustomError(
-          asset,
-          "AccountIsBlocked",
-        );
+        await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_C.address)).to.not.be.reverted;
       });
 
       it("GIVEN the caller lacks ROLE_MATURITY_REDEEMER WHEN fullRedeemAtMaturity THEN reverts with AccountHasNoRole", async () => {
@@ -112,11 +111,10 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
         );
       });
 
-      it("GIVEN the token holder lacks valid KYC status WHEN fullRedeemAtMaturity THEN reverts with InvalidKycStatus", async () => {
-        await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_C.address)).to.be.revertedWithCustomError(
-          asset,
-          "InvalidKycStatus",
-        );
+      it("GIVEN the token holder lacks valid KYC status WHEN fullRedeemAtMaturity THEN it succeeds instead of reverting with InvalidKycStatus", async () => {
+        await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
+
+        await expect(asset.connect(signer_A).fullRedeemAtMaturity(signer_C.address)).to.not.be.reverted;
       });
 
       it("GIVEN the current date is before maturity WHEN fullRedeemAtMaturity THEN reverts with MaturityDateInvalid", async () => {
@@ -238,12 +236,13 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
         ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
       });
 
-      it("GIVEN the token holder account is blocked WHEN redeemAtMaturityByPartitionRange THEN reverts with AccountIsBlocked", async () => {
-        await asset.connect(signer_D).addToControlList(signer_B.address);
+      it("GIVEN the token holder account is blocked WHEN redeemAtMaturityByPartitionRange THEN it succeeds instead of reverting with AccountIsBlocked", async () => {
+        await asset.connect(signer_B).grantKyc(signer_C.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+        await asset.connect(signer_D).addToControlList(signer_C.address);
+        await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
 
-        await expect(
-          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_B.address, ZERO, 10),
-        ).to.be.revertedWithCustomError(asset, "AccountIsBlocked");
+        await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10)).to.not.be
+          .reverted;
       });
 
       it("GIVEN the caller lacks ROLE_MATURITY_REDEEMER WHEN redeemAtMaturityByPartitionRange THEN reverts with AccountHasNoRole", async () => {
@@ -268,10 +267,11 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
         ).to.be.revertedWithCustomError(asset, "IsPaused");
       });
 
-      it("GIVEN the token holder lacks valid KYC status WHEN redeemAtMaturityByPartitionRange THEN reverts with InvalidKycStatus", async () => {
-        await expect(
-          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10),
-        ).to.be.revertedWithCustomError(asset, "InvalidKycStatus");
+      it("GIVEN the token holder lacks valid KYC status WHEN redeemAtMaturityByPartitionRange THEN it succeeds instead of reverting with InvalidKycStatus", async () => {
+        await asset.changeSystemTimestamp(maturityDate + TIME_PERIODS_S.DAY);
+
+        await expect(asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_C.address, ZERO, 10)).to.not.be
+          .reverted;
       });
 
       it("GIVEN the current date is before maturity WHEN redeemAtMaturityByPartitionRange THEN reverts with MaturityDateInvalid", async () => {
@@ -281,10 +281,14 @@ export function maturityTests(getCtx: () => AssetMockCtx): void {
       });
 
       it("GIVEN a recovered wallet WHEN redeemAtMaturityByPartitionRange THEN reverts with WalletRecovered", async () => {
-        await asset.recoveryAddress(signer_A.address, signer_B.address, ADDRESS_ZERO);
+        const signers = await ethers.getSigners();
+        const recoveredSigner = signers[11];
+
+        await asset.connect(signer_A).recoveryAddress(recoveredSigner.address, signer_B.address, ADDRESS_ZERO);
+        await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_MATURITY_REDEEMER, recoveredSigner.address);
 
         await expect(
-          asset.connect(signer_A).redeemAtMaturityByPartitionRange(signer_A.address, ZERO, 10),
+          asset.connect(recoveredSigner).redeemAtMaturityByPartitionRange(recoveredSigner.address, ZERO, 10),
         ).to.be.revertedWithCustomError(asset, "WalletRecovered");
       });
 


### PR DESCRIPTION
## Description

FIND-062 — `Maturity::fullRedeemAtMaturity()` and `Maturity::redeemAtMaturityByPartitionRange()` gated mandatory maturity redemption on `onlyListedAllowed(_tokenHolder)` and `onlyValidKycStatus(IKyc.KycStatus.GRANTED, _tokenHolder)`. Both evaluated the token holder's state rather than the caller (`ROLE_MATURITY_REDEEMER`), enabling a holder to unilaterally block an issuer-driven mandatory redemption by letting their KYC lapse or ending up on the control list.

Removes `onlyListedAllowed` and `onlyValidKycStatus` from `fullRedeemAtMaturity()` and `redeemAtMaturityByPartitionRange()` in `Maturity.sol`, and adds `@dev` NatSpec notes documenting the carve-out as an intentional design decision for issuer-driven mandatory corporate actions. Updates integration tests to verify that redemption completes successfully even if the holder account is blocked or lacks active KYC.

Fixes FIND-062

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests: `Maturity Tests` suite passing (49 tests).
- Reproduction from FIND-062: confirmed that `fullRedeemAtMaturity()` and `redeemAtMaturityByPartitionRange()` succeed when holder is blocked on the control list or lacks valid KYC status.
- No regression in existing maturity suite (role checks, paused state, clearing status, date checks, recovered wallet checks).
- Linters: `lint:sol` and `lint:js` passing with 0 errors.

### Test Results (if any)
```
49 passing
```

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅