### PR TITLE
docs: note that the deployed testnet contracts are not ABI-compatible with main

### DIFF
--- a/docs/ats/developer-guides/contracts/deployed-addresses.md
+++ b/docs/ats/developer-guides/contracts/deployed-addresses.md
@@ -23,6 +23,34 @@ Latest deployed smart contract addresses for Asset Tokenization Studio.
 | Factory Proxy          | 0.0.7708432 | 0x5fA65CA30d1984701F10476664327f97c864A9D3 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7708432) |
 | Factory Implementation | 0.0.7708430 | 0x3803219f13E23998FdDCa67AdA60EeB8E62eEEA8 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7708430) |
 
+
+## Reading the source for a deployed version
+
+The addresses above run **contract version 4.0.0**. Read struct definitions and role
+constants from the matching release tag, **not from `main`** — several ABI-affecting
+changes have landed since.
+
+`SecurityData` was reordered after `v5.0.0-ats`. The fields and their types are unchanged,
+but the order is not, so it is a different tuple and therefore a different selector:
+
+| `deployBond` field order | selector | present in `0.0.7708430` bytecode |
+| --- | --- | --- |
+| `main` (contracts 8.0.0) | `0x29002951` | no |
+| `v3.1.0-ats` … `v5.0.0-ats` (bools first) | `0x5133f0e0` | yes |
+
+Calling the deployed factory with a payload built from `main` fails as `execution reverted`
+with **no data and no reason string**, identically for every `configId`, because the proxy
+has no matching function to dispatch to. That looks like a bad configuration and is not one,
+which makes it expensive to diagnose.
+
+Role hashes moved as well, and that one fails more quietly: `_ISSUER_ROLE` is `0x4be32e88…`
+in the deployed version and `0x5eeaf560…` on `main`. A grant made with the `main` constants
+lands on a hash the deployed contract never checks, so `hasRole()` returns `true` while every
+guarded call still reverts. Only `DEFAULT_ADMIN_ROLE` (`0x00`) is stable across versions.
+
+Note also that `v4.0.0-ats` is not tagged in this repository; the nearest tags are
+`v3.1.0-ats` and `v4.1.0-ats`, which share the deployed field order.
+
 ## Version History
 
 | Version | BLR Proxy   | Factory Proxy | Release Date |


### PR DESCRIPTION
## What

Adds a short section to `deployed-addresses.md` warning that struct definitions and role constants must be read from the release tag matching the deployed version, not from `main`.

## Why

While integrating against the deployed testnet factory `0.0.7708432`, we lost a meaningful amount of time to a failure that is hard to diagnose from the error alone.

`SecurityData` was reordered after `v5.0.0-ats`. Same fields, same types, different order — so a different tuple and a different function selector:

| `deployBond` field order | selector | present in `0.0.7708430` bytecode |
| --- | --- | --- |
| `main` (contracts 8.0.0) | `0x29002951` | no |
| `v3.1.0-ats` … `v5.0.0-ats` (bools first) | `0x5133f0e0` | yes |

Building `deployBond` calldata from `main` and calling the deployed factory fails as `execution reverted` with **no data and no reason string** — identically for every `configId`. That reads as a bad configuration rather than an ABI mismatch, so the natural next step is to try other config ids, which never works.

Role hashes moved as well, and that one fails more quietly. `_ISSUER_ROLE` is `0x4be32e88…` in the deployed version and `0x5eeaf560…` on `main`. A grant made with `main`'s constants lands on a hash the deployed contract never checks, so `hasRole()` returns `true` while every guarded call still reverts. Only `DEFAULT_ADMIN_ROLE` (`0x00`) is stable across versions, which is fortunately enough to repair it without redeploying.

Also noted: `v4.0.0-ats` is not tagged in this repository. The nearest tags are `v3.1.0-ats` and `v4.1.0-ats`, which share the deployed field order.

## Verification

- Factory proxy `0.0.7708432` EIP-1967 implementation slot resolves to `0x3803219f13E23998FdDCa67AdA60EeB8E62eEEA8` (`0.0.7708430`).
- Selector `0x5133f0e0` appears in that implementation's runtime bytecode; `0x29002951` does not.
- A bond was successfully deployed from the factory using the bools-first layout: `0xD53072649037FEecD305920087791a37dF8D517F`.

Docs-only change; no code touched.