### PR TITLE
fix(ats:contracts): reject an ERC-3643 module that answers a seam call with empty returndata

### DIFF
--- a/.changeset/erc3643-module-empty-returndata.md
+++ b/.changeset/erc3643-module-empty-returndata.md
@@ -1,0 +1,9 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Reject an ERC-3643 compliance or identity-registry module that answers a seam staticcall with
+empty returndata. `ERC1594StorageWrapper` treated "no answer" as approval, so any address that
+accepts a staticcall without reverting (an externally owned account, a contract with a silent
+fallback, and on Hedera a system contract or a token's HIP-719 facade) silently disabled the seam
+it was wired to while `canTransferByPartition` still reported success.

--- a/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/asset/ERC1594StorageWrapper.sol
@@ -447,10 +447,14 @@ library ERC1594StorageWrapper {
         address to,
         uint256 value
     ) private view returns (bool status, bytes1 statusCode, bytes32 reasonCode, bytes memory details) {
-        bytes memory result = address(ERC3643StorageWrapper.getCompliance()).functionStaticCall(
+        address compliance = address(ERC3643StorageWrapper.getCompliance());
+        bytes memory result = compliance.functionStaticCall(
             abi.encodeWithSelector(ICompliance.canTransfer.selector, sender, address(0), 0),
             IERC3643Types.ComplianceCallFailed.selector
         );
+        if (compliance != address(0) && (result.length != 32 || abi.decode(result, (uint256)) > 1)) {
+            LowLevelCall.revertWithData(IERC3643Types.ComplianceCallFailed.selector, result);
+        }
         if (result.length > 0 && !abi.decode(result, (bool))) {
             return (
                 false,
@@ -481,10 +485,14 @@ library ERC1594StorageWrapper {
         address to,
         uint256 value
     ) private view returns (bool status, bytes1 statusCode, bytes32 reasonCode, bytes memory details) {
-        bytes memory result = address(ERC3643StorageWrapper.getCompliance()).functionStaticCall(
+        address compliance = address(ERC3643StorageWrapper.getCompliance());
+        bytes memory result = compliance.functionStaticCall(
             abi.encodeWithSelector(ICompliance.canTransfer.selector, from, to, value),
             IERC3643Types.ComplianceCallFailed.selector
         );
+        if (compliance != address(0) && (result.length != 32 || abi.decode(result, (uint256)) > 1)) {
+            LowLevelCall.revertWithData(IERC3643Types.ComplianceCallFailed.selector, result);
+        }
         if (result.length > 0 && !abi.decode(result, (bool))) {
             return (
                 false,
@@ -540,10 +548,14 @@ library ERC1594StorageWrapper {
         if (!KycStorageWrapper.verifyKycStatus(IKyc.KycStatus.GRANTED, account)) {
             return (false, Eip1066.DISALLOWED_OR_STOP, IKyc.InvalidKycStatus.selector, abi.encode(account));
         }
-        bytes memory isVerified = address(ERC3643StorageWrapper.getIdentityRegistry()).functionStaticCall(
+        address identityRegistry = address(ERC3643StorageWrapper.getIdentityRegistry());
+        bytes memory isVerified = identityRegistry.functionStaticCall(
             abi.encodeWithSelector(IIdentityRegistry.isVerified.selector, account),
             IERC3643Types.IdentityRegistryCallFailed.selector
         );
+        if (identityRegistry != address(0) && (isVerified.length != 32 || abi.decode(isVerified, (uint256)) > 1)) {
+            LowLevelCall.revertWithData(IERC3643Types.IdentityRegistryCallFailed.selector, isVerified);
+        }
         if (isVerified.length > 0 && !abi.decode(isVerified, (bool))) {
             return (false, Eip1066.DISALLOWED_OR_STOP, IERC3643Types.AddressNotVerified.selector, abi.encode(account));
         }

--- a/packages/ats/contracts/contracts/test/mocks/MockedSilentModule.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockedSilentModule.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+/**
+ * @title MockedSilentModule
+ * @author Asset Tokenization Studio Team
+ * @notice Answers every selector with success and empty returndata.
+ * @dev This is the observable behaviour shared by an externally owned account, a
+ * contract with a silent fallback, a Hedera system contract, and a Hedera token's
+ * HIP-719 facade. Registering any of them as `compliance` or `identityRegistry`
+ * makes the corresponding ERC-3643 seam pass unconditionally, because
+ * `ERC1594StorageWrapper` reads "no answer" as "allowed".
+ *
+ * Used as the failing case for both seams; no Hedera-specific behaviour is
+ * needed to reproduce it.
+ */
+contract MockedSilentModule {
+    // solhint-disable-next-line no-empty-blocks
+    fallback() external {}
+}

--- a/packages/ats/contracts/test/contracts/integration/layer_1/ERC3643/silentModule.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/layer_1/ERC3643/silentModule.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { IAssetMock, ComplianceMock, IdentityRegistryMock } from "@contract-types";
+import type { AssetMockCtx } from "@test";
+import { executeRbac, MAX_UINT256 } from "@test";
+import { ATS_ROLES, EMPTY_STRING, ZERO } from "@scripts";
+
+const AMOUNT = 1000;
+const EMPTY_VC_ID = EMPTY_STRING;
+
+/**
+ * An ERC-3643 module that answers every selector with success and empty returndata.
+ *
+ * `ERC1594StorageWrapper` inspects the returndata of its `ICompliance` and
+ * `IIdentityRegistry` staticcalls and treats an empty answer as approval, so any address
+ * of this shape silently disables the seam it is wired to. An externally owned account, a
+ * contract with a silent fallback, a Hedera system contract and a Hedera token's HIP-719
+ * facade all behave this way; only the second is needed to reproduce the seam on any EVM.
+ */
+export function silentModuleTests(getCtx: () => AssetMockCtx): void {
+  describe("ERC3643 Silent Module Tests", () => {
+    let signer_A: HardhatEthersSigner;
+    let signer_B: HardhatEthersSigner;
+    let signer_D: HardhatEthersSigner;
+    let signer_E: HardhatEthersSigner;
+
+    let asset: IAssetMock;
+    let silentModule: string;
+
+    beforeEach(async () => {
+      const ctx = getCtx();
+      signer_A = ctx.deployer;
+      signer_B = ctx.user1;
+      signer_D = ctx.user3;
+      signer_E = ctx.user4;
+      asset = ctx.asset;
+
+      const silent = await (await ethers.getContractFactory("MockedSilentModule", signer_A)).deploy();
+      await silent.waitForDeployment();
+      silentModule = silent.target as string;
+
+      await executeRbac(asset, [
+        { role: ATS_ROLES.ROLE_KYC, members: [signer_B.address] },
+        { role: ATS_ROLES.ROLE_SSI_MANAGER, members: [signer_A.address] },
+        { role: ATS_ROLES.ROLE_AGENT, members: [signer_A.address] },
+        { role: ATS_ROLES.ROLE_TREX_OWNER, members: [signer_A.address] },
+      ]);
+
+      await asset.grantRole(ATS_ROLES.ROLE_ISSUER, signer_A.address);
+      await asset.addIssuer(signer_E.address);
+      await asset.connect(signer_B).grantKyc(signer_D.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_E.address);
+      await asset.connect(signer_B).grantKyc(signer_E.address, EMPTY_VC_ID, ZERO, MAX_UINT256, signer_E.address);
+
+      // Both modules default to address(0) on the shared fixture, so the balance is minted
+      // before the module under test is wired in.
+      await asset.mint(signer_E.address, AMOUNT);
+    });
+
+    describe("compliance seam", () => {
+      it("GIVEN a permissive ComplianceMock WHEN transfer THEN it succeeds", async () => {
+        const complianceMock: ComplianceMock = await (
+          await ethers.getContractFactory("ComplianceMock", signer_A)
+        ).deploy(true, false);
+        await complianceMock.waitForDeployment();
+        await asset.connect(signer_A).setCompliance(complianceMock.target as string);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.not.be.reverted;
+      });
+
+      it("GIVEN a denying ComplianceMock WHEN transfer THEN it reverts with ComplianceNotAllowed", async () => {
+        const complianceMock: ComplianceMock = await (
+          await ethers.getContractFactory("ComplianceMock", signer_A)
+        ).deploy(false, false);
+        await complianceMock.waitForDeployment();
+        await asset.connect(signer_A).setCompliance(complianceMock.target as string);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.be.revertedWithCustomError(
+          asset,
+          "ComplianceNotAllowed",
+        );
+      });
+
+      it("GIVEN a compliance that answers with empty returndata WHEN transfer THEN it reverts with ComplianceCallFailed", async () => {
+        await asset.connect(signer_A).setCompliance(silentModule);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.be.revertedWithCustomError(
+          asset,
+          "ComplianceCallFailed",
+        );
+      });
+
+      it("GIVEN no compliance configured WHEN transfer THEN it succeeds", async () => {
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.not.be.reverted;
+      });
+    });
+
+    describe("identity registry seam", () => {
+      it("GIVEN a verifying IdentityRegistryMock WHEN transfer THEN it succeeds", async () => {
+        const identityRegistryMock: IdentityRegistryMock = await (
+          await ethers.getContractFactory("IdentityRegistryMock", signer_A)
+        ).deploy(true, false);
+        await identityRegistryMock.waitForDeployment();
+        await asset.connect(signer_A).setIdentityRegistry(identityRegistryMock.target as string);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.not.be.reverted;
+      });
+
+      it("GIVEN a rejecting IdentityRegistryMock WHEN transfer THEN it reverts with AddressNotVerified", async () => {
+        const identityRegistryMock: IdentityRegistryMock = await (
+          await ethers.getContractFactory("IdentityRegistryMock", signer_A)
+        ).deploy(false, false);
+        await identityRegistryMock.waitForDeployment();
+        await asset.connect(signer_A).setIdentityRegistry(identityRegistryMock.target as string);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.be.revertedWithCustomError(
+          asset,
+          "AddressNotVerified",
+        );
+      });
+
+      it("GIVEN an identity registry that answers with empty returndata WHEN transfer THEN it reverts with IdentityRegistryCallFailed", async () => {
+        await asset.connect(signer_A).setIdentityRegistry(silentModule);
+
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.be.revertedWithCustomError(
+          asset,
+          "IdentityRegistryCallFailed",
+        );
+      });
+
+      it("GIVEN no identity registry configured WHEN transfer THEN it succeeds", async () => {
+        await expect(asset.connect(signer_E).transfer(signer_D.address, AMOUNT / 2)).to.not.be.reverted;
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

`ERC1594StorageWrapper` asks the `ICompliance` and `IIdentityRegistry` modules whether a transfer
is allowed, then treats **an empty answer as a yes**.

```solidity
bytes memory result = address(ERC3643StorageWrapper.getCompliance()).functionStaticCall(
    abi.encodeWithSelector(ICompliance.canTransfer.selector, from, to, value),
    IERC3643Types.ComplianceCallFailed.selector
);
if (result.length > 0 && !abi.decode(result, (bool))) {
    return (false, ...DISALLOWED...);
}
return (true, Eip1066.SUCCESS, ...);
```

`result.length > 0` tests whether the module answered at all, and the absence of an answer falls
through to `SUCCESS`. Any address that accepts a staticcall without reverting and returns nothing
passes the gate, silently: no revert, no event, and `canTransferByPartition` reports success.

Three call sites share the pattern, all in `domain/asset/ERC1594StorageWrapper.sol`:
`_validateSenderCompliance`, `_validateTransferCompliance` and `_validateIdentifiedAccount`.

### What answers with success and empty returndata

An EOA, any `fallback() external {}`, and on Hedera two classes native to the chain. Measured by
`eth_call` through Hedera's mirror node, unauthenticated, testnet 296:

| target | `canTransfer` / `isVerified` / `getKycStatus` / `isPaused` |
|---|---|
| a conforming `IExternalKycList` (control) | answers `getKycStatus`, reverts on the other three |
| EOA, 0 bytes of code | **success, `0x`** |
| HTS token, 147-byte HIP-719 facade | **success, `0x`** |
| HTS system contract `0x167` | **success, `0x`** |
| an ATS security, wrong interface (control) | reverts on all four |

The two controls are what make the middle rows a measurement rather than a probe that returns the
same thing for everything. A security whose `compliance` or `identityRegistry` points at any of
those enforces nothing and reports that it is enforcing. On a network where every fungible token is
an HTS address, a plausible typo produces a permissive security rather than a broken one.

### Why the code-length guard is the wrong fix here

We drafted `target.code.length == 0` first and measured it before proposing it. `EXTCODESIZE` on
testnet 296 gives HTS system contracts `0x167`, `0x168`, `0x169`, `0x16a` a codesize of **0**, and
an HTS token **147** (controls: a deployed ATS security 390, a never-deployed address 0).

It is wrong in both directions. It rejects every Hedera system contract, and it admits every HTS
token, which passes `code.length > 0` and still answers with empty returndata. It would have
merged, closed the EOA case, and left the case native to this chain. Checking the answer rather
than the target subsumes all four classes and needs no Hedera knowledge to review.

### The change

Three call sites, four lines each.

```solidity
address compliance = address(ERC3643StorageWrapper.getCompliance());
bytes memory result = compliance.functionStaticCall(
    abi.encodeWithSelector(ICompliance.canTransfer.selector, from, to, value),
    IERC3643Types.ComplianceCallFailed.selector
);
if (compliance != address(0) && (result.length != 32 || abi.decode(result, (uint256)) > 1)) {
    LowLevelCall.revertWithData(IERC3643Types.ComplianceCallFailed.selector, result);
}
```

`LowLevelCall` is deliberately unchanged: six other sites use `functionCall` for the void
`transferred` / `created` / `destroyed` notifications, where empty returndata is correct, and a
blanket rule inside `verifyCallResultFromTarget` would break all six. The `address(0)` test
preserves "module not configured" exactly, distinguishing *unset* from *answered nothing*. It
reverts rather than returning `DISALLOWED` because a module that cannot answer is a broken
configuration, not a policy decision, and both error selectors already exist and are already passed
into the call. Glad to switch to a reason code if you would rather `canTransfer` never revert.

**Not fixed here:** those six void sites have the same exposure and cannot be closed this way, since
the only available signal is whether the target has code, which the table above shows is unsafe on
Hedera. Happy to take it as a follow-up.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Eight new cases in `test/contracts/integration/layer_1/ERC3643/silentModule.test.ts`, four per
seam, using one new mock (`MockedSilentModule`, a bare `fallback() external {}`) that reproduces
the HIP-719 facade's behaviour on any EVM. **No Hedera needed to run them.**

Run with the patch and again with it reverted, because a test that passes both ways is not evidence:

| | with the patch | reverted |
|---|---|---|
| new tests | **8 passing** | **6 passing, 2 failing** |

The two failures read `Expected transaction to be reverted with custom error 'ComplianceCallFailed',
but it didn't revert`, and the same for `IdentityRegistryCallFailed`. **The other six are controls
and pass in both columns:** a permissive module still permits, a denying module still denies, and an
unset module still disables its gate.

**Full `packages/ats/contracts` suite with only this branch applied: `3653 passing, 3 pending, 0
failing`.** Also clean: `prettier --check`, and `solhint` with the local `solhint-plugin-ats` at 0
errors and 0 warnings on every file touched. The `.betterer.results` ratchet is unaffected, measured
rather than assumed: the committed baseline is 55 warnings across 18 files, and a full run with this
change returns 55 across the same 18.

The Hedera measurements are ours, not the maintainers', and each is reproducible from a script we
can hand over on request.

**Node version**:

- [ ] 20
- [x] 22
- [ ] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅
