### PR TITLE
docs: point deployed-addresses at the v8.0.0 deployment

### DIFF
--- a/docs/ats/developer-guides/contracts/deployed-addresses.md
+++ b/docs/ats/developer-guides/contracts/deployed-addresses.md
@@ -11,22 +11,32 @@ Latest deployed smart contract addresses for Asset Tokenization Studio.
 
 ## Hedera Testnet
 
-**Smart Contract Version:** 4.0.0
+**Smart Contract Version:** 8.0.0
 
 ### Infrastructure Contracts
 
 | Contract               | Contract ID | EVM Address                                | HashScan                                                             |
 | ---------------------- | ----------- | ------------------------------------------ | -------------------------------------------------------------------- |
-| ProxyAdmin             | 0.0.7707872 | 0x76220dAa89df1d0be4C6997Dc401FCB98A586F6a | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7707872) |
-| BLR Proxy              | 0.0.7707874 | 0xEFEF4CAe9642631Cfc6d997D6207Ee48fa78fe42 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7707874) |
-| BLR Implementation     | 0.0.7707873 | 0xd53A586C1b11a5E7c34912a466e97c02Ad2d5786 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7707873) |
-| Factory Proxy          | 0.0.7708432 | 0x5fA65CA30d1984701F10476664327f97c864A9D3 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7708432) |
-| Factory Implementation | 0.0.7708430 | 0x3803219f13E23998FdDCa67AdA60EeB8E62eEEA8 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.7708430) |
+| ProxyAdmin             | 0.0.9212218 | 0x92664e864200b8fa891195ceec93880f5bfa6f22 | [View on HashScan](https://hashscan.io/testnet/contract/0.0.9212218) |
+| BLR Proxy              | 0.0.9212226 | 0xBA2D5FC2083A0b8f164c50e65d782087fBA18E0a | [View on HashScan](https://hashscan.io/testnet/contract/0.0.9212226) |
+| BLR Implementation     | 0.0.9212222 | 0x86ba690fa76625162501ec1e773056870e56a06d | [View on HashScan](https://hashscan.io/testnet/contract/0.0.9212222) |
+| Factory Proxy          | 0.0.9213391 | 0xd1F118A40f3b02883D35909eF2517e7EDd78379d | [View on HashScan](https://hashscan.io/testnet/contract/0.0.9213391) |
+
+The BLR Proxy and Factory Proxy addresses are the two an integrator configures,
+and they match `apps/ats/web/.env.example` in this repository
+(`REACT_APP_RPC_RESOLVER` and `REACT_APP_RPC_FACTORY`).
+
+> The Factory Implementation row has been left out rather than carried over. The
+> factory proxy does not expose its implementation through the EIP-1967 slot or
+> a public view, so it could not be verified the way the others were, and a
+> stale address is worse than an absent one. A maintainer with the deployment
+> output can restore the row.
 
 ## Version History
 
 | Version | BLR Proxy   | Factory Proxy | Release Date |
 | ------- | ----------- | ------------- | ------------ |
+| 8.0.0   | 0.0.9212226 | 0.0.9213391   | 2026-06-12   |
 | 4.0.0   | 0.0.7707874 | 0.0.7708432   | 2026-01-22   |
 | 2.0.1   | 0.0.7511642 | 0.0.7512002   | 2024-12-23   |
 


### PR DESCRIPTION
### The problem

`docs/ats/developer-guides/contracts/deployed-addresses.md` still lists the **4.0.0** contracts deployed 2026-01-22, while the current release is `v.8.0.0-ats` and this repository's own `apps/ats/web/.env.example` already carries the newer resolver and factory.

A developer following the docs configures one deployment and reads the ABI of another.

### It is observable, not theoretical

Both deployments are live on Hedera testnet right now:

```
BLR the docs list    0xEFEF4CAe9642631Cfc6d997D6207Ee48fa78fe42
  getConfigurationsLength() -> 5

BLR in .env.example  0xBA2D5FC2083A0b8f164c50e65d782087fBA18E0a
  getConfigurationsLength() -> 8
  getBusinessLogicCount()   -> 108
```

That the older one still answers is what makes it expensive. The mistake does not surface as a failed call; it surfaces later as a missing configuration id, or as a facet that is not registered on the deployment you are actually talking to.

### What this changes

Updates the testnet table to 8.0.0 and adds a version-history row.

Every address was read back from the chain rather than copied:

| Contract | Contract ID | Source |
|---|---|---|
| ProxyAdmin | `0.0.9212218` | BLR proxy EIP-1967 admin slot |
| BLR Proxy | `0.0.9212226` | `apps/ats/web/.env.example`, confirmed answering the v8 ABI |
| BLR Implementation | `0.0.9212222` | BLR proxy EIP-1967 implementation slot |
| Factory Proxy | `0.0.9213391` | `apps/ats/web/.env.example`, confirmed answering the v8 ABI |

Contract ids and the 2026-06-12 creation date come from the mirror node.

### One row left out on purpose

**Factory Implementation** is omitted rather than updated. The factory proxy does not expose its implementation through the EIP-1967 slot or a public view, so I could not verify it the way I verified the others — and carrying the 4.0.0 value forward would leave the page wrong in a quieter way. A maintainer with the deployment output can restore it in a line.

### How I ran into it

Building an underwriting market for tokenized securities on ATS. The published addresses cost the better part of a day before I noticed `.env.example` disagreed with the docs and checked both against the chain.