### PR TITLE
docs(ats): document on-chain ISIN validation and programmatic KYC prerequisites

### DIFF
--- a/docs/ats/user-guides/creating-bond.md
+++ b/docs/ats/user-guides/creating-bond.md
@@ -73,6 +73,10 @@ ATS supports four types of bonds at the smart contract level, each designed for 
 - Must follow the ISO 6166 standard format
 - Required for regulatory compliance and international trading
 
+:::warning ISIN is validated on-chain
+The factory validates the ISIN inside `deployBond` and **reverts with `WrongISIN`** when it fails — including for an **empty string**. The check covers the 12-character structure and the ISO 6166 (Luhn) check digit, not registry membership, so on testnet any structurally valid, checksum-correct ISIN works (for example, one derived deterministically from your own asset identifier). Programmatic integrators calling the factory directly hit this before any UI validation would.
+:::
+
 ### Bond Permissions
 
 Configure administrative permissions for the bond token:

--- a/docs/ats/user-guides/managing-compliance.md
+++ b/docs/ats/user-guides/managing-compliance.md
@@ -69,6 +69,16 @@ Before you can validate KYC, you need to designate accounts as issuers. Issuers 
 
 The issuers list shows all accounts authorized to upload VCs for KYC validation.
 
+### Programmatic quick reference (fresh token)
+
+When you drive KYC from the SDK or directly against the contracts, a freshly deployed token needs this exact order — the creator starts with `DEFAULT_ADMIN_ROLE` only:
+
+1. Grant yourself the operational roles: `_SSI_MANAGER_ROLE`, `_KYC_ROLE` (and `_CONTROL_LIST_ROLE` for allowlist-mode tokens). Skipping this reverts with `AccountHasNoRole`.
+2. Register a KYC issuer with `addIssuer(account)` (SSI Manager facet).
+3. Call `grantKyc(account, vcId, validFrom, validTo, issuer)` — the `issuer` argument **must be on the SSI issuer list**, otherwise the call reverts with `AccountIsNotIssuer`. A zero-address issuer always fails; `vcId` may reference an off-chain Verifiable Credential.
+
+The UI performs these steps for you; contract-level callers must perform them explicitly.
+
 ### Step 3: Grant KYC to an Account
 
 Once you have issuers configured, you can validate KYC for specific accounts by uploading their Verifiable Credentials.


### PR DESCRIPTION
Documents two integration footguns we hit building on the v8 testnet factory (context: #1390):

1. **Creating a bond — ISIN**: an admonition stating that the factory validates the ISIN on-chain and reverts with `WrongISIN` (including for an empty string), that the check is structure + ISO 6166 check digit (not registry membership), and that a derived checksum-valid ISIN is therefore fine on testnet. Today the page describes the format but not the revert, so SDK/contract callers discover it the hard way.

2. **Managing compliance — programmatic quick reference**: the exact fresh-token order for contract-level callers (grant operational roles → `addIssuer` → `grantKyc` with an SSI-listed issuer) with the revert names (`AccountHasNoRole`, `AccountIsNotIssuer`). The existing guide covers the UI path, which performs these steps implicitly.

Both additions are doc-only, written in the surrounding style, and reflect behavior we verified against the deployed testnet factory (`0.0.9213391`) while shipping an invoice-financing platform on ATS for ETHOnline 2026.