### PR TITLE
fix(clearing): exempt expired clearing reclaim from KYC/identity checks

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC20StorageWrapper.sol
@@ -560,7 +560,7 @@ library ERC20StorageWrapper {
      * @dev Reverts with `IAllowanceTypes.SpenderWithZeroAddress` if `spender` is `address(0)`.
      * @param spender The address of the spender to validate.
      */
-    function _checkSpenderWithZeroAddress(address spender) private view {
+    function _checkSpenderWithZeroAddress(address spender) private pure {
         if (spender == address(0)) revert IAllowanceTypes.SpenderWithZeroAddress();
     }
 

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/ClearingByPartition.sol
@@ -92,6 +92,8 @@ abstract contract ClearingByPartition is IClearingByPartition, Modifiers {
     }
 
     /// @inheritdoc IClearingByPartition
+    /// @dev Intentional recovery carve-out: exempt from identity/KYC checks because it returns
+    ///      the holder's own locked tokens rather than performing a new regulated transfer.
     function reclaimClearingOperationByPartition(
         IClearingByPartition.ClearingOperationIdentifier calldata _clearingOperationIdentifier
     )
@@ -103,7 +105,6 @@ abstract contract ClearingByPartition is IClearingByPartition, Modifiers {
         onlyDefaultPartitionWithSinglePartition(_clearingOperationIdentifier.partition)
         onlyWithValidClearingId(_clearingOperationIdentifier)
         onlyValidExpirationTimestampForClearing(_clearingOperationIdentifier, true)
-        onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))
         returns (bool success_)
     {
         success_ = ClearingLifecycleOps.reclaimClearingOperationByPartition(_clearingOperationIdentifier);

--- a/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/clearingByPartition/IClearingByPartition.sol
@@ -53,10 +53,16 @@ interface IClearingByPartition is IClearingTypes {
     ) external returns (bool success_);
 
     /**
-     * @notice Reclaims a clearing operation returning funds back to the token holder
-     * @dev Callable by the token holder once the operation has expired.
-     * @param _clearingOperationIdentifier Struct containing the parameters that identify the clearing operation
-     * @return success_ True if the operation was reclaimed successfully
+     * @notice Reclaims an expired clearing operation for a partition and returns locked tokens
+     *         to the token holder.
+     * @dev Callable only after the operation has passed its expiration timestamp. Releases the
+     *      locked balance back to the token holder, restores any consumed allowance, and removes
+     *      the clearing record from storage. Emits a `ClearingOperationReclaimed` event.
+     *      Exempt from identity / KYC checks as an intentional recovery carve-out, since reclaiming
+     *      returns the holder's own locked tokens rather than executing a new regulated transfer.
+     * @param _clearingOperationIdentifier Struct containing the partition, token holder address,
+     *        clearing ID, and operation type.
+     * @return success_ True if the clearing operation is successfully reclaimed.
      */
     function reclaimClearingOperationByPartition(
         IClearingTypes.ClearingOperationIdentifier calldata _clearingOperationIdentifier

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -21,7 +21,6 @@ import {
   GAS_LIMIT,
   gasLimitOverride,
   hederaGasOverrides,
-  gasLimitOverride,
   info,
   retryTransaction,
   RetryOptions,

--- a/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/clearingByPartition/clearingByPartition.test.ts
@@ -1459,6 +1459,37 @@ export function clearingByPartitionTests(getCtx: () => AssetMockCtx): void {
           asset.connect(signer_A).reclaimClearingOperationByPartition(identifier),
         ).to.be.revertedWithCustomError(asset, "WrongClearingId");
       });
+
+      it("GIVEN a clearing transfer by partition WHEN reclaimClearingOperationByPartition with unidentified account THEN transaction success", async () => {
+        const balanceBefore = await asset.balanceOf(signer_A.address);
+        const clearingOperation = {
+          partition: _DEFAULT_PARTITION,
+          expirationTimestamp: SHORT_EXPIRATION_TIMESTAMP,
+          data: EMPTY_HEX_BYTES,
+        };
+        await asset.connect(signer_A).clearingRedeemByPartition(clearingOperation, _AMOUNT);
+
+        expect(await asset.balanceOf(signer_A.address)).to.equal(balanceBefore - BigInt(_AMOUNT));
+        expect(await asset.getClearedAmountForByPartition(_DEFAULT_PARTITION, signer_A.address)).to.equal(_AMOUNT);
+
+        await asset.changeSystemTimestamp(SHORT_EXPIRATION_TIMESTAMP);
+
+        const identifier = {
+          clearingOperationType: ClearingOperationType.Redeem,
+          partition: _DEFAULT_PARTITION,
+          tokenHolder: signer_A.address,
+          clearingId: 1,
+        };
+        await asset.grantRole(ATS_ROLES.ROLE_INTERNAL_KYC_MANAGER, signer_A.address);
+        await asset.activateInternalKyc();
+        // Revoke identity for signer_A
+        await asset.connect(signer_B).revokeKyc(signer_A.address);
+
+        // Wait until expiration date
+        await asset.changeSystemTimestamp(clearingOperation.expirationTimestamp + 1);
+
+        await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(identifier)).to.not.be.reverted;
+      });
     });
 
     // ─── Read functions ────────────────────────────────────────────────────────

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC1400/ERC1410/erc1410.test.ts
@@ -1334,7 +1334,7 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           );
         });
 
-        it("GIVEN a clearing transfer WHEN reclaimClearingOperationByPartition with unidentified account THEN transaction fails", async () => {
+        it("GIVEN a clearing transfer WHEN reclaimClearingOperationByPartition with unidentified account THEN transaction success", async () => {
           await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_C.address);
 
           await asset.grantRole(ATS_ROLES.ROLE_INTERNAL_KYC_MANAGER, signer_A.address);
@@ -1345,7 +1345,8 @@ export function erc1410Tests(getCtx: () => AssetMockCtx): void {
           // Wait until expiration date
           await asset.changeSystemTimestamp(clearingOperation.expirationTimestamp + 1);
 
-          await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(clearingIdentifier)).to.be.reverted;
+          await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(clearingIdentifier)).to.not.be
+            .reverted;
         });
       });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/clearing/clearing.test.ts
@@ -1564,7 +1564,7 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           );
         });
 
-        it("GIVEN a clearing transfer WHEN reclaimClearingOperationByPartition with unidentified account THEN transaction fails", async () => {
+        it("GIVEN a clearing transfer WHEN reclaimClearingOperationByPartition with unidentified account THEN transaction success", async () => {
           await asset.connect(signer_A).clearingTransferByPartition(clearingOperation, _AMOUNT, signer_C.address);
 
           await asset.grantRole(ATS_ROLES.ROLE_INTERNAL_KYC_MANAGER, signer_A.address);
@@ -1575,7 +1575,8 @@ export function clearingTests(getCtx: () => AssetMockCtx): void {
           // Wait until expiration date
           await asset.changeSystemTimestamp(clearingOperation.expirationTimestamp + 1);
 
-          await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(clearingIdentifier)).to.be.reverted;
+          await expect(asset.connect(signer_A).reclaimClearingOperationByPartition(clearingIdentifier)).to.not.be
+            .reverted;
         });
       });
 


### PR DESCRIPTION
## Description

This PR closes FIND-058 from the external security audit: `ClearingByPartition::reclaimClearingOperationByPartition()` enforced `onlyIdentifiedAddresses` on the token holder, preventing a user whose KYC was revoked or whose identity record lapsed after creating a clearing operation from reclaiming their locked tokens once the operation expired.

**Fix:**
- Removed `onlyIdentifiedAddresses(_clearingOperationIdentifier.tokenHolder, address(0))` from `reclaimClearingOperationByPartition()` in `ClearingByPartition.sol`.
- Added NatSpec `@dev` notes in `IClearingByPartition.sol` and `ClearingByPartition.sol` documenting the exemption as an intentional recovery carve-out (reclaiming returns the holder's own locked tokens rather than performing a new regulated transfer).
- Added a new integration test in `clearingByPartition.test.ts` and inverted existing sibling tests in `layer_1/clearing/clearing.test.ts` and `layer_1/ERC1400/ERC1410/erc1410.test.ts` to assert that reclaim succeeds even with revoked KYC.
- No regression on `approveClearingOperationByPartition()` or other clearing lifecycle paths.

Fixes FIND-058.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests — `run-ai-checks.sh` (compile, lint, typecheck, tests, coverage)
- New tests: verified that `reclaimClearingOperationByPartition()` succeeds for holders with revoked KYC after operation expiration; inverted layer_1 tests to match.
- Result: PASS

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅