### PR TITLE
fix(ats:contracts): validate an external KYC list at registration time

### DIFF
--- a/.changeset/external-kyc-list-registration-check.md
+++ b/.changeset/external-kyc-list-registration-check.md
@@ -1,0 +1,10 @@
+---
+"@hashgraph/asset-tokenization-contracts": patch
+---
+
+Validate an external KYC list at registration time. `addExternalKycList`,
+`updateExternalKycLists` and `initializeExternalKycLists` accepted any non-zero address, and a
+wrong one made every subsequent transfer revert inside `isExternallyGranted`, for every holder,
+with an error naming neither the list nor the cause. The candidate is now staticcalled once and
+rejected with `NotAnExternalKycList` if it cannot answer `getKycStatus`. Removal and deactivation
+are deliberately left unguarded, because they are the recovery path.

--- a/docs/ats/api/contracts/facets/IAsset.md
+++ b/docs/ats/api/contracts/facets/IAsset.md
@@ -13544,6 +13544,22 @@ error NotAllowedInMultiPartitionMode()
 
 Thrown when a single-partition operation is attempted on a multi-partition token.
 
+### NotAnExternalKycList
+
+```solidity
+error NotAnExternalKycList(address kycList)
+```
+
+Thrown when a candidate address does not answer `IExternalKycList.getKycStatus`.
+
+_Raised at registration time so that a non-conforming list is rejected before it can make every subsequent transfer revert inside `isExternallyGranted`._
+
+#### Parameters
+
+| Name    | Type    | Description                                    |
+| ------- | ------- | ---------------------------------------------- |
+| kycList | address | The address that was offered for registration. |
+
 ### PartitionNotAllowedInSinglePartitionMode
 
 ```solidity

--- a/docs/ats/api/contracts/facets/externalKycListManagement/ExternalKycListManagement.md
+++ b/docs/ats/api/contracts/facets/externalKycListManagement/ExternalKycListManagement.md
@@ -362,6 +362,22 @@ _Enforced by `ExternalListManagementStorageWrapper.addExternalList` for the exte
 | ---- | ------- | --------------------------------------------------------- |
 | max  | uint256 | Maximum number of entries permitted in the external list. |
 
+### NotAnExternalKycList
+
+```solidity
+error NotAnExternalKycList(address kycList)
+```
+
+Thrown when a candidate address does not answer `IExternalKycList.getKycStatus`.
+
+_Raised at registration time so that a non-conforming list is rejected before it can make every subsequent transfer revert inside `isExternallyGranted`._
+
+#### Parameters
+
+| Name    | Type    | Description                                    |
+| ------- | ------- | ---------------------------------------------- |
+| kycList | address | The address that was offered for registration. |
+
 ### UnlistedKycList
 
 ```solidity

--- a/docs/ats/api/contracts/facets/externalKycListManagement/ExternalKycListManagementFacet.md
+++ b/docs/ats/api/contracts/facets/externalKycListManagement/ExternalKycListManagementFacet.md
@@ -404,6 +404,22 @@ _Enforced by `ExternalListManagementStorageWrapper.addExternalList` for the exte
 | ---- | ------- | --------------------------------------------------------- |
 | max  | uint256 | Maximum number of entries permitted in the external list. |
 
+### NotAnExternalKycList
+
+```solidity
+error NotAnExternalKycList(address kycList)
+```
+
+Thrown when a candidate address does not answer `IExternalKycList.getKycStatus`.
+
+_Raised at registration time so that a non-conforming list is rejected before it can make every subsequent transfer revert inside `isExternallyGranted`._
+
+#### Parameters
+
+| Name    | Type    | Description                                    |
+| ------- | ------- | ---------------------------------------------- |
+| kycList | address | The address that was offered for registration. |
+
 ### UnlistedKycList
 
 ```solidity

--- a/docs/ats/api/contracts/facets/externalKycListManagement/IExternalKycListManagement.md
+++ b/docs/ats/api/contracts/facets/externalKycListManagement/IExternalKycListManagement.md
@@ -268,6 +268,22 @@ Thrown when attempting to add an address already present in the external KYC lis
 | ------- | ------- | ------------------------------------------------- |
 | kycList | address | The duplicate external KYC list contract address. |
 
+### NotAnExternalKycList
+
+```solidity
+error NotAnExternalKycList(address kycList)
+```
+
+Thrown when a candidate address does not answer `IExternalKycList.getKycStatus`.
+
+_Raised at registration time so that a non-conforming list is rejected before it can make every subsequent transfer revert inside `isExternallyGranted`._
+
+#### Parameters
+
+| Name    | Type    | Description                                    |
+| ------- | ------- | ---------------------------------------------- |
+| kycList | address | The address that was offered for registration. |
+
 ### UnlistedKycList
 
 ```solidity

--- a/packages/ats/contracts/contracts/domain/core/ExternalListManagementStorageWrapper.sol
+++ b/packages/ats/contracts/contracts/domain/core/ExternalListManagementStorageWrapper.sol
@@ -8,6 +8,7 @@ import { Pagination } from "../../infrastructure/utils/Pagination.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { IExternalControlList } from "../../facets/externalControlListManagement/IExternalControlList.sol";
 import { IExternalKycList } from "../../facets/externalKycListManagement/IExternalKycList.sol";
+import { IExternalKycListManagement } from "../../facets/externalKycListManagement/IExternalKycListManagement.sol";
 import { IKyc } from "../../facets/kyc/IKyc.sol";
 
 /// @custom:hash storage ControlListManagement
@@ -143,13 +144,14 @@ library ExternalListManagementStorageWrapper {
 
     /**
      * @notice Initialises the external KYC-list namespace with `_kycLists` and marks it initialised.
-     * @dev Each entry is validated for non-zero before insertion. Gas scales with `_kycLists.length`.
+     * @dev Each entry is validated as a working `IExternalKycList` before insertion, which covers
+     *      the non-zero check. Gas scales with `_kycLists.length`.
      * @param _kycLists External `IExternalKycList` contracts to register.
      */
     function initializeExternalKycLists(address[] calldata _kycLists) internal {
         uint256 length = _kycLists.length;
         for (uint256 index; index < length; ) {
-            DefaultValueValidation.checkZeroAddress(_kycLists[index]);
+            checkIsExternalKycList(_kycLists[index]);
             addExternalList(STORAGE_LOCATION_KYC_MANAGEMENT, _kycLists[index]);
             unchecked {
                 ++index;
@@ -234,6 +236,25 @@ library ExternalListManagementStorageWrapper {
             }
         }
         return true;
+    }
+
+    /**
+     * @notice Reverts unless `_list` answers `IExternalKycList.getKycStatus` with a valid status.
+     * @dev Staticcalls the candidate once, at registration time. Rejects an externally owned
+     *      account, a codeless address, a contract with a silent fallback and a contract that
+     *      implements a different interface: all four are accepted today, and all four make every
+     *      subsequent transfer revert inside `isExternallyGranted`. The zero-address check runs
+     *      first so that a zero address still reports `ZeroAddressNotAllowed`.
+     * @param _list Candidate external KYC list.
+     */
+    function checkIsExternalKycList(address _list) internal view {
+        DefaultValueValidation.checkZeroAddress(_list);
+        (bool answered, bytes memory data) = _list.staticcall(
+            abi.encodeWithSelector(IExternalKycList.getKycStatus.selector, address(this))
+        );
+        if (!answered || data.length != 32 || abi.decode(data, (uint256)) > uint256(type(IKyc.KycStatus).max)) {
+            revert IExternalKycListManagement.NotAnExternalKycList(_list);
+        }
     }
 
     /**

--- a/packages/ats/contracts/contracts/facets/externalKycListManagement/ExternalKycListManagement.sol
+++ b/packages/ats/contracts/contracts/facets/externalKycListManagement/ExternalKycListManagement.sol
@@ -39,6 +39,17 @@ abstract contract ExternalKycListManagement is IExternalKycListManagement, Modif
         bool[] calldata _actives
     ) external override onlyOperational onlyActivated onlyUnpaused onlyRole(ROLE_KYC_MANAGER) returns (bool success_) {
         ArrayValidation.checkUniqueValues(_kycLists, _actives);
+        uint256 length = _kycLists.length;
+        for (uint256 index; index < length; ) {
+            // Only entries being activated are probed. A deactivation must keep working on a list
+            // that has stopped answering, because that is the recovery path out of this bug.
+            if (_actives[index]) {
+                ExternalListManagementStorageWrapper.checkIsExternalKycList(_kycLists[index]);
+            }
+            unchecked {
+                ++index;
+            }
+        }
         success_ = ExternalListManagementStorageWrapper.updateExternalLists(
             STORAGE_LOCATION_KYC_MANAGEMENT,
             _kycLists,
@@ -63,6 +74,7 @@ abstract contract ExternalKycListManagement is IExternalKycListManagement, Modif
         validateAddressNotZero(_kycLists)
         returns (bool success_)
     {
+        ExternalListManagementStorageWrapper.checkIsExternalKycList(_kycLists);
         success_ = ExternalListManagementStorageWrapper.addExternalList(STORAGE_LOCATION_KYC_MANAGEMENT, _kycLists);
         if (!success_) {
             revert ListedKycList(_kycLists);

--- a/packages/ats/contracts/contracts/facets/externalKycListManagement/IExternalKycListManagement.sol
+++ b/packages/ats/contracts/contracts/facets/externalKycListManagement/IExternalKycListManagement.sol
@@ -69,6 +69,14 @@ interface IExternalKycListManagement {
     error ExternalKycListsNotUpdated(address[] kycList, bool[] actives);
 
     /**
+     * @notice Thrown when a candidate address does not answer `IExternalKycList.getKycStatus`.
+     * @dev Raised at registration time so that a non-conforming list is rejected before it can
+     *      make every subsequent transfer revert inside `isExternallyGranted`.
+     * @param kycList The address that was offered for registration.
+     */
+    error NotAnExternalKycList(address kycList);
+
+    /**
      * @notice One-time initialiser that populates the external KYC list at token deployment.
      * @dev Can only be called once; subsequent calls revert via `onlyFacetNotRegistered`.
      *      The leading-underscore naming convention signals this is an initialiser function.

--- a/packages/ats/contracts/contracts/test/mocks/MockedNonKycList.sol
+++ b/packages/ats/contracts/contracts/test/mocks/MockedNonKycList.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import { IExternalKycList } from "../../facets/externalKycListManagement/IExternalKycList.sol";
+import { IKyc } from "../../facets/kyc/IKyc.sol";
+
+/**
+ * @title MockedSilentFallback
+ * @author Asset Tokenization Studio Team
+ * @notice Answers every selector with success and empty returndata.
+ * @dev The observable behaviour of a contract with a silent fallback and of a Hedera
+ * token's HIP-719 facade. Accepted as an external KYC list today; every transfer
+ * afterwards reverts inside `isExternallyGranted` when the ABI decoder rejects the
+ * empty answer.
+ */
+contract MockedSilentFallback {
+    // solhint-disable-next-line no-empty-blocks
+    fallback() external {}
+}
+
+/**
+ * @title MockedWrongInterface
+ * @author Asset Tokenization Studio Team
+ * @notice A contract that is not an `IExternalKycList` and has no fallback.
+ * @dev Reverts on the `getKycStatus` selector rather than answering it. Accepted as an
+ * external KYC list today, which is the C2 case: a real contract, wired to the wrong seam.
+ */
+contract MockedWrongInterface {
+    /**
+     * @notice Returns a constant, so the contract has code and a selector that is not the seam's.
+     * @return An arbitrary non-zero value.
+     */
+    function someOtherFunction() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+/**
+ * @title MockedBreakableKycList
+ * @author Asset Tokenization Studio Team
+ * @notice A conforming external KYC list that can be made to stop answering.
+ * @dev Exists to exercise the recovery path. `removeExternalKycList` is deliberately not
+ * guarded by the registration probe, because removal must keep working on a list that has
+ * stopped answering; that is the only way out of the state this bug creates.
+ */
+contract MockedBreakableKycList is IExternalKycList {
+    bool public broken;
+    mapping(address => IKyc.KycStatus) private _kycStatus;
+
+    /**
+     * @notice Grants KYC to `account` so the list can be used as a working control.
+     * @param account Address to mark as GRANTED.
+     */
+    function grantKyc(address account) external {
+        _kycStatus[account] = IKyc.KycStatus.GRANTED;
+    }
+
+    /**
+     * @notice Makes every later `getKycStatus` call revert, simulating a list that has stopped
+     *         answering after it was registered.
+     */
+    function breakList() external {
+        broken = true;
+    }
+
+    /// @inheritdoc IExternalKycList
+    function getKycStatus(address account) external view override returns (IKyc.KycStatus) {
+        require(!broken, "list is broken");
+        return _kycStatus[account];
+    }
+}

--- a/packages/ats/contracts/test/contracts/integration/externalKycLists/externalKycListRegistration.test.ts
+++ b/packages/ats/contracts/test/contracts/integration/externalKycLists/externalKycListRegistration.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers.js";
+import { IAssetMock, MockedExternalKycList } from "@contract-types";
+import type { AssetMockCtx } from "@test";
+import { ADDRESS_ZERO, ATS_ROLES, RESOLVER_KEYS } from "@scripts";
+
+/**
+ * Registration-time validation of external KYC lists.
+ *
+ * Every address that is not a working `IExternalKycList` is accepted today and makes every
+ * later transfer revert inside `isExternallyGranted`, for every holder, with an error that
+ * names neither the list nor the cause. These cases pin the four shapes that are accepted
+ * (an externally owned account, a silent fallback, a wrong interface, and, on Hedera, a
+ * token facade or a system contract, both of which present as one of the first two), and
+ * the controls pin what registration must keep accepting and what removal must keep doing.
+ */
+export function externalKycListRegistrationTests(getCtx: () => AssetMockCtx): void {
+  describe("ExternalKycList Registration Tests", () => {
+    let signer_A: HardhatEthersSigner;
+    let signer_E: HardhatEthersSigner;
+
+    let asset: IAssetMock;
+    let conformingList: MockedExternalKycList;
+    let eoa: string;
+    let silentFallback: string;
+    let wrongInterface: string;
+
+    beforeEach(async () => {
+      const ctx = getCtx();
+      signer_A = ctx.deployer;
+      signer_E = ctx.user4;
+      asset = ctx.asset;
+      conformingList = ctx.externalMocks.kyc[0];
+      eoa = signer_E.address;
+
+      const silent = await (await ethers.getContractFactory("MockedSilentFallback", signer_A)).deploy();
+      await silent.waitForDeployment();
+      silentFallback = silent.target as string;
+
+      const wrong = await (await ethers.getContractFactory("MockedWrongInterface", signer_A)).deploy();
+      await wrong.waitForDeployment();
+      wrongInterface = wrong.target as string;
+
+      await asset.connect(signer_A).grantRole(ATS_ROLES.ROLE_KYC_MANAGER, signer_A.address);
+    });
+
+    describe("addExternalKycList", () => {
+      it("GIVEN a conforming external KYC list WHEN addExternalKycList THEN it is accepted", async () => {
+        await expect(asset.connect(signer_A).addExternalKycList(conformingList.target as string)).to.not.be.reverted;
+        expect(await asset.isExternalKycList(conformingList.target as string)).to.be.true;
+      });
+
+      it("GIVEN an externally owned account WHEN addExternalKycList THEN it reverts with NotAnExternalKycList", async () => {
+        await expect(asset.connect(signer_A).addExternalKycList(eoa))
+          .to.be.revertedWithCustomError(asset, "NotAnExternalKycList")
+          .withArgs(eoa);
+      });
+
+      it("GIVEN a contract with a silent fallback WHEN addExternalKycList THEN it reverts with NotAnExternalKycList", async () => {
+        await expect(asset.connect(signer_A).addExternalKycList(silentFallback))
+          .to.be.revertedWithCustomError(asset, "NotAnExternalKycList")
+          .withArgs(silentFallback);
+      });
+
+      it("GIVEN a contract with the wrong interface WHEN addExternalKycList THEN it reverts with NotAnExternalKycList", async () => {
+        await expect(asset.connect(signer_A).addExternalKycList(wrongInterface))
+          .to.be.revertedWithCustomError(asset, "NotAnExternalKycList")
+          .withArgs(wrongInterface);
+      });
+
+      it("GIVEN the zero address WHEN addExternalKycList THEN it still reverts with ZeroAddressNotAllowed", async () => {
+        await expect(asset.connect(signer_A).addExternalKycList(ADDRESS_ZERO)).to.be.revertedWithCustomError(
+          asset,
+          "ZeroAddressNotAllowed",
+        );
+      });
+    });
+
+    describe("updateExternalKycLists", () => {
+      it("GIVEN a conforming list activated WHEN updateExternalKycLists THEN it is accepted", async () => {
+        await expect(asset.connect(signer_A).updateExternalKycLists([conformingList.target as string], [true])).to.not
+          .be.reverted;
+        expect(await asset.isExternalKycList(conformingList.target as string)).to.be.true;
+      });
+
+      it("GIVEN a non-conforming list activated WHEN updateExternalKycLists THEN it reverts with NotAnExternalKycList", async () => {
+        await expect(asset.connect(signer_A).updateExternalKycLists([silentFallback], [true]))
+          .to.be.revertedWithCustomError(asset, "NotAnExternalKycList")
+          .withArgs(silentFallback);
+      });
+
+      it("GIVEN the zero address activated WHEN updateExternalKycLists THEN it still reverts with ZeroAddressNotAllowed", async () => {
+        await expect(
+          asset.connect(signer_A).updateExternalKycLists([ADDRESS_ZERO], [true]),
+        ).to.be.revertedWithCustomError(asset, "ZeroAddressNotAllowed");
+      });
+
+      it("GIVEN a registered list that has stopped answering WHEN it is deactivated THEN the deactivation succeeds", async () => {
+        const breakable = await (await ethers.getContractFactory("MockedBreakableKycList", signer_A)).deploy();
+        await breakable.waitForDeployment();
+        const list = breakable.target as string;
+
+        await asset.connect(signer_A).addExternalKycList(list);
+        await breakable.breakList();
+
+        await expect(asset.connect(signer_A).updateExternalKycLists([list], [false])).to.not.be.reverted;
+        expect(await asset.isExternalKycList(list)).to.be.false;
+      });
+    });
+
+    describe("initializeExternalKycLists", () => {
+      it("GIVEN a conforming list WHEN initializeExternalKycLists THEN it emits ExternalKycListInitialized", async () => {
+        await asset.forceFacetNotRegistered(RESOLVER_KEYS.externalKycListManagement);
+        await expect(asset.initializeExternalKycLists([conformingList.target as string])).to.emit(
+          asset,
+          "ExternalKycListInitialized",
+        );
+      });
+
+      it("GIVEN a non-conforming list WHEN initializeExternalKycLists THEN it reverts with NotAnExternalKycList", async () => {
+        await asset.forceFacetNotRegistered(RESOLVER_KEYS.externalKycListManagement);
+        await expect(asset.initializeExternalKycLists([silentFallback]))
+          .to.be.revertedWithCustomError(asset, "NotAnExternalKycList")
+          .withArgs(silentFallback);
+      });
+    });
+
+    describe("removeExternalKycList", () => {
+      it("GIVEN a registered list that has stopped answering WHEN removeExternalKycList THEN the removal succeeds", async () => {
+        const breakable = await (await ethers.getContractFactory("MockedBreakableKycList", signer_A)).deploy();
+        await breakable.waitForDeployment();
+        const list = breakable.target as string;
+
+        await asset.connect(signer_A).addExternalKycList(list);
+        await breakable.breakList();
+
+        await expect(asset.connect(signer_A).removeExternalKycList(list)).to.not.be.reverted;
+        expect(await asset.isExternalKycList(list)).to.be.false;
+      });
+    });
+  });
+}


### PR DESCRIPTION
Refs #1392

## Description

`addExternalKycList`, `updateExternalKycLists` and `initializeExternalKycLists` accept **any**
address. The only validation on the path is a zero-address check. Nothing asks whether the address
implements `IExternalKycList`, or whether it is a contract at all.

The failure is deferred to the first transfer, and it is total. `isExternallyGranted` makes a typed
call:

```solidity
if (IExternalKycList(externalKycListStorage.list.at(index)).getKycStatus(_account) != _kycStatus)
    return false;
```

Against anything non-conforming this reverts rather than returning false, and the revert bubbles out
of every transfer. The security cannot move, for anyone, in any direction, until an operator holding
`ROLE_KYC_MANAGER` works out which registered list is the dead one, from a revert naming neither the
list nor the reason. The Studio wires this list at **token creation**, so the realistic version is a
security born unable to settle, on a typo.

### Measured on chain

Testnet 296, against a live ATS security from the shipped factory. Each shape registered as the sole
external KYC list, the same transfer attempted after each, state restored and the restoration
verified. Twelve transactions, 1.29 HBAR.

| registered as the sole external KYC list | is it a contract? | accepted? | transfer |
|---|---|---|---|
| **control:** nothing registered | n/a | n/a | **succeeds**, an empty list reads GRANTED |
| an EOA | no | **yes** | reverts |
| a Hedera system contract (`0x167`) | no code | **yes** | reverts |
| a bn254 precompile (`0x06`) | no code | **yes** | reverts |
| an HTS token (147-byte HIP-719 facade) | 147 bytes | **yes** | reverts |
| a deployed contract with the wrong interface | 390 bytes | **yes** | reverts |
| **control:** a conforming implementation, restored | yes | yes | **succeeds** |

Five accepted, four not contracts, none an `IExternalKycList`, with no revert or event at
registration. Both controls move, so the reverts are a result and not a stuck harness.

### The change

Probe the candidate once at registration and reject it if it cannot answer `getKycStatus`.
Registration is a cold path (127,236 gas measured for `addExternalKycList`); one staticcall is not a
meaningful cost and is paid nowhere near the transfer path.

```solidity
function checkIsExternalKycList(address _list) internal view {
    DefaultValueValidation.checkZeroAddress(_list);
    (bool answered, bytes memory data) = _list.staticcall(
        abi.encodeWithSelector(IExternalKycList.getKycStatus.selector, address(this))
    );
    if (!answered || data.length != 32 || abi.decode(data, (uint256)) > uint256(type(IKyc.KycStatus).max)) {
        revert IExternalKycListManagement.NotAnExternalKycList(_list);
    }
}
```

Called from all three entry points, and in `updateExternalKycLists` only for entries being activated.

**Not ERC-165:** `IExternalKycList` has no `supportsInterface`, the only implementation in the tree
does not have one, and requiring it would reject every deployed list. A behaviour probe tests the
property that matters. It lives in the KYC path rather than `addExternalList`, the shared chokepoint
for four ERC-7201 namespaces expecting different interfaces. The zero-address check runs first, so a
zero address still reports `ZeroAddressNotAllowed`.

**Removal and deactivation are deliberately unguarded.** `removeExternalKycList`, and
`updateExternalKycLists` with `active = false`, must keep working on a list that has stopped
answering, because that is the recovery path out of this state. Both are pinned by tests.

**Noticed and not fixed here:** neither `updateExternalKycLists` nor `updateExternalLists` checks
that `_kycLists` and `_actives` are the same length, so a short `_actives` panics rather than
reverts. `IERC3643Types.InputBoolArrayLengthMismatch` already exists for it. The new loop indexes
`_actives` exactly as the existing one does, so this is unchanged in kind and outcome. One `if` and
a separate commit if you want it. The external control and pause namespaces have the same
registration gap; not measured on chain, so this PR leaves them alone.

## Type of change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Breaking change 💥
- [ ] Documentation update 📖
- [ ] Refactor 🔧

## Testing

Twelve new cases in `test/contracts/integration/externalKycLists/externalKycListRegistration.test.ts`
across all three entry points, with three new mocks (`MockedSilentFallback`, `MockedWrongInterface`,
`MockedBreakableKycList`). Every row of the on-chain table is reproduced on a plain EVM: **no Hedera
needed to run them.**

Run with the patch and again with it reverted, because a test that passes both ways is not evidence:
**12 passing with it, 7 passing and 5 failing without.** The seven are the controls.

The five failures are the five rejections: an EOA, a silent fallback and a wrong-interface contract,
via `addExternalKycList`, `updateExternalKycLists(active = true)` and `initializeExternalKycLists`.
Each registered before and now reverts `NotAnExternalKycList`. The seven controls pass in both
columns: a conforming list still registers through all three entry points, a zero address still
reports `ZeroAddressNotAllowed`, and both removal and deactivation still work on a list that has
stopped answering.

**Full `packages/ats/contracts` suite with only this branch applied: `3657 passing, 3 pending, 0
failing`.** That run is the one that mattered: an earlier version passed all twelve of its own tests
and still changed the error a caller sees when a zero address reaches `updateExternalKycLists`. Only
the project's suite caught it, and the zero-address controls exist because of it.

Generated API docs are included: `npm run doc` then
`prettier --write 'docs/ats/api/contracts/**/*.md'`, leaving exactly the four pages the new error
propagates to. Without the prettier step dodoc rewrites all 453, since its raw output is unformatted.

Also clean: `prettier --check`, and `solhint` with the local `solhint-plugin-ats` at 0 errors and 0
warnings on every file touched. The `.betterer.results` ratchet is unaffected, measured rather than
assumed: baseline 55 warnings across 18 files, and a full run with this change returns the same 55.

The Hedera measurements are ours, not the maintainers', and each is reproducible from a script we
can hand over on request.

**Node version**:

- [ ] 20
- [x] 22
- [ ] 24

## Checklist

- [x] Style Guidelines followed ✅
- [x] Documentation Updated 📚
- [x] **Linters** - No New Warnings ⚠️
- [x] Local Tests Pass ✅
- [x] Effective Tests Added ✔️
- [x] No reduction of **Coverage** ✅
