### PR TITLE
feat(contracts): enforce ERC-1594 isIssuable flag and finalisation

### DIFF
--- a/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
@@ -13,6 +13,7 @@ import { LowLevelCall } from "../../infrastructure/utils/LowLevelCall.sol";
 import { IERC1410Types } from "../../facets/commonTypes/IERC1410Types.sol";
 import { ITransfer } from "../../facets/transfer/ITransfer.sol";
 import { IAllowanceTypes } from "../../facets/allowance/IAllowanceTypes.sol";
+import { IMintTypes } from "../../facets/mint/IMintTypes.sol";
 import { ERC20StorageWrapper } from "./ERC20StorageWrapper.sol";
 import { ERC1410StorageWrapper } from "./ERC1410StorageWrapper.sol";
 import { AdjustBalancesStorageWrapper } from "./AdjustBalancesStorageWrapper.sol";
@@ -102,11 +103,29 @@ library ERC1594StorageWrapper {
     }
 
     /**
+     * @notice Disables token issuance permanently.
+     * @dev Sets `issuance` to `false`. The state change is one-way and cannot be undone.
+     */
+    function disableIssuance() internal {
+        _erc1594Storage().issuance = false;
+    }
+
+    /**
      * @notice Returns whether token issuance is currently enabled.
      * @return True if the `issuance` flag is set, otherwise false.
      */
     function isIssuable() internal view returns (bool) {
         return _erc1594Storage().issuance;
+    }
+
+    /**
+     * @notice Reverts with `IMintTypes.IssuanceIsDisabled` if token issuance has been disabled.
+     * @dev Backing implementation of the `onlyIssuable` modifier.
+     */
+    function requireIssuable() internal view {
+        if (!isIssuable()) {
+            revert IMintTypes.IssuanceIsDisabled();
+        }
     }
 
     /**

--- a/packages/ats/contracts/contracts/facets/batchMint/BatchMint.sol
+++ b/packages/ats/contracts/contracts/facets/batchMint/BatchMint.sol
@@ -44,6 +44,7 @@ abstract contract BatchMint is IBatchMint, Modifiers {
         onlyOperational
         onlyActivated
         onlyUnpaused
+        onlyIssuable
         onlyValidInputAmountsArrayLength(_toList, _amounts)
         onlyWithoutMultiPartition
         onlyAnyRole(_buildRoles(ROLE_ISSUER, ROLE_AGENT))

--- a/packages/ats/contracts/contracts/facets/mint/IMint.sol
+++ b/packages/ats/contracts/contracts/facets/mint/IMint.sol
@@ -52,6 +52,20 @@ interface IMint is IMintTypes {
     function mint(address _to, uint256 _amount) external;
 
     /**
+     * @notice Permanently disables issuance of new tokens.
+     * @dev Restricted to `DEFAULT_ADMIN_ROLE`. Sets the issuance flag to false and emits `IssuanceDisabled`.
+     *      Reverts if issuance has already been disabled.
+     */
+    function disableIssuance() external;
+
+    /**
+     * @notice Permanently finalizes issuance of new tokens.
+     * @dev Restricted to `DEFAULT_ADMIN_ROLE`. Sets the issuance flag to false and emits `IssuanceFinalized`.
+     *      Reverts if issuance has already been disabled.
+     */
+    function finalizeIssuance() external;
+
+    /**
      * @notice Returns whether further issuance is permitted for this security.
      * @dev Once a token returns `false` it must never return `true` again. Implementations read
      *      the issuance flag maintained by `ERC1594StorageWrapper`.

--- a/packages/ats/contracts/contracts/facets/mint/IMintTypes.sol
+++ b/packages/ats/contracts/contracts/facets/mint/IMintTypes.sol
@@ -19,4 +19,21 @@ interface IMintTypes {
      * @param data Arbitrary payload forwarded alongside the issuance.
      */
     event Issued(address indexed operator, address indexed to, uint256 value, bytes data);
+
+    /**
+     * @notice Emitted when token issuance is disabled.
+     * @param operator Account that disabled issuance.
+     */
+    event IssuanceDisabled(address indexed operator);
+
+    /**
+     * @notice Emitted when token issuance is finalized.
+     * @param operator Account that finalized issuance.
+     */
+    event IssuanceFinalized(address indexed operator);
+
+    /**
+     * @notice Thrown when an issuance operation is attempted after issuance has been permanently disabled.
+     */
+    error IssuanceIsDisabled();
 }

--- a/packages/ats/contracts/contracts/facets/mint/Mint.sol
+++ b/packages/ats/contracts/contracts/facets/mint/Mint.sol
@@ -42,6 +42,7 @@ abstract contract Mint is IMint, Modifiers {
         onlyOperational
         onlyActivated
         onlyUnpaused
+        onlyIssuable
         onlyWithoutMultiPartition
         onlyAnyRole(_buildRoles(ROLE_ISSUER, ROLE_AGENT))
         onlyWithinMaxSupply(_value, TimeTravelStorageWrapper.getBlockTimestamp())
@@ -62,6 +63,7 @@ abstract contract Mint is IMint, Modifiers {
         onlyOperational
         onlyActivated
         onlyUnpaused
+        onlyIssuable
         onlyWithoutMultiPartition
         onlyAnyRole(_buildRoles(ROLE_ISSUER, ROLE_AGENT))
         onlyWithinMaxSupply(_amount, TimeTravelStorageWrapper.getBlockTimestamp())
@@ -70,6 +72,34 @@ abstract contract Mint is IMint, Modifiers {
     {
         TokenCoreOps.issue(_to, _amount);
         emit Issued(EvmAccessors.getMsgSender(), _to, _amount, "");
+    }
+
+    /// @inheritdoc IMint
+    function disableIssuance()
+        external
+        override
+        onlyOperational
+        onlyActivated
+        onlyUnpaused
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyIssuable
+    {
+        ERC1594StorageWrapper.disableIssuance();
+        emit IssuanceDisabled(EvmAccessors.getMsgSender());
+    }
+
+    /// @inheritdoc IMint
+    function finalizeIssuance()
+        external
+        override
+        onlyOperational
+        onlyActivated
+        onlyUnpaused
+        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyIssuable
+    {
+        ERC1594StorageWrapper.disableIssuance();
+        emit IssuanceFinalized(EvmAccessors.getMsgSender());
     }
 
     /// @inheritdoc IMint

--- a/packages/ats/contracts/contracts/facets/mint/MintFacet.sol
+++ b/packages/ats/contracts/contracts/facets/mint/MintFacet.sol
@@ -25,7 +25,9 @@ contract MintFacet is Mint, IStaticFunctionSelectors {
                 this.initializeERC1594.selector,
                 this.isIssuable.selector,
                 this.issue.selector,
-                this.mint.selector
+                this.mint.selector,
+                this.disableIssuance.selector,
+                this.finalizeIssuance.selector
             );
     }
 

--- a/packages/ats/contracts/contracts/facets/mintByPartition/MintByPartition.sol
+++ b/packages/ats/contracts/contracts/facets/mintByPartition/MintByPartition.sol
@@ -41,6 +41,7 @@ abstract contract MintByPartition is IMintByPartition, Modifiers {
         onlyOperational
         onlyActivated
         onlyUnpaused
+        onlyIssuable
         onlyAnyRole(_buildRoles(ROLE_ISSUER, ROLE_AGENT))
         onlyDefaultPartitionWithSinglePartition(_issueData.partition)
         onlyWithinMaxSupply(_issueData.value, TimeTravelStorageWrapper.getBlockTimestamp())

--- a/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/AssetModifiers.sol
@@ -7,6 +7,7 @@ import { ClearingModifiers } from "./ClearingModifiers.sol";
 import { CouponModifiers } from "./CouponModifiers.sol";
 import { ComplianceModifiers } from "./ComplianceModifiers.sol";
 import { ERC1410Modifiers } from "./ERC1410Modifiers.sol";
+import { ERC1594Modifiers } from "./ERC1594Modifiers.sol";
 import { ERC3643Modifiers } from "./ERC3643Modifiers.sol";
 import { ExpirationModifiers } from "./ExpirationModifiers.sol";
 import { HoldModifiers } from "./HoldModifiers.sol";
@@ -56,6 +57,7 @@ abstract contract AssetModifiers is
     CouponModifiers,
     ComplianceModifiers,
     ERC1410Modifiers,
+    ERC1594Modifiers,
     ERC3643Modifiers,
     ExpirationModifiers,
     HoldModifiers,

--- a/packages/ats/contracts/contracts/services/asset/ERC1594Modifiers.sol
+++ b/packages/ats/contracts/contracts/services/asset/ERC1594Modifiers.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { ERC1594StorageWrapper } from "../../domain/asset/ERC1594StorageWrapper.sol";
+
+/**
+ * @title ERC1594Modifiers
+ * @author Asset Tokenization Studio Team
+ * @notice Abstract contract providing ERC-1594 issuance precondition modifiers.
+ * @dev Re-exports checks from `ERC1594StorageWrapper` as modifiers for convenient use in facets.
+ */
+abstract contract ERC1594Modifiers {
+    /**
+     * @notice Reverts if token issuance has been disabled.
+     * @dev Enforces that `isIssuable()` returns `true`.
+     */
+    modifier onlyIssuable() {
+        ERC1594StorageWrapper.requireIssuable();
+        _;
+    }
+}

--- a/packages/ats/contracts/contracts/test/mocks/MockDiamondCutHelpers.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockDiamondCutHelpers.sol
@@ -14,6 +14,7 @@ import { ResolverProxyStorageWrapper } from "../../domain/core/ResolverProxyStor
 import { InitializerStorageWrapper } from "../../domain/core/InitializerStorageWrapper.sol";
 import { DeactivateStorageWrapper } from "../../domain/core/DeactivateStorageWrapper.sol";
 import { ERC1410StorageWrapper } from "../../domain/asset/ERC1410StorageWrapper.sol";
+import { ERC1594StorageWrapper } from "../../domain/asset/ERC1594StorageWrapper.sol";
 import { ERC1644StorageWrapper } from "../../domain/asset/ERC1644StorageWrapper.sol";
 import { ControlListStorageWrapper } from "../../domain/core/ControlListStorageWrapper.sol";
 import { KycStorageWrapper } from "../../domain/core/KycStorageWrapper.sol";
@@ -226,6 +227,7 @@ contract MockDiamondCutHelpers is IStaticFunctionSelectors, IMockDiamondCutHelpe
                 ++index;
             }
         }
+        ERC1594StorageWrapper.initialize();
     }
 
     /// @inheritdoc IMockDiamondCutHelpers

--- a/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/batchMint/batchMint.test.ts
@@ -122,6 +122,16 @@ export function batchMintTests(getCtx: () => AssetMockCtx): void {
           await expect(asset.batchMint(toList, amounts)).to.be.revertedWithCustomError(asset, "IsPaused");
         });
 
+        it("GIVEN disabled issuance WHEN batchMint THEN transaction fails with IssuanceIsDisabled", async () => {
+          await asset.connect(signer_A).disableIssuance();
+
+          const mintAmount = AMOUNT / 2;
+          const toList = [signer_D.address];
+          const amounts = [mintAmount];
+
+          await expect(asset.batchMint(toList, amounts)).to.be.revertedWithCustomError(asset, "IssuanceIsDisabled");
+        });
+
         it("GIVEN a recovered caller WHEN batchMint THEN transaction fails with WalletRecovered", async () => {
           await asset.recoveryAddress(signer_D.address, signer_B.address, ethers.ZeroAddress);
           await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_AGENT, signer_D.address);

--- a/packages/ats/contracts/test/contracts/integration/mint/mint.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/mint/mint.test.ts
@@ -43,6 +43,73 @@ export function mintTests(getCtx: () => AssetMockCtx): void {
       });
     });
 
+    describe("disableIssuance and finalizeIssuance", () => {
+      it("GIVEN isIssuable WHEN queried initially THEN returns true", async () => {
+        expect(await asset.isIssuable()).to.be.true;
+      });
+
+      it("GIVEN caller without DEFAULT_ADMIN_ROLE WHEN disableIssuance THEN reverts with AccountHasNoRole", async () => {
+        await expect(asset.connect(unknownSigner).disableIssuance())
+          .to.be.revertedWithCustomError(asset, "AccountHasNoRole")
+          .withArgs(unknownSigner.address, ATS_ROLES.DEFAULT_ADMIN_ROLE);
+      });
+
+      it("GIVEN caller without DEFAULT_ADMIN_ROLE WHEN finalizeIssuance THEN reverts with AccountHasNoRole", async () => {
+        await expect(asset.connect(unknownSigner).finalizeIssuance())
+          .to.be.revertedWithCustomError(asset, "AccountHasNoRole")
+          .withArgs(unknownSigner.address, ATS_ROLES.DEFAULT_ADMIN_ROLE);
+      });
+
+      it("GIVEN caller with DEFAULT_ADMIN_ROLE WHEN disableIssuance THEN emits IssuanceDisabled and sets isIssuable to false", async () => {
+        await expect(asset.connect(signer_A).disableIssuance())
+          .to.emit(asset, "IssuanceDisabled")
+          .withArgs(signer_A.address);
+        expect(await asset.isIssuable()).to.be.false;
+      });
+
+      it("GIVEN caller with DEFAULT_ADMIN_ROLE WHEN finalizeIssuance THEN emits IssuanceFinalized and sets isIssuable to false", async () => {
+        await expect(asset.connect(signer_A).finalizeIssuance())
+          .to.emit(asset, "IssuanceFinalized")
+          .withArgs(signer_A.address);
+        expect(await asset.isIssuable()).to.be.false;
+      });
+
+      it("GIVEN disabled issuance WHEN disableIssuance or finalizeIssuance called again THEN reverts with IssuanceIsDisabled", async () => {
+        await asset.connect(signer_A).disableIssuance();
+        await expect(asset.connect(signer_A).disableIssuance()).to.be.revertedWithCustomError(
+          asset,
+          "IssuanceIsDisabled",
+        );
+        await expect(asset.connect(signer_A).finalizeIssuance()).to.be.revertedWithCustomError(
+          asset,
+          "IssuanceIsDisabled",
+        );
+      });
+
+      it("GIVEN disabled issuance WHEN issue or mint is called THEN reverts with IssuanceIsDisabled", async () => {
+        await executeRbac(asset, [
+          { role: ATS_ROLES.ROLE_KYC, members: [signer_B.address] },
+          { role: ATS_ROLES.ROLE_SSI_MANAGER, members: [signer_A.address] },
+          { role: ATS_ROLES.ROLE_CAP, members: [signer_A.address] },
+          { role: ATS_ROLES.ROLE_ISSUER, members: [signer_A.address] },
+        ]);
+        await asset.addIssuer(signer_A.address);
+        await asset.connect(signer_B).grantKyc(signer_E.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_A.address);
+        await asset.connect(signer_A).setMaxSupply(MAX_SUPPLY);
+
+        await asset.connect(signer_A).disableIssuance();
+
+        await expect(asset.connect(signer_A).issue(signer_E.address, AMOUNT, DATA)).to.be.revertedWithCustomError(
+          asset,
+          "IssuanceIsDisabled",
+        );
+        await expect(asset.connect(signer_A).mint(signer_E.address, AMOUNT)).to.be.revertedWithCustomError(
+          asset,
+          "IssuanceIsDisabled",
+        );
+      });
+    });
+
     describe("initializeERC1594 event", () => {
       it("GIVEN a caller with DEFAULT_ADMIN_ROLE WHEN initializeERC1594 is called THEN emits ERC1594Initialized", async () => {
         await asset.forceFacetNotRegistered(RESOLVER_KEYS.mint);

--- a/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/mintByPartition/mintByPartition.test.ts
@@ -123,6 +123,19 @@ export function mintByPartitionTests(getCtx: () => AssetMockCtx): void {
         expect(await asset.balanceOfByPartition(DEFAULT_PARTITION, signer_E.address)).to.equal(AMOUNT);
       });
 
+      it("GIVEN disabled issuance WHEN issueByPartition THEN reverts with IssuanceIsDisabled", async () => {
+        await asset.connect(signer_A).disableIssuance();
+
+        await expect(
+          asset.issueByPartition({
+            partition: DEFAULT_PARTITION,
+            tokenHolder: signer_E.address,
+            value: AMOUNT,
+            data: EMPTY_HEX_BYTES,
+          }),
+        ).to.be.revertedWithCustomError(asset, "IssuanceIsDisabled");
+      });
+
       it("GIVEN a recovered caller WHEN issueByPartition THEN reverts with WalletRecovered", async () => {
         await asset.grantRole(ATS_ROLES.ROLE_AGENT, signer_C.address);
         await asset.connect(signer_C).recoveryAddress(signer_E.address, signer_D.address, ethers.ZeroAddress);


### PR DESCRIPTION
**## Description

This PR addresses FIND-050 from the external security audit: `ERC1594StorageWrapper::issue()` and other minting write paths (`mint`, `batchMint`, `issueByPartition`) executed token minting without validating whether token issuance was active via `isIssuable()`. Furthermore, the `issuance` boolean in storage was initialised to `true` with no administrative setter to change it to `false`, leaving `isIssuable()` as a non-enforceable read-only view and preventing security tokens from formally closing their issuance phase.

**Fix & Implementation Details:**

- **Issuance Finalisation Entry Points**: Added `disableIssuance()` and `finalizeIssuance()` to `IMint`, `Mint`, and `MintFacet`, restricted to `DEFAULT_ADMIN_ROLE`. Invoking either permanently sets the `issuance` flag to `false` in diamond storage and emits `IssuanceDisabled` / `IssuanceFinalized` (reverting with `IssuanceIsDisabled` if already disabled).
- **`onlyIssuable` Modifier**: Created `ERC1594Modifiers` providing `onlyIssuable` (which invokes `ERC1594StorageWrapper.requireIssuable()`) and integrated it into `AssetModifiers`.
- **Protected Mint Paths**: Gated all issuance entry points (`Mint::issue`, `Mint::mint`, `BatchMint::batchMint`, and `MintByPartition::issueByPartition`) with `onlyIssuable`, causing any subsequent minting attempt to revert with `IssuanceIsDisabled`.
- **Integration Tests**: Added full test coverage across `mint.test.ts`, `batchMint.test.ts`, and `mintByPartition.test.ts` validating RBAC access control, event emissions, one-way state transitions, and expected reverts across all single, batch, and partitioned issuance paths.

Fixes FIND-050.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

- Automated tests: `run-ai-checks.sh` (compile, typecheck, lint, unit/integration tests, coverage).
- Integration test suite: `mint.test.ts`, `batchMint.test.ts`, `mintByPartition.test.ts` (77 passing).
- Linters: `lint:sol` and `lint:js` passing with 0 errors.

### Test Results (if any)

```
  Mint Integration Tests
    77 passing
```

**Node version**:

- [ ] 20
- [ ] 22
- [x] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅**
