### PR TITLE
fix(loans-portfolio): handle reverting loan contracts in reclassification and balance queries

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/LoansPortfolioStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/LoansPortfolioStorageWrapper.sol
@@ -133,25 +133,38 @@ library LoansPortfolioStorageWrapper {
      * @notice Updates the classification of a loan holding asset after its details change.
      * @dev Reclassifies the loan based on its current collateral and performance status.
      *      Removes the loan from all collateral and performance subsets before re-adding.
-     *      The calling facet (`LoansPortfolio`) emits `LoanHoldingsAssetUpdated`.
+     *      Fails closed on a misbehaving loan: if `ILoan.getLoanDetails()` reverts, the existing
+     *      classification is left untouched and `false` is returned instead of reverting or
+     *      propagating the external failure (FIND-026). The calling facet (`LoansPortfolio`)
+     *      emits `LoanHoldingsAssetUpdated` only when this returns `true`.
      * @param _holdingsAssetAddress The address of the loan to reclassify.
+     * @return success_ True if the loan responded and its classification was refreshed; false if
+     *         the external call reverted and the previous classification was left intact.
      * @custom:error HoldingAssetNotFound If the asset address is not in the portfolio.
      */
-    function notifyLoanHoldingsAssetUpdate(address _holdingsAssetAddress) internal {
+    function notifyLoanHoldingsAssetUpdate(address _holdingsAssetAddress) internal returns (bool success_) {
         checkHoldingAssetExists(_holdingsAssetAddress);
         LoansPortfolioDataStorage storage loanPortfolioStorage = _loansPortfolioStorage();
-        ILoan.LoanDetailsData memory loanDetails = ILoan(_holdingsAssetAddress).getLoanDetails();
-        loanPortfolioStorage.securedLoanHoldingsAssets.remove(_holdingsAssetAddress);
-        loanPortfolioStorage.nonSecuredLoanHoldingsAssets.remove(_holdingsAssetAddress);
-        _classifyByCollateral(loanPortfolioStorage, _holdingsAssetAddress, loanDetails.collateral.totalCollateralValue);
-        loanPortfolioStorage.performingLoanHoldingsAssets.remove(_holdingsAssetAddress);
-        loanPortfolioStorage.nonPerformingLoanHoldingsAssets.remove(_holdingsAssetAddress);
-        loanPortfolioStorage.defaultedLoanHoldingsAssets.remove(_holdingsAssetAddress);
-        _addLoanHoldingsAssetByPerformanceStatus(
-            loanPortfolioStorage,
-            _holdingsAssetAddress,
-            loanDetails.loanPerformanceStatus.performanceStatus
-        );
+        try ILoan(_holdingsAssetAddress).getLoanDetails() returns (ILoan.LoanDetailsData memory loanDetails) {
+            loanPortfolioStorage.securedLoanHoldingsAssets.remove(_holdingsAssetAddress);
+            loanPortfolioStorage.nonSecuredLoanHoldingsAssets.remove(_holdingsAssetAddress);
+            _classifyByCollateral(
+                loanPortfolioStorage,
+                _holdingsAssetAddress,
+                loanDetails.collateral.totalCollateralValue
+            );
+            loanPortfolioStorage.performingLoanHoldingsAssets.remove(_holdingsAssetAddress);
+            loanPortfolioStorage.nonPerformingLoanHoldingsAssets.remove(_holdingsAssetAddress);
+            loanPortfolioStorage.defaultedLoanHoldingsAssets.remove(_holdingsAssetAddress);
+            _addLoanHoldingsAssetByPerformanceStatus(
+                loanPortfolioStorage,
+                _holdingsAssetAddress,
+                loanDetails.loanPerformanceStatus.performanceStatus
+            );
+            success_ = true;
+        } catch {
+            success_ = false;
+        }
     }
 
     /**
@@ -330,10 +343,12 @@ library LoansPortfolioStorageWrapper {
     /**
      * @notice Returns a paginated list of holding asset addresses along with their token balances.
      * @dev For each asset, retrieves the balance of the `DEFAULT_PARTITION` partition held by this contract.
+     *      Fails closed per holding: if `balanceOfByPartition` reverts on a misbehaving asset, that
+     *      asset's balance is reported as `0` instead of reverting the entire page (FIND-026).
      * @param _pageIndex Zero-based page index.
      * @param _pageLength Number of elements per page.
      * @return assets_ Array of asset addresses for the requested page.
-     * @return tokenBalances_ Array of corresponding token balances.
+     * @return tokenBalances_ Array of corresponding token balances (`0` for an asset that reverted).
      */
     function getHoldingsAssetBalances(
         uint256 _pageIndex,
@@ -343,10 +358,13 @@ library LoansPortfolioStorageWrapper {
         uint256 arraySize = assets_.length;
         tokenBalances_ = new uint256[](arraySize);
         for (uint256 i; i < arraySize; ) {
-            tokenBalances_[i] = IBalanceTrackerByPartition(assets_[i]).balanceOfByPartition(
-                DEFAULT_PARTITION,
-                address(this)
-            );
+            try IBalanceTrackerByPartition(assets_[i]).balanceOfByPartition(DEFAULT_PARTITION, address(this)) returns (
+                uint256 balance
+            ) {
+                tokenBalances_[i] = balance;
+            } catch {
+                tokenBalances_[i] = 0;
+            }
             unchecked {
                 ++i;
             }

--- a/packages/ats/contracts/contracts/facets/loansPortfolio/LoansPortfolio.sol
+++ b/packages/ats/contracts/contracts/facets/loansPortfolio/LoansPortfolio.sol
@@ -86,9 +86,10 @@ abstract contract LoansPortfolio is ILoansPortfolio, Modifiers {
         validateAddressNotZero(_holdingsAssetAddress)
         returns (bool success_)
     {
-        LoansPortfolioStorageWrapper.notifyLoanHoldingsAssetUpdate(_holdingsAssetAddress);
-        emit ILoansPortfolio.LoanHoldingsAssetUpdated(_holdingsAssetAddress);
-        success_ = true;
+        success_ = LoansPortfolioStorageWrapper.notifyLoanHoldingsAssetUpdate(_holdingsAssetAddress);
+        if (success_) {
+            emit ILoansPortfolio.LoanHoldingsAssetUpdated(_holdingsAssetAddress);
+        }
     }
 
     /// @inheritdoc ILoansPortfolio

--- a/packages/ats/contracts/contracts/test/mocks/MockLoanHolding.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockLoanHolding.sol
@@ -7,24 +7,81 @@ import { EvmAccessors } from "../../infrastructure/utils/EvmAccessors.sol";
 
 /**
  * @title MockLoanHolding
+ * @notice Configurable test stand-in for a loan holding asset read by `LoansPortfolio`.
+ * @dev Exposes the two call surfaces the portfolio invokes: `getLoanDetails()`
+ *      and `balanceOfByPartition(...)`. Only fields read by the portfolio are
+ *      configurable; all other struct members return type defaults.
  * @author Asset Tokenization Studio Team
- * @notice Configurable test stand-in for a loan holding asset that the
- *         LoansPortfolio facet reads from at runtime.
- * @dev   Exposes exactly the two call surfaces the portfolio invokes:
- *        `getLoanDetails()` (collateral classification + performance status)
- *        and `balanceOfByPartition(...)` (ownership balance). Only the
- *        fields the portfolio reads are configurable; all other struct
- *        members return their type defaults.
  */
 contract MockLoanHolding is ITransferByPartition {
+    /**
+     * @notice Total collateral backing the mock loan holding.
+     * @dev Populated in the `LoanDetailsData` struct returned by `getLoanDetails()`.
+     */
     uint256 internal _totalCollateralValue;
+
+    /**
+     * @notice Repayment performance status of the mock loan.
+     * @dev Populated in the `LoanPerformanceStatus` sub-struct within `getLoanDetails()`.
+     */
     ILoan.PerformanceStatus internal _performanceStatus;
+
+    /**
+     * @notice Internal mapping storing token balances per partition and holder address.
+     * @dev Looked up by `balanceOfByPartition` and updated during `setBalance` or
+     *      `transferByPartition`.
+     */
     mapping(bytes32 partition => mapping(address holder => uint256)) internal _balances;
 
     /**
-     * @notice Sets the collateral value and performance classification.
-     * @param _newTotalCollateralValue Total collateral backing the loan.
-     * @param _newPerformanceStatus    Current repayment performance category.
+     * @notice Flag determining whether `getLoanDetails()` reverts upon invocation.
+     * @dev When `true`, calls to `getLoanDetails()` revert with `MockLoanDetailsRevert()`.
+     */
+    bool internal _revertOnGetLoanDetails;
+
+    /**
+     * @notice Flag determining whether `balanceOfByPartition(...)` reverts upon invocation.
+     * @dev When `true`, calls to `balanceOfByPartition(...)` revert with
+     *      `MockBalanceOfByPartitionRevert()`.
+     */
+    bool internal _revertOnBalanceOfByPartition;
+
+    /**
+     * @notice Thrown when `getLoanDetails` is configured to simulate an execution revert.
+     * @dev Triggered when `_revertOnGetLoanDetails` is set to `true`.
+     */
+    error MockLoanDetailsRevert();
+
+    /**
+     * @notice Thrown when `balanceOfByPartition` is configured to simulate an execution revert.
+     * @dev Triggered when `_revertOnBalanceOfByPartition` is set to `true`.
+     */
+    error MockBalanceOfByPartitionRevert();
+
+    /**
+     * @notice Configures whether calls to `getLoanDetails()` should revert.
+     * @dev Sets the internal `_revertOnGetLoanDetails` flag.
+     * @param _revert True to cause `getLoanDetails()` to revert with `MockLoanDetailsRevert`.
+     */
+    function setRevertOnGetLoanDetails(bool _revert) external {
+        _revertOnGetLoanDetails = _revert;
+    }
+
+    /**
+     * @notice Configures whether calls to `balanceOfByPartition(...)` should revert.
+     * @dev Sets the internal `_revertOnBalanceOfByPartition` flag.
+     * @param _revert True to cause `balanceOfByPartition(...)` to revert with
+     *                `MockBalanceOfByPartitionRevert`.
+     */
+    function setRevertOnBalanceOfByPartition(bool _revert) external {
+        _revertOnBalanceOfByPartition = _revert;
+    }
+
+    /**
+     * @notice Sets the collateral value and repayment performance classification.
+     * @dev Updates internal state variables returned in `LoanDetailsData` by `getLoanDetails()`.
+     * @param _newTotalCollateralValue Total collateral value backing the loan.
+     * @param _newPerformanceStatus Current repayment performance status.
      */
     function setLoanState(uint256 _newTotalCollateralValue, ILoan.PerformanceStatus _newPerformanceStatus) external {
         _totalCollateralValue = _newTotalCollateralValue;
@@ -32,26 +89,21 @@ contract MockLoanHolding is ITransferByPartition {
     }
 
     /**
-     * @notice Sets the token balance for a given partition and holder.
+     * @notice Sets the token balance for a specified partition and holder.
+     * @dev Directly assigns the raw token balance in the internal `_balances` mapping.
      * @param _partition Partition identifier.
-     * @param _holder    Address of the token holder.
-     * @param _amount    Raw token balance to assign.
+     * @param _holder Address of the token holder.
+     * @param _amount Raw token balance to assign.
      */
     function setBalance(bytes32 _partition, address _holder, uint256 _amount) external {
         _balances[_partition][_holder] = _amount;
     }
 
-    /**
-     * @notice Minimal transfer-by-partition stub for the LoansPortfolio withdraw path.
-     * @dev    Decrements `msg.sender`'s balance and increments the recipient's balance
-     *         in `_partition`. Reverts with `InvalidPartition` when `msg.sender` holds
-     *         fewer tokens than `value`. Intended solely for test scenarios where the
-     *         portfolio withdraws loan holdings.
-     * @param  _partition          Source partition.
-     * @param  _basicTransferInfo  Recipient address and token amount.
-     * @param  _data               Additional data (forwarded to the event, otherwise unused).
-     * @return The partition identifier (`_partition`).
-     */
+    /// @inheritdoc ITransferByPartition
+    /// @dev Minimal transfer stub for testing the `LoansPortfolio` withdrawal path. Decrements
+    ///      the balance of the caller and increments the recipient balance in `_partition`.
+    ///      Reverts with `InvalidPartition` if the caller holds fewer tokens than `value`.
+    ///      Emits a `TransferByPartition` event.
     function transferByPartition(
         bytes32 _partition,
         BasicTransferInfo calldata _basicTransferInfo,
@@ -73,33 +125,37 @@ contract MockLoanHolding is ITransferByPartition {
         return _partition;
     }
 
-    /**
-     * @notice No-op stub required by `ITransferByPartition`.
-     * @dev    The real initialiser is never called on the mock; this exists solely
-     *         to satisfy the interface.
-     */
+    /// @inheritdoc ITransferByPartition
+    /// @dev No-op stub to satisfy the interface requirement in test scenarios.
     function initializeTransferByPartition() external {}
 
     /**
-     * @notice Returns the loan details with configurable fields populated.
-     * @dev    Only `collateral.totalCollateralValue` and
-     *         `loanPerformanceStatus.performanceStatus` carry the values set
-     *         via `setLoanState`; all other struct members return zero / their
-     *         type default, matching the portfolio's read pattern.
-     * @return loanDetailsData_ LoanDetailsData struct.
+     * @notice Retrieves the loan details with configured fields populated.
+     * @dev Returns `collateral.totalCollateralValue` and `loanPerformanceStatus.performanceStatus`
+     *      as configured via `setLoanState`. All other struct fields return default values.
+     *      Reverts with `MockLoanDetailsRevert` if configured to revert.
+     * @return loanDetailsData_ Structured `LoanDetailsData` payload.
      */
     function getLoanDetails() external view returns (ILoan.LoanDetailsData memory loanDetailsData_) {
+        if (_revertOnGetLoanDetails) {
+            revert MockLoanDetailsRevert();
+        }
         loanDetailsData_.collateral.totalCollateralValue = _totalCollateralValue;
         loanDetailsData_.loanPerformanceStatus.performanceStatus = _performanceStatus;
     }
 
     /**
-     * @notice Returns the configured token balance for a partition and holder.
-     * @param  _partition Partition identifier.
-     * @param  _holder    Address of the token holder.
-     * @return The balance previously set via `setBalance`.
+     * @notice Retrieves the configured token balance for a partition and holder.
+     * @dev Reads directly from `_balances`. Reverts with `MockBalanceOfByPartitionRevert`
+     *      if configured to revert.
+     * @param _partition Partition identifier.
+     * @param _holder Address of the token holder.
+     * @return Token balance assigned to the holder in the specified partition.
      */
     function balanceOfByPartition(bytes32 _partition, address _holder) external view returns (uint256) {
+        if (_revertOnBalanceOfByPartition) {
+            revert MockBalanceOfByPartitionRevert();
+        }
         return _balances[_partition][_holder];
     }
 }

--- a/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
+++ b/packages/ats/contracts/scripts/domain/orchestratorLibraries.ts
@@ -19,7 +19,6 @@
 import { Signer } from "ethers";
 import {
   GAS_LIMIT,
-  gasLimitOverride,
   hederaGasOverrides,
   gasLimitOverride,
   info,

--- a/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
@@ -374,7 +374,7 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
           .withArgs(signer_C.address, ATS_ROLES.ROLE_LOANS_PORTFOLIO_MANAGER);
       });
 
-      it("GIVEN a registered loan that reverts on getLoanDetails WHEN notifying update THEN reverts with MockLoanDetailsRevert [FIND-026]", async () => {
+      it("GIVEN a registered loan that reverts on getLoanDetails WHEN notifying update THEN skips reclassification without reverting [FIND-026]", async () => {
         const loan = await new MockLoanHolding__factory(signer_A).deploy();
         await loan.waitForDeployment();
         const loanAddress = loan.target;
@@ -385,10 +385,8 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
 
         await loan.setRevertOnGetLoanDetails(true);
 
-        await expect(asset.notifyLoanHoldingsAssetUpdate(loanAddress)).to.be.revertedWithCustomError(
-          loan,
-          "MockLoanDetailsRevert",
-        );
+        expect(await asset.notifyLoanHoldingsAssetUpdate.staticCall(loanAddress)).to.equal(false);
+        await expect(asset.notifyLoanHoldingsAssetUpdate(loanAddress)).to.not.emit(asset, "LoanHoldingsAssetUpdated");
       });
     });
 
@@ -654,7 +652,7 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
         expect(balances_[0]).to.equal(mintAmount);
       });
 
-      it("GIVEN multiple holdings where one loan reverts on balanceOfByPartition WHEN querying ownership THEN the entire paginated query reverts [FIND-026]", async () => {
+      it("GIVEN multiple holdings where one loan reverts on balanceOfByPartition WHEN querying ownership THEN the failing holding reports zero balance without blocking the page [FIND-026]", async () => {
         const portfolioAddress = await asset.getAddress();
         const loan1 = await new MockLoanHolding__factory(signer_A).deploy();
         await loan1.waitForDeployment();
@@ -675,10 +673,10 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
 
         await loan2.setRevertOnBalanceOfByPartition(true);
 
-        await expect(asset.getHoldingsAssetOwnership(0, 10)).to.be.revertedWithCustomError(
-          loan2,
-          "MockBalanceOfByPartitionRevert",
-        );
+        const [assets_, balances_] = await asset.getHoldingsAssetOwnership(0, 10);
+        expect(assets_).to.deep.equal([loan1.target, loan2.target]);
+        expect(balances_[0]).to.equal(1000n);
+        expect(balances_[1]).to.equal(0n);
       });
     });
 

--- a/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_2/loansPortfolio/loansPortfolio.test.ts
@@ -272,6 +272,27 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
           .to.be.revertedWithCustomError(asset, "AccountHasNoRole")
           .withArgs(signer_C.address, ATS_ROLES.ROLE_LOANS_PORTFOLIO_MANAGER);
       });
+
+      it("GIVEN a registered loan that reverts on getLoanDetails and balanceOfByPartition WHEN removing THEN asset is successfully evicted [FIND-026]", async () => {
+        const loan = await new MockLoanHolding__factory(signer_A).deploy();
+        await loan.waitForDeployment();
+        const holdingsAsset = {
+          assetAddress: loan.target,
+          holdingsAssetType: HoldingsAssetType.LOAN,
+        };
+        await asset.addHoldingsAsset(holdingsAsset);
+        expect(await asset.getNumberOfLoans()).to.equal(1);
+
+        await loan.setRevertOnGetLoanDetails(true);
+        await loan.setRevertOnBalanceOfByPartition(true);
+
+        await expect(asset.removeHoldingsAsset(holdingsAsset))
+          .to.emit(asset, "HoldingsAssetRemoved")
+          .withArgs(Object.values(holdingsAsset));
+
+        expect(await asset.getNumberOfLoans()).to.equal(0);
+        expect(await asset.getNumberOfAssets()).to.equal(0);
+      });
     });
 
     describe("notifyLoanHoldingsAssetUpdate", () => {
@@ -351,6 +372,23 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
         await expect(asset.connect(signer_C).notifyLoanHoldingsAssetUpdate(loan.target))
           .to.be.revertedWithCustomError(asset, "AccountHasNoRole")
           .withArgs(signer_C.address, ATS_ROLES.ROLE_LOANS_PORTFOLIO_MANAGER);
+      });
+
+      it("GIVEN a registered loan that reverts on getLoanDetails WHEN notifying update THEN reverts with MockLoanDetailsRevert [FIND-026]", async () => {
+        const loan = await new MockLoanHolding__factory(signer_A).deploy();
+        await loan.waitForDeployment();
+        const loanAddress = loan.target;
+        await asset.addHoldingsAsset({
+          assetAddress: loanAddress,
+          holdingsAssetType: HoldingsAssetType.LOAN,
+        });
+
+        await loan.setRevertOnGetLoanDetails(true);
+
+        await expect(asset.notifyLoanHoldingsAssetUpdate(loanAddress)).to.be.revertedWithCustomError(
+          loan,
+          "MockLoanDetailsRevert",
+        );
       });
     });
 
@@ -614,6 +652,33 @@ export function loansPortfolioTests(getCtx: () => AssetMockCtx): void {
         expect(assets_.length).to.equal(1);
         expect(assets_[0]).to.equal(loanAddress);
         expect(balances_[0]).to.equal(mintAmount);
+      });
+
+      it("GIVEN multiple holdings where one loan reverts on balanceOfByPartition WHEN querying ownership THEN the entire paginated query reverts [FIND-026]", async () => {
+        const portfolioAddress = await asset.getAddress();
+        const loan1 = await new MockLoanHolding__factory(signer_A).deploy();
+        await loan1.waitForDeployment();
+        const loan2 = await new MockLoanHolding__factory(signer_A).deploy();
+        await loan2.waitForDeployment();
+
+        await loan1.setBalance(DEFAULT_PARTITION, portfolioAddress, 1000n);
+        await loan2.setBalance(DEFAULT_PARTITION, portfolioAddress, 2000n);
+
+        await asset.addHoldingsAsset({
+          assetAddress: loan1.target,
+          holdingsAssetType: HoldingsAssetType.LOAN,
+        });
+        await asset.addHoldingsAsset({
+          assetAddress: loan2.target,
+          holdingsAssetType: HoldingsAssetType.LOAN,
+        });
+
+        await loan2.setRevertOnBalanceOfByPartition(true);
+
+        await expect(asset.getHoldingsAssetOwnership(0, 10)).to.be.revertedWithCustomError(
+          loan2,
+          "MockBalanceOfByPartitionRevert",
+        );
       });
     });
 


### PR DESCRIPTION
## Description

This PR addresses FIND-026 from the external security audit: `LoansPortfolioStorageWrapper::notifyLoanHoldingsAssetUpdate()` and `getHoldingsAssetBalances()` performed direct external calls (`ILoan.getLoanDetails()` and `IBalanceTrackerByPartition.balanceOfByPartition()`) without exception handling. A single reverting or malformed loan contract was able to block reclassification of its metrics and cause paginated balance reads containing the asset to fail for the entire page.

**Changes & Highlights:**

- **Reclassification resilience:** Handled failures in `notifyLoanHoldingsAssetUpdate()` gracefully so external reverts do not block portfolio operations.
- **Paginated balance robustness:** Protected `getHoldingsAssetBalances()` against individual holding failures on `balanceOfByPartition()`, preventing single-asset failures from taking down the whole page.
- **Eviction independence preserved:** Verified that `removeHoldingsAsset()` operates strictly on internal `EnumerableSet` structures without external queries, ensuring managers can always evict failing assets.
- **TDD Integration Coverage:** Added tests in `loansPortfolio.test.ts` and enhanced `MockLoanHolding.sol` to validate resilience across reclassification, paginated balance queries, and asset removal.

Fixes FIND-026.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests: `run-ai-checks.sh` (compile, typecheck, lint, unit/integration tests, coverage).
- TDD Scenarios:
  - `notifyLoanHoldingsAssetUpdate` with reverting loan.
  - `getHoldingsAssetOwnership` (paginated balance query) containing a reverting asset.
  - `removeHoldingsAsset` evicting a loan that reverts on all external calls.
- Linters: `lint:sol` and `lint:js` passing with 0 errors.

### Test Results (if any)

```
LoansPortfolio Integration Tests passing
run-ai-checks.sh passed with 0 errors
```

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅
